### PR TITLE
Fix presence error due to array containing duplicate values.

### DIFF
--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -18,7 +18,7 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                     $scope.presences = [{ status: "free", indicatorText: ""}];
                 } else {
                     $scope.presences = _.map(
-                        _.uniqBy(currentState, _.clientId.person.email),
+                        _.uniqBy(currentState, (s) => { return s.clientId.person.email; }),
                         (pr) => {
                             var person = pr.clientId.person;
                             return { indicatorText:

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -18,7 +18,7 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                     $scope.presences = [{ status: "free", indicatorText: ""}];
                 } else {
                     $scope.presences = _.map(
-                        _.uniq(currentState, false, (s) => { return s.clientId.person.email; }),
+                        _.uniqBy(currentState, _.clientId.person.email),
                         (pr) => {
                             var person = pr.clientId.person;
                             return { indicatorText:


### PR DESCRIPTION
This is something leftover from the underscore to lodash migration - the syntax for specifying an iterator is different in lodash.