### PR TITLE
Use CAPI to render the contents of the item drawer.

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -35,6 +35,14 @@ object Config extends AwsInstanceTags {
     case _ => "https://tagmanager.code.dev-gutools.co.uk"
   }
 
+  lazy val contentApiUrl: String = stage match {
+    case "PROD" => s"https://preview.content.guardianapis.com"
+    case _ => "https://preview.content.code.dev-guardianapis.com"
+  }
+
+  lazy val capiPreviewUsername = config.getConfigStringOrFail("capi.preview.username")
+  lazy val capiPreviewPassword = config.getConfigStringOrFail("capi.preview.password")
+
   lazy val incopyExportUrl: String = "gnm://composer/export/${composerId}"
 
   lazy val viewerUrl: String = s"https://viewer.$domain"

--- a/app/controllers/CAPIService.scala
+++ b/app/controllers/CAPIService.scala
@@ -1,0 +1,26 @@
+package controllers
+
+import play.api.libs.ws.{WS, WSAuthScheme, WSResponse}
+import config.Config
+import play.api.libs.ws.WSAuthScheme.BASIC
+import play.api.mvc.Controller
+import play.api.Play.current
+
+object CAPIService extends Controller with PanDomainAuthActions{
+
+  def previewCapiProxy(path: String) = APIAuthAction.async { request =>
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val req = WS
+      .url(s"${Config.contentApiUrl}/$path?${request.rawQueryString}")
+      .withAuth(Config.capiPreviewUsername, Config.capiPreviewPassword, BASIC)
+      .get()
+
+    req.map(response => response.status match {
+      case 200 => Ok(response.json)
+      case _ => BadGateway(s"CAPI returned error code ${response.status}")
+    })
+  }
+
+}

--- a/conf/routes
+++ b/conf/routes
@@ -45,7 +45,9 @@ DELETE         /api/stubs/:stubId                          controllers.Api.delet
 GET            /api/statuses                               controllers.Api.statusus
 GET            /api/sections                               controllers.Api.sections
 
-# API V1
+# CAPI
+
+GET            /capi/*path                                 controllers.CAPIService.previewCapiProxy(path)
 
 
 # Content

--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -312,6 +312,10 @@ $drawer-breakpoint-small: 1400px;
     color: $c-red;
 }
 
+.drawer-warning {
+    color: $c-red;
+}
+
 .drawer__section-control {
     width: 100%;
 }

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -9,6 +9,7 @@
                             <i class="drawer__icon--content-type" wf-icon="furniture"/>
                             Furniture
                         </div>
+                        <span class ="drawer-warning" ng-if="capiData.capiError">Warning: Could not reach content api. Some fields will be missing. Please go to composer to view full content information. If problem persists contact digitalcms.dev@guardian.co.uk.</span>
                         <div class="content-list-drawer__container-inner__info-panel__furniture__body">
                             <div class="content-list-drawer__container-inner__info-panel__furniture__body__column-wide">
                                 <ul class="drawer__column--wide">
@@ -118,7 +119,7 @@
                                     </li>
                                     <li class="drawer__section" ng-show="contentItem.contentType == 'article'">
                                         <span class="drawer__section-title">Word count</span>
-                                        <span class="drawer__section-control">{{ contentItem.wordCount }} </span>
+                                        <span class="drawer__section-control">{{ capiData.wordCount }} </span>
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Commissioning info</span>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -27,12 +27,12 @@
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Headline</span>
-                                        <span class="drawer__section-data-row">{{ contentItem.headline || '-' }}</span>
+                                        <span class="drawer__section-data-row">{{ capiData.headline || '-' }}</span>
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Standfirst</span>
-                                        <span class="drawer__section-data-row" ng-class="{'drawer__section-data-row--empty': !contentItem.standfirst}">
-                                            {{ contentItem.standfirst || "None" }}
+                                        <span class="drawer__section-data-row" ng-class="{'drawer__section-data-row--empty': !capiData.standfirst}">
+                                            {{ capiData.standfirst || "None" }}
                                         </span>
                                     </li>
                                     <li class="drawer__section">

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -1,6 +1,5 @@
 <tr class="content-list-drawer content-list-drawer--hidden" ng-class="{'content-list-drawer--trashed': contentItem.item.trashed}">
     <td colspan="100" class="content-list-drawer__full-width">
-
         <div class="content-list-drawer__container"><!-- div for animation -->
 
             <div class="content-list-drawer__container-inner"><!-- div for padding/spacing -->
@@ -56,7 +55,7 @@
                                         <span class="drawer__section-title">Main media</span>
 
                                         <div ng-if="contentItem.mainMediaType == 'image'" class="drawer__section-image-container">
-                                            <img ng-src="{{ contentItem.mainMediaUrl}}" alt=""/>
+                                            <img ng-src="{{ capiData.mainMediaUrl}}" alt=""/>
                                         </div>
                                         <div ng-if="contentItem.mainMediaNoPreview" class="drawer__section-image-container">
                                             {{contentItem.mainMediaType}}
@@ -68,14 +67,14 @@
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Caption</span>
-                                        <span class="drawer__section-data-row" ng-class="{'drawer__section-data-row--empty': !contentItem.mainMediaCaption}">
-                                            {{ contentItem.mainMediaCaption || "None" }}
+                                        <span class="drawer__section-data-row" ng-class="{'drawer__section-data-row--empty': !capiData.mainMediaCaption}">
+                                            {{ capiData.mainMediaCaption || "None" }}
                                     </span>
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Alt text</span>
-                                    <span class="drawer__section-data-row" ng-class="{'drawer__section-data-row--empty': !contentItem.mainMediaAltText}">
-                                        {{ contentItem.mainMediaAltText || "None" }}
+                                    <span class="drawer__section-data-row" ng-class="{'drawer__section-data-row--empty': !capiData.mainMediaAltText}">
+                                        {{ capiData.mainMediaAltText || "None" }}
                                     </span>
                                     </li>
                                 </ul>
@@ -85,17 +84,17 @@
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Trail picture</span>
 
-                                        <div ng-if="contentItem.trailImageUrl" class="drawer__section-image-container">
-                                            <img ng-src="{{ contentItem.trailImageUrl }}" alt=""/>
+                                        <div ng-if="capiData.trailImageUrl" class="drawer__section-image-container">
+                                            <img ng-src="{{ capiData.trailImageUrl }}" alt=""/>
                                         </div>
-                                        <div ng-if="!contentItem.trailImageUrl" class="drawer__section-data-row drawer__section-data-row--empty">
+                                        <div ng-if="!capiData.trailImageUrl" class="drawer__section-data-row drawer__section-data-row--empty">
                                             None
                                         </div>
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Trail text</span>
-                                    <span class="drawer__section-data-row" ng-class="{'drawer__section-data-row--empty': !contentItem.trailtext}">
-                                        {{ contentItem.trailtext || "None" }}
+                                    <span class="drawer__section-data-row" ng-class="{'drawer__section-data-row--empty': !capiData.trailText}">
+                                        {{ capiData.trailText || "None" }}
                                     </span>
                                     </li>
                                 </ul>
@@ -104,7 +103,7 @@
                                 <ul class="drawer__column--wide">
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Comments</span>
-                                        <span class="drawer__section-data-row">{{ contentItem.commentsTitle }}</span>
+                                        <span class="drawer__section-data-row">{{ capiData.commentsTitle }}</span>
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Optimised for web</span>
@@ -123,9 +122,9 @@
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Commissioning info</span>
-                                        <span class="drawer__section-data-row" ng-repeat="desk in contentItem.commissioningDesks" ng-show="contentItem.commissioningDesks.length">{{ desk.externalName }}</span>
-                                        <span class="drawer__section-data-row--warning" ng-show="!contentItem.commissioningDesks.length">None</span>
-                                        <span class="drawer__section-data-row--warning" ng-show="tagsUnavailable()">Comissioning info is temporarily unavailable</span>
+                                        <span class="drawer__section-data-row" ng-repeat="desk in capiData.commissioningDesks" ng-show="capiData.commissioningDesks.length">{{ desk }}</span>
+                                        <span class="drawer__section-data-row--warning" ng-show="!capiData.commissioningDesks.length">None</span>
+                                        <span class="drawer__section-data-row--warning" ng-show="tagsUnavailable()">Commissioning info is temporarily unavailable</span>
                                     </li>
                                 </ul>
                             </div>
@@ -154,7 +153,7 @@
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">First published</span>
-                                        <span class="drawer__section-data-row">{{ (contentItem.firstPublished | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime) || "-" }}</span>
+                                        <span class="drawer__section-data-row">{{ (capiData.firstPublishedDate | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime) || "-" }}</span>
                                     </li>
                                     <li class="drawer__section">
                                         <span class="drawer__section-title">Scheduled</span>

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -114,7 +114,6 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
              */
             this.toggleContent = (contentItem, $contentListItemElement, capiData) => {
 
-                console.log("toggle got capi data!", capiData)
                 var selectedItem = $scope.contentList.selectedItem;
 
                 if (selectedItem && selectedItem.id !== contentItem.id) {

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -173,9 +173,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             wfCapiService.getCapiContent(contentItem.path)
                 .then((resp) => {
                 const parsed = wfCapiService.parseCapiData(resp);
-            console.log(parsed)
-            contentListDrawerController.toggleContent(contentItem, contentListItemElement, parsed);
-
+                contentListDrawerController.toggleContent(contentItem, contentListItemElement, parsed);
             });
 
 

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -13,7 +13,7 @@ import contentListDrawerTemplate from './content-list-drawer.html!ng-template';
  * @param contentService
  * @param prodOfficeService
  */
-export function wfContentListDrawer($rootScope, config, $timeout, $window, contentService, prodOfficeService, featureSwitches, wfGoogleApiService) {
+export function wfContentListDrawer($rootScope, config, $timeout, $window, contentService, prodOfficeService, featureSwitches, wfGoogleApiService, wfCapiService) {
 
     var hiddenClass = 'content-list-drawer--hidden';
 
@@ -79,7 +79,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             /**
              * Shows a new contentItem moving the drawer to the row beneath its element.
              */
-            this.showContent = (contentItem, $contentListItemElement) => {
+            this.showContent = (contentItem, $contentListItemElement, capiData) => {
 
                 var self = this;
 
@@ -91,6 +91,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
 
                         $scope.contentItem = contentItem;
                         $scope.contentList.selectedItem = contentItem;
+                        $scope.capiData = capiData;
 
                         $scope.currentDatePickerValue = $scope.contentItem.item.due ? $scope.contentItem.item.due : undefined;
 
@@ -111,14 +112,16 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
              * Toggles drawer display and can display a different contentItem
              * if one is already being displayed.
              */
-            this.toggleContent = (contentItem, $contentListItemElement) => {
+            this.toggleContent = (contentItem, $contentListItemElement, capiData) => {
+
+                console.log("toggle got capi data!", capiData)
                 var selectedItem = $scope.contentList.selectedItem;
 
                 if (selectedItem && selectedItem.id !== contentItem.id) {
-                    return this.hide().then(() => this.showContent(contentItem, $contentListItemElement));
+                    return this.hide().then(() => this.showContent(contentItem, $contentListItemElement, capiData));
                 }
 
-                return this.isHidden() ? this.showContent(contentItem, $contentListItemElement) : this.hide();
+                return this.isHidden() ? this.showContent(contentItem, $contentListItemElement, capiData) : this.hide();
             };
 
             this.updateAssigneeUserImage = function () {
@@ -167,7 +170,16 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
 
                 $scope.composerRestorerUrl = buildComposerRestorerUrl(contentItem.composerId);
 
-                contentListDrawerController.toggleContent(contentItem, contentListItemElement);
+            wfCapiService.getCapiContent(contentItem.path)
+                .then((resp) => {
+                const parsed = wfCapiService.parseCapiData(resp);
+            console.log(parsed)
+            contentListDrawerController.toggleContent(contentItem, contentListItemElement, parsed);
+
+            });
+
+
+                // contentListDrawerController.toggleContent(contentItem, contentListItemElement);
 
             });
 

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -174,6 +174,8 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
                 .then((resp) => {
                 const parsed = wfCapiService.parseCapiData(resp);
                 contentListDrawerController.toggleContent(contentItem, contentListItemElement, parsed);
+            }, (err) => {
+                contentListDrawerController.toggleContent(contentItem, contentListItemElement, wfCapiService.emptyCapiObject());
             });
 
 

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -9,6 +9,7 @@ import 'lib/date-service';
 import 'lib/presence';
 import 'lib/prodoffice-service';
 import 'lib/column-service';
+import 'lib/capi-service';
 
 import 'components/editable-field/editable-field';
 
@@ -20,14 +21,14 @@ import { wfContentListDrawer } from 'components/content-list-drawer/content-list
 import { wfLoader } from 'components/loader/loader';
 
 
-angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOfficeService', 'wfPresenceService', 'wfEditableField'])
+angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOfficeService', 'wfPresenceService', 'wfEditableField', 'wfCapiService'])
     .service('wfContentItemParser', ['config', 'statusLabels', 'sections', wfContentItemParser])
     .filter('getPriorityString', wfGetPriorityStringFilter)
     .controller('wfContentListController', ['$rootScope', '$scope', '$anchorScroll', 'statuses', 'legalValues', 'priorities', 'sections', 'wfContentService', 'wfContentPollingService', 'wfContentItemParser', 'wfPresenceService', 'wfColumnService', 'wfPreferencesService', 'wfFiltersService', wfContentListController])
     .directive('wfContentListLoader', ['$rootScope', wfLoader])
     .directive('wfContentItemUpdateAction', wfContentItemUpdateActionDirective)
     .directive('wfContentListItem', ['$rootScope', 'statuses', 'legalValues', 'sections', wfContentListItem])
-    .directive('wfContentListDrawer', ['$rootScope', 'config', '$timeout', '$window', 'wfContentService', 'wfProdOfficeService', 'wfFeatureSwitches', 'wfGoogleApiService', wfContentListDrawer])
+    .directive('wfContentListDrawer', ['$rootScope', 'config', '$timeout', '$window', 'wfContentService', 'wfProdOfficeService', 'wfFeatureSwitches', 'wfGoogleApiService', 'wfCapiService', wfContentListDrawer])
     .directive("bindCompiledHtml", function($compile, $timeout) {
         return {
             scope: {

--- a/public/lib/capi-service.js
+++ b/public/lib/capi-service.js
@@ -1,0 +1,38 @@
+import angular from 'angular';
+
+angular.module('wfCapiService', [])
+    .service('wfCapiService', ['$http', '$q', 'config', 'wfHttpSessionService', wfCapiService]);
+
+function wfCapiService($http, $q, config, wfHttpSessionService) {
+
+    function parseCapiData(response, target) {
+        target = target || {};
+
+        var data = response.data;
+        console.log(data);
+        var usefulFields = {
+            headline: data.response.content.fields.headline,
+            standfirst: data.response.content.fields.standfirst
+        }
+
+        return usefulFields;
+    }
+
+
+    function getCapiContent(path) {
+        return $http({
+            method: 'GET',
+            url: "/capi/"+path,
+            params: {'show-fields': 'headline,standfirst'},
+            withCredentials: true
+        });
+    }
+
+
+    this.getCapiContent = getCapiContent;
+
+    this.parseCapiData = parseCapiData;
+
+
+}
+

--- a/public/lib/capi-service.js
+++ b/public/lib/capi-service.js
@@ -1,16 +1,16 @@
 import angular from 'angular';
 
 angular.module('wfCapiService', [])
-    .service('wfCapiService', ['$http', '$q', 'config', 'wfHttpSessionService', wfCapiService]);
+    .service('wfCapiService', ['$http', '$q', wfCapiService]);
 
-function wfCapiService($http, $q, config, wfHttpSessionService) {
+function wfCapiService($http, $q) {
 
     function getSize(asset) {
         if (asset.typeData) {
             const w = parseInt(asset.typeData.width);
             const h = parseInt(asset.typeData.height);
             return h && w ? h * w : null;
-        } else null;
+        } else return null;
     }
 
 
@@ -36,6 +36,23 @@ function wfCapiService($http, $q, config, wfHttpSessionService) {
         return tags.map((t) => t.webTitle);
     }
 
+    function emptyCapiObject() {
+        return {
+            headline: "unknown",
+            standfirst: "unknown",
+            mainMediaUrl: "",
+            mainMediaCaption: "unknown",
+            mainMediaAltText: "unknown",
+            trailImageUrl: "",
+            trailText : "unknown",
+            commentsTitle: "unknown",
+            wordCount: "unknown",
+            commissioningDesks: "",
+            firstPublishedDate: "",
+            capiError: true
+        }
+    }
+
     function parseCapiData(response) {
 
         if (response.data) {
@@ -48,9 +65,6 @@ function wfCapiService($http, $q, config, wfHttpSessionService) {
                     const tags = content.tags;
 
                     const mainMedia = elements ? getMainMedia(elements): null;
-
-                    console.log(fields)
-
 
                     return {
                         headline: fields ? fields.headline : "",
@@ -68,8 +82,7 @@ function wfCapiService($http, $q, config, wfHttpSessionService) {
                 }
             }
         } else {
-            // need to fail gracefully when capi unavailable
-            return {};
+            return emptyCapiObject();
         }
     }
 
@@ -83,14 +96,15 @@ function wfCapiService($http, $q, config, wfHttpSessionService) {
                 'show-elements': 'all',
                 'show-tags': 'tracking'
             },
-            withCredentials: true
+            withCredentials: true,
+            timeout: 1000
         });
     }
 
 
     this.getCapiContent = getCapiContent;
-
     this.parseCapiData = parseCapiData;
+    this.emptyCapiObject = emptyCapiObject;
 
 
 }

--- a/public/lib/capi-service.js
+++ b/public/lib/capi-service.js
@@ -21,15 +21,19 @@ function wfCapiService($http, $q) {
     }
 
     function getMainMedia(elements) {
-        const mainElement = elements.filter((e) => e.relation === "main")[0];
-        const smallest = getSmallestAsset(mainElement.assets);
+        const mainElements = elements.filter((e) => e.relation === "main");
 
-        return {
-            url: smallest.file,
-            caption: smallest.typeData.caption,
-            altText: smallest.typeData.altText
-        };
-
+        if (mainElements.length && mainElements[0] && mainElements[0].assets) {
+            const smallest = getSmallestAsset(mainElements[0].assets);
+            if (smallest) {
+                return {
+                    url: smallest.file,
+                    caption: smallest.typeData.caption,
+                    altText: smallest.typeData.altText
+                };
+            }
+        }
+        return null;
     }
 
     function getTagTitles(tags) {
@@ -59,7 +63,7 @@ function wfCapiService($http, $q) {
             const resp = response.data.response;
             if (resp) {
                 const content = resp.content;
-                if (content) {
+                if (content && content.fields) {
                     const fields = content.fields;
                     const elements = content.elements;
                     const tags = content.tags;
@@ -67,23 +71,22 @@ function wfCapiService($http, $q) {
                     const mainMedia = elements ? getMainMedia(elements): null;
 
                     return {
-                        headline: fields ? fields.headline : "",
-                        standfirst: fields ? fields.standfirst : "",
+                        headline: fields.headline ? fields.headline : "",
+                        standfirst: fields.standfirst ? fields.standfirst : "",
                         mainMediaUrl: mainMedia ? mainMedia.url : "",
                         mainMediaCaption: mainMedia ? mainMedia.caption : "",
                         mainMediaAltText: mainMedia ? mainMedia.altText : "",
-                        trailImageUrl: fields ? fields.thumbnail : "",
-                        trailText : fields ? fields.trailText : "",
-                        commentsTitle: fields ? fields.commentable ? "on" : "off" : "on",
-                        wordCount: fields ? fields.wordCount ? fields.wordCount : "" : "",
+                        trailImageUrl: fields.thumbnail ? fields.thumbnail : "",
+                        trailText : fields.trailText ? fields.trailText : "",
+                        commentsTitle: fields.commentable ? fields.commentable ? "on" : "off" : "on",
+                        wordCount: fields.wordCount ? fields.wordCount : "",
                         commissioningDesks: tags ? getTagTitles(tags) : "",
                         firstPublishedDate: fields.firstPublicationDate ? fields.firstPublicationDate : ""
                     }
                 }
             }
-        } else {
-            return emptyCapiObject();
         }
+        return emptyCapiObject();
     }
 
 


### PR DESCRIPTION
As part of the 'get atoms in workflow' project, we want to simplify the amount of composer-specific stuff in workflow. This is stage one of that - fetching all fields that are not displayed in the content list on the client side at the point when the content list drawer is opened.

Tested on CODE. Best to deploy this early on in the day as it's quite a major change (major change) to a pretty fundamental bit of workflow.