### PR TITLE
Fix admin styles and scripts

### DIFF
--- a/app/views/admin/adminLayout.scala.html
+++ b/app/views/admin/adminLayout.scala.html
@@ -20,10 +20,9 @@
     </div>
 </div>
 
-<script src="@routes.Assets.versioned("node_modules/angular/angular.min.js")"></script>
 <script>
     CONFIG = @Html(config.toString);
 </script>
-<script src="@routes.Assets.versioned("admin.js")"></script>
+<script src="@routes.Assets.versioned("build/admin.bundle.js")"></script>
 
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -10,18 +10,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!--<meta name="viewport" content="width=device-width, initial-scale=1">-->
     <title>@title</title>
-
-    @** TODO: Pull css in with Webpack **@
-    <link href="@routes.Assets.versioned("node_modules/bootstrap/dist/css/bootstrap.min.css")" rel="stylesheet">
-
-    @** TODO: get rid of everything that needs jQuery: **@
-    <script src="@routes.Assets.versioned("node_modules/jquery/dist/jquery.min.js")" type="text/javascript"></script>
-
     <style>
         .admin {
             padding-top: 72px;
         }
     </style>
+    <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("build/main.css")"/>
 </head>
 
 <body>

--- a/conf/webpack.conf.js
+++ b/conf/webpack.conf.js
@@ -5,6 +5,14 @@ var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
+    entry: {
+        app: './public/app.js',
+        admin: './public/admin.js'
+    },
+    output: {
+        filename: '[name].bundle.js',
+        path: path.join(__dirname, '..', 'public', 'build'),
+    },
     module: {
         loaders: [
             {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "workflow-frontend",
   "author": "Guardian Digital CMS team",
   "scripts": {
-    "build-dev": "webpack ./public/app.js ./public/build/app.bundle.js --config ./conf/webpack.conf.js --watch",
-    "build": "webpack ./public/app.js ./public/build/app.bundle.js --config ./conf/webpack.prod.conf.js",
+    "build-dev": "webpack --config ./conf/webpack.conf.js --watch",
+    "build": "webpack --config ./conf/webpack.prod.conf.js",
     "test": "karma start"
   },
   "devDependencies": {

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,8 +1,16 @@
 /**
  * 
  */
+import angular from 'angular';
 
-console.log("Hello to the admin")
+// App-wide Styles
+import './main.scss';
+
+console.log("Welcome to the admin")
+
+// Angular whiens that the 'workflow' module doesn't exist even though
+// it isn't used. This fixes the error but it's otherwise useless.
+var workflow = angular.module('workflow', []);
 
 var SectionToTagApp = angular.module('SectionToTag', []);
 SectionToTagApp.controller('tagsPickerAppCtrl', function($scope,$http) {


### PR DESCRIPTION
This fixes the missing styles and scripts on the admin page.

### Before
![picture 189](https://cloud.githubusercontent.com/assets/2104095/26311029/bfe57cde-3efa-11e7-991c-52b2ac3f1c5b.png)

### After
![picture 190](https://cloud.githubusercontent.com/assets/2104095/26311030/bffaf884-3efa-11e7-83db-866a2a920096.png)



#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)