### PR TITLE
Add PR template with badge showing integration test status.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,5 @@
+<!--Your pull request-->
+
+## Editorial tools integration tests
+The editorial tools integration tests live here: https://circleci.com/gh/guardian/editorial-tools-integration-tests and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
+[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)


### PR DESCRIPTION
Sam was right - sticking badges on stuff without having any knowledge of the build number or branch is challenging. This is a hack to at least somewhat improve the visibility of the integration tests.