### PR TITLE
Check if section exists rather than just checking that it's not null.

### DIFF
--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -37,7 +37,7 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
 
     $scope.stub = stub;
 
-    if ($scope.stub.section !== null) {
+    if ($scope.stub.section) {
         /**
          * To ensure that a modal loaded without a preference for section does not validate,
          * only set the section if a preference was found


### PR DESCRIPTION
This should fix this error showing up in sentry and reported by central prod: https://app.getsentry.com/the-guardian/workflow/issues/130449721/