### PR TITLE
Correction to allow mouse events on the Restore button

### DIFF
--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -389,7 +389,7 @@ $drawer-breakpoint-small: 1400px;
         position: absolute;
         z-index: 999;
         top: 0;
-        height: 100%;
+        height: 16vw;
         left: 0;
         width: calc(100% - 120px);
         line-height: 100%;


### PR DESCRIPTION
When an item in trashed there is an overlay at z-index 999 which prevents access
to the Restore button. This change reduces the size of the overlay div without
changing the display of the label "Trashed" itself.