### PR TITLE
Send through tracking parameter to support tracking tags

### DIFF
--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -83,7 +83,7 @@ function wfComposerService($http, $q, config, wfHttpSessionService) {
         return request({
             method: 'POST',
             url: config.composerNewContent,
-            params: { 'type': type, 'tags': commissioningDesks },
+            params: { 'type': type, 'tracking': commissioningDesks },
             withCredentials: true
         });
     };


### PR DESCRIPTION
Reflecting https://github.com/guardian/flexible-content/pull/2657 this send through tracking tags with the param "tracking" rather than the general "tags"