### PR TITLE
Make it possible to run workflow-frontend without running datastore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@ The Angular frontend and associated Scala API for Workflow.
 
 ### Install
 
+In order to run, workflow-frontend needs to talk to the CODE workflow datastore. It does this via an SSH tunnel to a 
+workflow-frontend CODE instance.
+
 - Make sure that you are running the right version of nodejs, should be v0.10.45. 
 - Run the install script `./setup.sh` 
 - In the `conf` folder copy `workflow-frontend-application.local-example.conf` into `workflow-frontend-application.local.conf` and edit it to replace *example.email@guardian.co.uk* by your Guardian email address.
+- Run the script `./setup-ssh-tunnel.sh` to set up an ssh tunnel to a CODE datastore instance. You will need [marauder]()
+    installed for this script to work. If the script fails, you could also run the command ssh -f ubuntu@<WORKFLOW-FRONTEND-CODE-INSTANCE> -L 5002:$<DATASTORE-ELB>:80 -N
 
 ### Run
 

--- a/conf/workflow-frontend-application.local-example.conf
+++ b/conf/workflow-frontend-application.local-example.conf
@@ -1,5 +1,5 @@
 logging.logstash.enabled = false
-api.url="http://localhost:9095/api"
+api.url="http://localhost:5002/api"
 
 application.admin.whitelist=[
   "example.email@guardian.co.uk"

--- a/setup-ssh-tunnel.sh
+++ b/setup-ssh-tunnel.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -e
+
+function HELP {
+>&2 cat << EOF
+
+  Usage: ${0} -t RDS-HOST [-s CODE] [-u ubuntu]
+
+  This script sets up an ssh tunnel from localhost port 5902 to the RDS-HOST provided on port 5432
+   using a workflow datastore instance discovered via prism as a bastion host.
+
+    -u user       [optional] the user to install the SSH keys for. Defaults to ubuntu.
+
+    -s stage   [optional] the stage to set up an ssh tunnel for. Defaults to CODE.
+
+    -h            Displays this help message. No further functions are
+                  performed.
+
+EOF
+exit 1
+}
+
+# Process options
+while getopts u:s:t:h FLAG; do
+  case $FLAG in
+    u)
+      SSH_USER=$OPTARG
+      ;;
+    s)
+      STAGE=$OPTARG
+      ;;
+    h)  #show help
+      HELP
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+
+if [ -z "${STAGE}" ]; then
+  STAGE="CODE"
+fi
+
+if [ -z "${SSH_USER}" ]; then
+  SSH_USER="ubuntu"
+fi
+
+DATASTORE_ELB=$(aws elb describe-load-balancers --load-balancer-names workflow-Datastor-2BM0DSD8PKK1 --profile workflow --region eu-west-1 | jq .LoadBalancerDescriptions[].DNSName -r)
+echo $DATASTORE_ELB
+WF_FRONTEND_HOST=$(marauder -s stage=${STAGE} app=workflow-frontend --short)
+echo $WF_FRONTEND_HOST
+
+echo "Runnning command: ssh -f ${SSH_USER}@${WF_FRONTEND_HOST} -L 5002:${DATASTORE_ELB}:80 -N"
+
+ssh -f ${SSH_USER}@${WF_FRONTEND_HOST} -L 5002:${DATASTORE_ELB}:80 -N


### PR DESCRIPTION
This change adds a script to setup an ssh tunnel so that workflow-frontend can be run locally more easily. Conf/readme files have been updated accordingly.