### PR TITLE
Moving the Trashed div to horizontal position to avoid affecting surrounding elements

### DIFF
--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -394,7 +394,6 @@ $drawer-breakpoint-small: 1400px;
         width: calc(100% - 120px);
         line-height: 100%;
         font-weight: bold;
-        transform: rotate(-12deg);
         text-align: center;
         color: transparentize($c-red, 0.8);
 


### PR DESCRIPTION
This change keeps the Trashed div in horizontal position (no rotation), to avoid affecting the surrounding UI elements. The restore button was affected, but actually other elements were affected as well. 

The slight change in the visuals was authorised by Nathan.

