### PR TITLE
Replace logstash with kinesis

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -8,7 +8,7 @@ import config.Config
 object Global extends WithFilters(RedirectToHTTPSFilter, new GzipFilter, LoggingFilter) with GlobalSettings {
   override def beforeStart(app: Application) {
 
-    LogConfig.init(Config.logStashConf)
+    LogConfig.init()
 
     /* It's horrible, but this is absolutely necessary for correct interpretation
      * of datetime columns in prog almost certainly what no sane person ever wants to do.

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -1,7 +1,7 @@
 package config
 
-import _root_.aws.AwsInstanceTags
 import com.gu.workflow.lib.{Config => config}
+import com.gu.workflow.util.AwsInstanceTags
 import lib.LogStashConf
 import play.Logger
 

--- a/common-lib/src/main/scala/com/gu/workflow/lib/LogConfig.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/LogConfig.scala
@@ -1,78 +1,60 @@
 package lib
 
-import java.io.File
+import java.security.SecureRandom
 
-import ch.qos.logback.classic.{Logger => LogbackLogger, LoggerContext}
-import ch.qos.logback.core.util.Duration
-import play.api.Logger
-import play.api.{Logger => PlayLogger, LoggerLike}
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.core.{FileAppender, ConsoleAppender}
-import net.logstash.logback.encoder.LogstashEncoder
-import net.logstash.logback.appender.LogstashTcpSocketAppender
-import org.slf4j.{Logger => SLFLogger, LoggerFactory}
+import ch.qos.logback.classic.{Logger => LogbackLogger}
+import com.amazonaws.auth.{InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
+import com.gu.logback.appender.kinesis.KinesisAppender
+import com.gu.workflow.util.{AWS, AwsInstanceTags}
+import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
+import play.api.{Logger => PlayLogger}
 
 case class LogStashConf(host: String, port: Int, enabled: Boolean)
 
-object LogConfig {
+object LogConfig extends AwsInstanceTags {
 
   val rootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger]
-  lazy val loggingContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
 
   import play.api.Play.current
   val config = play.api.Play.configuration
+  val loggingPrefix = "aws.kinesis.logging"
 
-  lazy val customFields = (
+  def init() = {
     for {
-      app   <- config.getString("logging.fields.app")
-      stage <- config.getString("logging.fields.stage")
-    } yield Map(
-      "stack" -> "workflow",
-      "stage" -> stage.toUpperCase,
-      "app"   -> app
-    )
-  ).getOrElse(Map("logging-error" -> "bad-logging-config"))
+      stack <- readTag("Stack")
+      app <- readTag("App")
+      stage <- readTag("Stage")
+      stream <- config.getString(s"$loggingPrefix.streamName")
+    } yield {
+      val context = rootLogger.getLoggerContext
 
-  def makeCustomFields: String = {
-    "{" + (for((k, v) <- customFields) yield(s""""${k}":"${v}"""")).mkString(",") + "}"
-  }
+      val layout = new LogstashLayout()
+      layout.setContext(context)
+      layout.setCustomFields(s"""{"stack":"$stack","app":"$app","stage":"$stage"}""")
+      layout.start()
 
-  def asLogBack(l: LoggerLike): Option[LogbackLogger] = l.logger match {
-    case l: LogbackLogger => Some(l)
-    case _ => None
-  }
+      val appender = new KinesisAppender[ILoggingEvent]()
+      appender.setBufferSize(1000)
+      appender.setRegion(AWS.region.getName)
+      appender.setStreamName(stream)
+      appender.setContext(context)
+      appender.setLayout(layout)
+      appender.setCredentialsProvider(buildCredentialsProvider())
+      appender.start()
 
-  def makeEncoder(context: LoggerContext) = {
-    val e = new LogstashEncoder()
-    e.setContext(context)
-    e.setCustomFields(makeCustomFields)
-    e.start()
-    e
-  }
-
-  def makeTcpAppender(context: LoggerContext, host: String, port: Int) = {
-    val a = new LogstashTcpSocketAppender()
-    a.setContext(context)
-    a.setEncoder(makeEncoder(context))
-    a.setKeepAliveDuration(Duration.buildBySeconds(30.0))
-    a.addDestination(s"$host:$port")
-    a.start()
-    a
-  }
-
-
-  def init(conf: LogStashConf) = {
-    if(conf.enabled) {
-      PlayLogger.info("LogConfig initializing")
-      asLogBack(PlayLogger).map { lb =>
-        lb.info("Configuring Logback")
-        val context = lb.getLoggerContext
-        // remove the default configuration
-        lb.addAppender(makeTcpAppender(context, conf.host, conf.port))
-        lb.info("Configured Logback")
-      } getOrElse( Logger.info("not running using logback") )
-    } else {
-      PlayLogger.info("Logging disabled")
+      rootLogger.addAppender(appender)
     }
+  }
+
+  private def buildCredentialsProvider() = {
+    val stsRole = config.getString(s"$loggingPrefix.stsRoleToAssume").get
+
+    val random = new SecureRandom()
+    val sessionId = s"session${random.nextDouble()}"
+
+    val instanceProvider = new InstanceProfileCredentialsProvider()
+    new STSAssumeRoleSessionCredentialsProvider(instanceProvider, stsRole, sessionId)
   }
 }

--- a/common-lib/src/main/scala/com/gu/workflow/util/AWS.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/util/AWS.scala
@@ -1,11 +1,11 @@
-package aws
+package com.gu.workflow.util
 
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
 import com.amazonaws.services.ec2.AmazonEC2Client
-import com.amazonaws.services.ec2.model.DescribeTagsRequest
-import com.amazonaws.services.ec2.model.Filter
+import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
 import com.amazonaws.util.EC2MetadataUtils
+
 import scala.collection.JavaConverters._
 
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,10 @@ object Dependencies {
 
   val playDependencies = Seq(ws, "com.typesafe.play" %% "play-json" % "2.4.8")
 
-  val awsDependencies = Seq("com.amazonaws" % "aws-java-sdk" % "1.11.8")
+  val awsDependencies = Seq(
+    "com.amazonaws" % "aws-java-sdk" % "1.11.8",
+    "com.gu" % "kinesis-logback-appender" % "1.3.0"
+  )
 
   val akkaDependencies = Seq(
     "com.typesafe.akka" %% "akka-agent" % "2.4.7",

--- a/project/WorkflowBuild.scala
+++ b/project/WorkflowBuild.scala
@@ -47,7 +47,7 @@ object WorkflowBuild extends Build {
 
   lazy val commonLib = project("common-lib")
     .settings(
-      libraryDependencies ++= akkaDependencies ++ logbackDependencies ++ testDependencies ++ playDependencies
+      libraryDependencies ++= akkaDependencies ++ logbackDependencies ++ testDependencies ++ playDependencies ++ awsDependencies
     )
 
  def appDistSettings(application: String, deployJsonDir: Def.Initialize[File] = baseDirectory) = Seq(


### PR DESCRIPTION
This PR changes workflow-frontend to log to kinesis rather than logstash.

The implementation is based on how [Tag Manager](https://github.com/guardian/tagmanager/blob/master/app/modules/LogShipping.scala) and [Media Atom Maker](https://github.com/guardian/media-atom-maker/blob/master/app/util/LogShipping.scala) log to kinesis.

Deployment of this PR is dependent on:

- [ ] https://github.com/guardian/machine-images/pull/122
- [ ] https://github.com/guardian/editorial-tools-platform/pull/46

cc @philmcmahon @sihil @clloyd
