### PR TITLE
Revert "Revert "Fix presence error due to array containing duplicate values.""

### DIFF
--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -18,7 +18,7 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                     $scope.presences = [{ status: "free", indicatorText: ""}];
                 } else {
                     $scope.presences = _.map(
-                        _.uniq(currentState, false, (s) => { return s.clientId.person.email; }),
+                        _.uniqBy(currentState, (s) => { return s.clientId.person.email; }),
                         (pr) => {
                             var person = pr.clientId.person;
                             return { indicatorText:


### PR DESCRIPTION
Reverts guardian/workflow-frontend#44

Weirdly, reverting this change fixed the problem we were having with app.bundle.js not being found. Lets see if re-applying it creates any problems