### PR TITLE
switch back to moment.zone()

### DIFF
--- a/public/lib/location-service.js
+++ b/public/lib/location-service.js
@@ -94,15 +94,15 @@ function wfLocationServiceFactory($rootScope, wfSettingsService) {
          * Logic ported from composer / swells.
          */
         guessLocation(date) {
-            var offset = moment(date).utcOffset();
+            var offset = moment(date).zone();
             // offset to be applied to now in minutes to get to UTC
             // I.E if now is UTC +0100 offset is -60
             // don't blame me.
-            if (offset <= 480 && offset >= 660) {
+            if (offset <= -480 && offset >= -660) {
                 return 'SYD';
-            } else if (offset <= -560 && offset >= -400) {
+            } else if (offset <= 560 && offset >= 400) {
                 return 'SFO';
-            } else if (offset < -400 && offset >= -240) {
+            } else if (offset < 400 && offset >= 240) {
                 return 'NYC';
             } else {
                 return 'LON';


### PR DESCRIPTION
Fixes `moment.utcOffset is not a function` error as it doesn't exist in the latest version of moment.