### PR TITLE
Enables cross domain HTTP DELETE requests (for Composer)

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -253,10 +253,12 @@ object Api extends Controller with PanDomainAuthActions {
     }
   }
 
-  def deleteContent(composerId: String) = APIAuthAction {
-    CommonAPI.deleteContent(Seq(composerId)).fold(err =>
-      Logger.error(s"failed to delete content with composer id: $composerId"), identity)
-    NoContent
+  def deleteContent(composerId: String) = CORSable(composerUrl) {
+    APIAuthAction {
+      CommonAPI.deleteContent(Seq(composerId)).fold(err =>
+        Logger.error(s"failed to delete content with composer id: $composerId"), identity)
+      NoContent
+    }
   }
 
   def deleteStub(stubId: Long) = APIAuthAction {

--- a/conf/routes
+++ b/conf/routes
@@ -5,7 +5,7 @@
 # Application
 GET            /                                           controllers.Application.index
 
-OPTIONS        /api/*url                                   controllers.Api.allowCORSAccess(methods = "PUT, POST", url: String)
+OPTIONS        /api/*url                                   controllers.Api.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)
 
 GET            /dashboard                                  controllers.Application.dashboard
 


### PR DESCRIPTION
This change allows a new feature being developed in Composer
to send HTTP DELETE requests to workflow-frontend.