### PR TITLE
Create media atoms from workflow

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -26,6 +26,8 @@ object Config extends AwsInstanceTags {
   lazy val composerUrl: String = s"https://composer.$domain"
   lazy val composerRestorerUrl: String = s"https://restorer.$domain/content"
 
+  lazy val mediaAtomMakerUrl: String = s"https://video.$domain"
+
   lazy val presenceUrl: String = s"wss://presence.$domain/socket"
   lazy val presenceClientLib: String = s"https://presence.$domain/client/1/lib.js"
 

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -41,7 +41,6 @@ object Api extends Controller with PanDomainAuthActions {
   implicit val flatStubWrites: Writes[Stub] = Stub.flatStubWrites
 
   def allowCORSAccess(methods: String, args: Any*) = CORSable(composerUrl) {
-
     Action { implicit req =>
       val requestedHeaders = req.headers("Access-Control-Request-Headers")
       NoContent.withHeaders("Access-Control-Allow-Methods" -> methods, "Access-Control-Allow-Headers" -> requestedHeaders)
@@ -62,7 +61,7 @@ object Api extends Controller with PanDomainAuthActions {
 
   def content = APIAuthAction.async(getContentBlock)
 
-  def getContentbyId(composerId: String) = CORSable(Config.composerUrl) {
+  def getContentbyId(composerId: String) = CORSable(composerUrl) {
       APIAuthAction.async { implicit request =>
         ApiResponseFt[Option[Stub]](for {
           item <- ContentApi.contentByComposerId(composerId)

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,37 +1,30 @@
 package controllers
 
-import com.gu.workflow.api.{ DesksAPI, SectionsAPI, SectionDeskMappingsAPI }
-import com.gu.workflow.lib.{TagService, StatusDatabase}
-
+import com.gu.workflow.api.{DesksAPI, SectionDeskMappingsAPI, SectionsAPI}
+import com.gu.workflow.lib.{StatusDatabase, TagService}
 import config.Config
 import config.Config.defaultExecutionContext
-import models.{ Desk, Tag }
-
-import lib.Composer._
-import models.Section
+import lib.{Atom, Composer}
+import models.{Desk, Section}
 import play.api.Logger
-
+import play.api.libs.json.{Format, Json}
 import play.api.mvc._
-import play.api.libs.json.Json
+
 import scala.concurrent.Future
 
 object Application extends Controller with PanDomainAuthActions {
 
   def getSortedSections(): Future[List[Section]] = {
-    SectionsAPI.getSections.asFuture.map { x =>
-      x match {
-        case Left(err) => Logger.error(s"error fetching sections: $err"); List()
-        case Right(sections) => sections.sortBy(_.name)
-      }
+    SectionsAPI.getSections.asFuture.map {
+      case Left(err) => Logger.error(s"error fetching sections: $err"); List()
+      case Right(sections) => sections.sortBy(_.name)
     }
   }
 
   def getSortedDesks(): Future[List[Desk]] = {
-    DesksAPI.getDesks.asFuture.map { x =>
-      x match {
-        case Right(desks) => desks.sortBy(_.name)
-        case Left(err) => Logger.error(s"error fetching desks: $err"); List()
-      }
+    DesksAPI.getDesks.asFuture.map {
+      case Right(desks) => desks.sortBy(_.name)
+      case Left(err) => Logger.error(s"error fetching desks: $err"); List()
     }
   }
 
@@ -45,9 +38,8 @@ object Application extends Controller with PanDomainAuthActions {
     }
   }
 
-
   def index = AuthAction { request =>
-    Redirect(routes.Application.dashboard)
+    Redirect(routes.Application.dashboard())
   }
 
   def dashboard = app("Workflow")
@@ -66,15 +58,15 @@ object Application extends Controller with PanDomainAuthActions {
 
   // limited tag fields we want output into the DOM
   case class LimitedTag(id: Long, externalName: String)
-  object LimitedTag { implicit val jsonFormats = Json.format[LimitedTag]}
+  object LimitedTag { implicit val jsonFormats: Format[LimitedTag] = Json.format[LimitedTag]}
 
   def app(title: String) = AuthAction.async { request =>
 
     for {
       statuses <- StatusDatabase.statuses
-      sections <-  getSortedSections
-      desks <- getSortedDesks
-      sectionsInDesks <- getSectionsInDesks
+      sections <-  getSortedSections()
+      desks <- getSortedDesks()
+      sectionsInDesks <- getSectionsInDesks()
       commissioningDesks <- TagService.getTags(Config.tagManagerUrl+
         "/hyper/tags?limit=100&query=tracking/commissioningdesk/&type=tracking&searchField=path")
     }
@@ -83,9 +75,12 @@ object Application extends Controller with PanDomainAuthActions {
 
       val config = Json.obj(
         "composer" -> Json.obj(
-          "create" -> newContentUrl,
-          "view" -> adminUrl,
-          "details" -> contentDetails
+          "create" -> Composer.newContentUrl,
+          "view" -> Composer.adminUrl,
+          "details" -> Composer.contentDetails
+        ),
+        "mediaAtomMaker" -> Json.obj(
+          "create" -> Atom.newContentUrl
         ),
         "statuses" -> statuses,
         "desks"    -> desks,

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -80,7 +80,8 @@ object Application extends Controller with PanDomainAuthActions {
           "details" -> Composer.contentDetails
         ),
         "mediaAtomMaker" -> Json.obj(
-          "create" -> Atom.newContentUrl
+          "create" -> Atom.newContentUrl,
+          "view" -> Atom.viewContentUrl
         ),
         "statuses" -> statuses,
         "desks"    -> desks,

--- a/app/controllers/Feature.scala
+++ b/app/controllers/Feature.scala
@@ -1,13 +1,14 @@
 package controllers
 
+import play.api.libs.json.{JsBoolean, JsObject}
 import play.api.mvc._
 
 object Feature extends Controller with PanDomainAuthActions {
 
   def featureList(implicit request: Request[_]): Map[String, Boolean] = {
     def featureDef(name: String): (String, Boolean) =
-      (name, request.cookies.get(name).map(_.value == "1").getOrElse(false))
-    Map(featureDef("incopy-export"))
+      (name, request.cookies.get(name).exists(_.value == "1"))
+    Map(featureDef("incopy-export"), featureDef("support-atoms"))
   }
 
   def makeCookie[A](name: String, value: Boolean => Boolean)

--- a/app/lib/Atom.scala
+++ b/app/lib/Atom.scala
@@ -4,5 +4,5 @@ import config.Config
 
 object Atom {
   lazy val mediaAtomMakerBaseUrl: String = Config.mediaAtomMakerUrl
-  lazy val newContentUrl: String = mediaAtomMakerBaseUrl + "/api2/atoms"
+  lazy val newContentUrl: String = mediaAtomMakerBaseUrl + "/api2/workflow/atoms"
 }

--- a/app/lib/Atom.scala
+++ b/app/lib/Atom.scala
@@ -5,5 +5,5 @@ import config.Config
 object Atom {
   lazy val mediaAtomMakerBaseUrl: String = Config.mediaAtomMakerUrl
   lazy val newContentUrl: String = mediaAtomMakerBaseUrl + "/api2/workflow/atoms"
-  lazy val viewContentUrl: String = mediaAtomMakerBaseUrl + "/video/"
+  lazy val viewContentUrl: String = mediaAtomMakerBaseUrl + "/videos/"
 }

--- a/app/lib/Atom.scala
+++ b/app/lib/Atom.scala
@@ -5,4 +5,5 @@ import config.Config
 object Atom {
   lazy val mediaAtomMakerBaseUrl: String = Config.mediaAtomMakerUrl
   lazy val newContentUrl: String = mediaAtomMakerBaseUrl + "/api2/workflow/atoms"
+  lazy val viewContentUrl: String = mediaAtomMakerBaseUrl + "/video/"
 }

--- a/app/lib/Atom.scala
+++ b/app/lib/Atom.scala
@@ -1,0 +1,8 @@
+package lib
+
+import config.Config
+
+object Atom {
+  lazy val mediaAtomMakerBaseUrl: String = Config.mediaAtomMakerUrl
+  lazy val newContentUrl: String = mediaAtomMakerBaseUrl + "/api2/atoms"
+}

--- a/app/lib/Composer.scala
+++ b/app/lib/Composer.scala
@@ -1,6 +1,6 @@
 package lib
 
-import play.api.libs.json.{JsString, JsValue}
+import play.api.libs.json.JsValue
 import config.Config
 
 object Composer {

--- a/conf/routes
+++ b/conf/routes
@@ -23,7 +23,6 @@ GET            /logout                                     controllers.Login.log
 # API
 
 GET            /api/content                                controllers.Api.content
-POST           /api/content                                controllers.Api.createContent
 GET            /api/content/:composerId                    controllers.Api.getContentbyId(composerId: String)
 PUT            /api/content/:composerId/status             controllers.Api.putStubStatusByComposerId(composerId: String)
 DELETE         /api/content/:composerId                    controllers.Api.deleteContent(composerId: String)

--- a/public/app.js
+++ b/public/app.js
@@ -144,7 +144,8 @@ angular.module('workflow',
             'presenceUrl': _wfConfig.presenceUrl,
             'incopyExportUrl': _wfConfig.incopyExportUrl,
             'composerRestorerUrl': _wfConfig.composerRestorerUrl,
-            'maxNoteLength': 500
+            'maxNoteLength': 500,
+            'mediaAtomMakerNewAtom': _wfConfig.mediaAtomMaker.create
         }
     )
     .constant({ 'statuses': _wfConfig.statuses })

--- a/public/app.js
+++ b/public/app.js
@@ -145,7 +145,8 @@ angular.module('workflow',
             'incopyExportUrl': _wfConfig.incopyExportUrl,
             'composerRestorerUrl': _wfConfig.composerRestorerUrl,
             'maxNoteLength': 500,
-            'mediaAtomMakerNewAtom': _wfConfig.mediaAtomMaker.create
+            'mediaAtomMakerNewAtom': _wfConfig.mediaAtomMaker.create,
+            'mediaAtomMakerViewAtom': _wfConfig.mediaAtomMaker.view
         }
     )
     .constant({ 'statuses': _wfConfig.statuses })

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -49,8 +49,7 @@
             <div class="form-group pull-right col-xs-5">
                 <label for="stub_section">Section *</label>
                 <div>
-                    <select id="stub_section" name="section" ng-model="stub.section" ng-options="section.name for section in
-                 sections" required>
+                    <select id="stub_section" name="section" ng-model="stub.section" ng-options="section.name for section in sections" required>
                     </select>
                 </div>
             </div>
@@ -113,7 +112,7 @@
             <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true,addToAtomEditor=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && contentName !== 'Atom'">
                 Create new
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false,addToAtomEditor=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentName === 'Atom'">
+            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false,addToAtomEditor=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentName === 'Atom' && stub.status !== 'Stub'">
                 Create atom
             </button>
         </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -107,13 +107,13 @@
             <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="cancel()">Cancel</button>
         </div>
         <div class="pull-right">
-            <button type="submit" class="btn btn-default" id="testing-create-stub" ng-click="ok(addToComposer=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
+            <button type="submit" class="btn btn-default" id="testing-create-stub" ng-click="ok(addToComposer=false,addToAtomEditor=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
                 Save stub
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && generalContentType !== 'Atom'">
+            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true,addToAtomEditor=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && generalContentType !== 'Atom'">
                 Create new
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="generalContentType === 'Atom'">
+            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false,addToAtomEditor=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="generalContentType === 'Atom'">
                 Create atom
             </button>
         </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -138,6 +138,11 @@
     <a ng-href="{{composerUrl}}" class="btn btn-primary pull-right" target="_blank" ng-click="cancel()" id="testing-view-in-composer">View in Composer</a>
 </div>
 
+<div class="modal-footer" ng-show="actionSuccess && editorUrl">
+    <button type="button" class="btn btn-default pull-left" ng-click="cancel()">Dismiss</button>
+    <a ng-href="{{editorUrl}}" class="btn btn-primary pull-right" target="_blank" ng-click="cancel()" id="testing-view-in-atom-editor">View in Editor</a>
+</div>
+
 <div class="modal-footer__alert">
     <div class="modal-footer alert alert-info" ng-show="wfComposerState ==='visible'">
         <p>This content is already tracked. <a href="#stub-{{stubId}}" ng-click="cancel()">View in Workflow.</a></p>
@@ -154,9 +159,11 @@
     </div>
 
     <div class="modal-footer alert alert-danger" ng-show="actionSuccess === false">
-        <p>Workflow's having difficulty communicating with Composer. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
+        <p ng-show="generalContentType !== 'Atom'">Workflow's having difficulty communicating with Composer. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
+        <p ng-show="generalContentType === 'Atom'">Workflow's having difficulty communicating with the editor. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
         <p>
             <a ng-show="composerUrl" href="{{composerUrl}}" target="_blank" ng-click="cancel()">View in Composer.</a>
+            <a ng-show="editorUrl" href="{{editorUrl}}" target="_blank" ng-click="cancel()">View in Editor.</a>
             <a ng-show="stubId" href="#stub-{{stubId}}" ng-click="cancel()">View in Workflow.</a>
         </p>
     </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -159,7 +159,7 @@
 
     <div class="modal-footer alert alert-danger" ng-show="actionSuccess === false">
         <p ng-show="contentName !== 'Atom'">Workflow's having difficulty communicating with Composer. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
-        <p ng-show="contentName === 'Atom'">Workflow's having difficulty communicating with the editor. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
+        <p ng-show="contentName === 'Atom'">Workflow's having difficulty communicating with the editor for this atom type. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
         <p>
             <a ng-show="composerUrl" href="{{composerUrl}}" target="_blank" ng-click="cancel()">View in Composer.</a>
             <a ng-show="editorUrl" href="{{editorUrl}}" target="_blank" ng-click="cancel()">View in Editor.</a>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -28,7 +28,7 @@
                 </div>
                 <p class="help-block" ng-class="{ 'help-block--invisible': mode === 'import' || stub.status === 'Stub' }">To save as a Stub, change status to News List</p>
             </div>
-            <div class="form-group pull-right col-xs-5" ng-if="generalContentType === 'Atom'">
+            <div class="form-group pull-right col-xs-5" ng-if="contentName === 'Atom'">
                 <label for="stub_content_type">Type *</label>
                 <div>
                     <select id="stub_content_type" name="content_type" ng-model="stub.contentType" ng-options="type for type in atomTypes" required>
@@ -110,10 +110,10 @@
             <button type="submit" class="btn btn-default" id="testing-create-stub" ng-click="ok(addToComposer=false,addToAtomEditor=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
                 Save stub
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true,addToAtomEditor=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && generalContentType !== 'Atom'">
+            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true,addToAtomEditor=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && contentName !== 'Atom'">
                 Create new
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false,addToAtomEditor=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="generalContentType === 'Atom'">
+            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false,addToAtomEditor=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentName === 'Atom'">
                 Create atom
             </button>
         </div>
@@ -159,8 +159,8 @@
     </div>
 
     <div class="modal-footer alert alert-danger" ng-show="actionSuccess === false">
-        <p ng-show="generalContentType !== 'Atom'">Workflow's having difficulty communicating with Composer. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
-        <p ng-show="generalContentType === 'Atom'">Workflow's having difficulty communicating with the editor. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
+        <p ng-show="contentName !== 'Atom'">Workflow's having difficulty communicating with Composer. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
+        <p ng-show="contentName === 'Atom'">Workflow's having difficulty communicating with the editor. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
         <p>
             <a ng-show="composerUrl" href="{{composerUrl}}" target="_blank" ng-click="cancel()">View in Composer.</a>
             <a ng-show="editorUrl" href="{{editorUrl}}" target="_blank" ng-click="cancel()">View in Editor.</a>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -28,6 +28,13 @@
                 </div>
                 <p class="help-block" ng-class="{ 'help-block--invisible': mode === 'import' || stub.status === 'Stub' }">To save as a Stub, change status to News List</p>
             </div>
+            <div class="form-group pull-right col-xs-5" ng-if="contentType === 'Atom'">
+                <label for="stub_type">Type *</label>
+                <div>
+                    <select id="stub_type" name="type" ng-model="type" ng-options="type for type in atomTypes" required>
+                    </select>
+                </div>
+            </div>
             <div class="form-group pull-left col-xs-8" ng-if="mode !== 'import'">
                 <label for="stub_cdesk">Commissioning info</label>
 
@@ -103,8 +110,11 @@
             <button type="submit" class="btn btn-default" id="testing-create-stub" ng-click="ok(addToComposer=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
                 Save stub
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub'">
+            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && contentType !== 'Atom'">
                 Create new
+            </button>
+            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentType === 'Atom'">
+                Create atom
             </button>
         </div>
     </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -31,7 +31,7 @@
             <div class="form-group pull-right col-xs-5" ng-if="contentName === 'Atom'">
                 <label for="stub_content_type">Type *</label>
                 <div>
-                    <select id="stub_content_type" name="content_type" ng-model="stub.contentType" ng-options="type for type in atomTypes" required>
+                    <select id="stub_content_type" name="content_type" ng-model="stub.contentType" ng-options="(type | lowercase) as type for type in atomTypes" required>
                     </select>
                 </div>
             </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -28,10 +28,10 @@
                 </div>
                 <p class="help-block" ng-class="{ 'help-block--invisible': mode === 'import' || stub.status === 'Stub' }">To save as a Stub, change status to News List</p>
             </div>
-            <div class="form-group pull-right col-xs-5" ng-if="contentType === 'Atom'">
-                <label for="stub_type">Type *</label>
+            <div class="form-group pull-right col-xs-5" ng-if="generalContentType === 'Atom'">
+                <label for="stub_content_type">Type *</label>
                 <div>
-                    <select id="stub_type" name="type" ng-model="type" ng-options="type for type in atomTypes" required>
+                    <select id="stub_content_type" name="content_type" ng-model="stub.contentType" ng-options="type for type in atomTypes" required>
                     </select>
                 </div>
             </div>
@@ -110,10 +110,10 @@
             <button type="submit" class="btn btn-default" id="testing-create-stub" ng-click="ok(addToComposer=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
                 Save stub
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && contentType !== 'Atom'">
+            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && generalContentType !== 'Atom'">
                 Create new
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentType === 'Atom'">
+            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="generalContentType === 'Atom'">
                 Create atom
             </button>
         </div>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -142,12 +142,13 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         const stub = $scope.stub;
         let promise;
 
-        if (!addToComposer && !($scope.mode === "import")) {
+        if ((!addToComposer || !addToAtomEditor) && !($scope.mode === "import")) {
             delete stub.status;
         }
 
         if ($scope.contentName === 'Atom') {
             stub['contentType'] = $scope.stub.contentType.toLowerCase();
+            stub['status'] = stub.status === undefined ? 'Stub' : stub.status;
             if (addToAtomEditor) {
                 promise = wfContentService.createInMediaAtomMaker(stub);
             } else if (stub.id) {

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -255,6 +255,8 @@ wfStubModal.run([
     'config',
     function ($window, $rootScope, $modal, $log, wfContentService, wfFiltersService, wfProdOfficeService, wfPreferencesService, wfLocationService, sections, config) {
 
+        var defaultAtomType = "media"
+
         function currentFilteredOffice() {
             return wfFiltersService.get('prodOffice');
         }
@@ -272,10 +274,12 @@ wfStubModal.run([
          */
         function setUpPreferedStub (contentType) {
 
+            console.log("[PMR 1458] setUpPreferedStub ", contentType)
+
             function createStubData (contentType, sectionName) {
 
                 return {
-                    contentType: contentType,
+                    contentType: contentType == "atom" ? defaultAtomType : contentType,
                     // Only send through a section if one is found in the prefs
                     section: sectionName === null ? sectionName : sections.filter((section) => section.name === sectionName)[0],
                     priority: 0,

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -11,12 +11,13 @@ import 'lib/filters-service';
 import 'lib/prodoffice-service';
 import { punters } from 'components/punters/punters';
 
-
-var wfStubModal = angular.module('wfStubModal', ['ui.bootstrap', 'legalStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService'])
+const wfStubModal = angular.module('wfStubModal', ['ui.bootstrap', 'legalStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService'])
     .directive('punters', ['$rootScope', 'wfGoogleApiService', punters]);
 
 function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, config, stub, mode, sections, statusLabels, legalStatesService, wfComposerService, wfProdOfficeService, wfContentService, wfPreferencesService, wfFiltersService, sectionsInDesks) {
-    var contentName = wfContentService.getTypes()[stub.contentType] || "News item";
+    const contentName = wfContentService.getTypes()[stub.contentType] || "News item";
+
+    $scope.contentType = contentName;
 
     $scope.mode = mode;
     $scope.modalTitle = ({
@@ -29,7 +30,7 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
     $scope.disabled = !!stub.composerId;
     $scope.sections = getSectionsList(sections);
     $scope.statuses = statusLabels;
-    $scope.cdesks = _wfConfig.commissioningDesks
+    $scope.cdesks = _wfConfig.commissioningDesks;
 
     if(mode==='import') {
        $scope.statuses = statusLabels.filter(function(s) { return s.value!=='Stub'});
@@ -43,7 +44,7 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
          * only set the section if a preference was found
          */
         $scope.stub.section = (function findSelectedSectionInAvailableSections (sect) {
-            var filteredSections = $scope.sections ? $scope.sections.filter((el) => (el ? el.name === sect.name : false)) : [];
+            const filteredSections = $scope.sections ? $scope.sections.filter((el) => (el ? el.name === sect.name : false)) : [];
             if (filteredSections.length > 0) {
                 return filteredSections[0];
             }
@@ -53,6 +54,8 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
 
     $scope.stub.status = 'Writers';
 
+    $scope.atomTypes = ['Media', 'Story questions'];
+
     /**
      * If the user currently has a desk selected then only
      * show the sections that are part of that desk in the dropdown
@@ -60,12 +63,12 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
      * @returns Filtered list of sections
      */
     function getSectionsList (sections) {
-        var deskId = wfFiltersService.get('desk');
+        const deskId = wfFiltersService.get('desk');
 
         if (deskId) {
-            var sectionsIdsInThisDesk = sectionsInDesks.filter((el) => el.deskId === parseInt(deskId, 10));
+            const sectionsIdsInThisDesk = sectionsInDesks.filter((el) => el.deskId === parseInt(deskId, 10));
             if (sectionsIdsInThisDesk.length > 0) {
-                var setSectionsIdsInThisDesk = new Set(sectionsIdsInThisDesk[0].sectionIds);
+                const setSectionsIdsInThisDesk = new Set(sectionsIdsInThisDesk[0].sectionIds);
                 sections = sections.filter((el) => setSectionsIdsInThisDesk.has(el.id))
             }
         }
@@ -99,8 +102,8 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
                 //check validity
                 if (composerContent) {
 
-                    var contentItem = wfComposerService.parseComposerData(composerContent.data, $scope.stub);
-                    var composerId = contentItem.composerId;
+                    const contentItem = wfComposerService.parseComposerData(composerContent.data, $scope.stub);
+                    const composerId = contentItem.composerId;
 
                     if(composerId) {
                         $scope.composerUrl = config.composerViewContent + '/' + composerId;
@@ -135,8 +138,8 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
     };
 
     $scope.ok = function (addToComposer) {
-        var stub = $scope.stub;
-        var promise;
+        const stub = $scope.stub;
+        let promise;
 
         if (!addToComposer && !($scope.mode === "import")) {
             delete stub.status;
@@ -153,7 +156,7 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
         $scope.actionInProgress = true;
 
         promise.then((response) => {
-            var eventName = ({
+            const eventName = ({
                 'create': 'stub.created',
                 'edit': 'stub.edited',
                 'import': 'content.imported'
@@ -284,7 +287,7 @@ wfStubModal.run([
         });
 
         function open(stub, mode) {
-            var modalInstance = $modal.open({
+            const modalInstance = $modal.open({
                 templateUrl: '/assets/components/stub-modal/stub-modal.html',
                 controller: StubModalInstanceCtrl,
                 windowClass: 'stubModal',

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -274,8 +274,6 @@ wfStubModal.run([
          */
         function setUpPreferedStub (contentType) {
 
-            console.log("[PMR 1458] setUpPreferedStub ", contentType)
-
             function createStubData (contentType, sectionName) {
 
                 return {

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -17,7 +17,9 @@ const wfStubModal = angular.module('wfStubModal', ['ui.bootstrap', 'legalStatesS
 function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, config, stub, mode, sections, statusLabels, legalStatesService, wfComposerService, wfProdOfficeService, wfContentService, wfPreferencesService, wfFiltersService, sectionsInDesks) {
 
     wfContentService.getTypes().then( (types) => {
-        $scope.contentName = types[stub.contentType] || "News item";
+        $scope.contentName =
+            (wfContentService.getAtomTypes())[stub.contentType] ?
+            "Atom" : (types[stub.contentType] || "News item");
 
         $scope.modalTitle = ({
             'create': `Create ${$scope.contentName}`,

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -142,31 +142,31 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
 
     $scope.ok = function (addToComposer, addToAtomEditor) {
         const stub = $scope.stub;
-        let promise;
-
-        if ($scope.contentName === 'Atom') {
-            stub['contentType'] = $scope.stub.contentType.toLowerCase();
-            stub['status'] = stub.status === undefined ? 'Stub' : stub.status;
-            if (addToAtomEditor) {
-                promise = wfContentService.createInMediaAtomMaker(stub);
-            } else if (stub.id) {
-                promise = wfContentService.updateStub(stub);
+        function createItemPromise() {
+            if ($scope.contentName === 'Atom') {
+                stub['contentType'] = $scope.stub.contentType.toLowerCase();
+                stub['status'] = stub.status === undefined ? 'Stub' : stub.status;
+                if (addToAtomEditor) {
+                    return wfContentService.createInMediaAtomMaker(stub);
+                } else if (stub.id) {
+                    return wfContentService.updateStub(stub);
+                } else {
+                    return wfContentService.createStub(stub);
+                }
             } else {
-                promise = wfContentService.createStub(stub);
-            }
-        } else {
-            if (addToComposer) {
-                promise = wfContentService.createInComposer(stub);
-            } else if (stub.id) {
-                promise = wfContentService.updateStub(stub);
-            } else {
-                promise = wfContentService.createStub(stub);
+                if (addToComposer) {
+                    return wfContentService.createInComposer(stub);
+                } else if (stub.id) {
+                    return wfContentService.updateStub(stub);
+                } else {
+                    return wfContentService.createStub(stub);
+                }
             }
         }
 
         $scope.actionInProgress = true;
 
-        promise.then((response) => {
+        createItemPromise().then((response) => {
             const eventName = ({
                 'create': 'stub.created',
                 'edit': 'stub.edited',

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -14,10 +14,10 @@ import { punters } from 'components/punters/punters';
 const wfStubModal = angular.module('wfStubModal', ['ui.bootstrap', 'legalStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService'])
     .directive('punters', ['$rootScope', 'wfGoogleApiService', punters]);
 
-function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, config, stub, mode, sections, statusLabels, legalStatesService, wfComposerService, wfProdOfficeService, wfContentService, wfPreferencesService, wfFiltersService, sectionsInDesks) {
+function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, config, stub, mode, sections, statusLabels, legalStatesService, wfComposerService, wfProdOfficeService, wfContentService, wfPreferencesService, wfFiltersService, sectionsInDesks) {
     const contentName = wfContentService.getTypes()[stub.contentType] || "News item";
 
-    $scope.contentType = contentName;
+    $scope.generalContentType = contentName;
 
     $scope.mode = mode;
     $scope.modalTitle = ({
@@ -31,6 +31,7 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
     $scope.sections = getSectionsList(sections);
     $scope.statuses = statusLabels;
     $scope.cdesks = _wfConfig.commissioningDesks;
+    $scope.atomTypes = ['Media', 'Story questions'];
 
     if(mode==='import') {
        $scope.statuses = statusLabels.filter(function(s) { return s.value!=='Stub'});
@@ -53,8 +54,6 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
     }
 
     $scope.stub.status = 'Writers';
-
-    $scope.atomTypes = ['Media', 'Story questions'];
 
     /**
      * If the user currently has a desk selected then only
@@ -143,6 +142,10 @@ function StubModalInstanceCtrl($rootScope,$scope, $modalInstance, $window, confi
 
         if (!addToComposer && !($scope.mode === "import")) {
             delete stub.status;
+        }
+
+        if (stub.contentType === 'Atom') {
+            stub['contentType'] = $scope.stub.contentType.toLowerCase();
         }
 
         if (addToComposer) {

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -255,7 +255,7 @@ wfStubModal.run([
     'config',
     function ($window, $rootScope, $modal, $log, wfContentService, wfFiltersService, wfProdOfficeService, wfPreferencesService, wfLocationService, sections, config) {
 
-        var defaultAtomType = "media"
+        const defaultAtomType = "media"
 
         function currentFilteredOffice() {
             return wfFiltersService.get('prodOffice');
@@ -277,7 +277,7 @@ wfStubModal.run([
             function createStubData (contentType, sectionName) {
 
                 return {
-                    contentType: contentType == "atom" ? defaultAtomType : contentType,
+                    contentType: contentType === "atom" ? defaultAtomType : contentType,
                     // Only send through a section if one is found in the prefs
                     section: sectionName === null ? sectionName : sections.filter((section) => section.name === sectionName)[0],
                     priority: 0,

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -15,16 +15,18 @@ const wfStubModal = angular.module('wfStubModal', ['ui.bootstrap', 'legalStatesS
     .directive('punters', ['$rootScope', 'wfGoogleApiService', punters]);
 
 function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, config, stub, mode, sections, statusLabels, legalStatesService, wfComposerService, wfProdOfficeService, wfContentService, wfPreferencesService, wfFiltersService, sectionsInDesks) {
-    const contentName = wfContentService.getTypes()[stub.contentType] || "News item";
 
-    $scope.generalContentType = contentName;
+    wfContentService.getTypes().then( (types) => {
+        $scope.contentName = types[stub.contentType] || "News item";
+
+        $scope.modalTitle = ({
+            'create': `Create ${$scope.contentName}`,
+            'edit': `Edit ${$scope.contentName}`,
+            'import': 'Import from Composer'
+        })[mode];
+    });
 
     $scope.mode = mode;
-    $scope.modalTitle = ({
-        'create': `Create ${contentName}`,
-        'edit': `Edit ${contentName}`,
-        'import': 'Import from Composer'
-    })[mode];
 
     $scope.formData = {};
     $scope.disabled = !!stub.composerId;
@@ -144,7 +146,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             delete stub.status;
         }
 
-        if ($scope.generalContentType === 'Atom') {
+        if ($scope.contentName === 'Atom') {
             stub['contentType'] = $scope.stub.contentType.toLowerCase();
             if (addToAtomEditor) {
                 promise = wfContentService.createInMediaAtomMaker(stub);
@@ -175,7 +177,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             $rootScope.$broadcast(eventName, { 'contentItem': stub });
             $rootScope.$broadcast('getContent');
 
-            if ($scope.generalContentType === 'Atom') {
+            if ($scope.contentName === 'Atom') {
                 if (stub.editorId && ($scope.mode != 'import')) {
                     $scope.editorUrl = wfContentService.getEditorUrl(stub.editorId)[stub.contentType];
                 } else {

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -175,13 +175,24 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             $rootScope.$broadcast(eventName, { 'contentItem': stub });
             $rootScope.$broadcast('getContent');
 
-            if(stub.composerId && ($scope.mode != 'import')) {
-                $scope.composerUrl = config.composerViewContent + '/' + stub.composerId;
+            if ($scope.generalContentType === 'Atom') {
+                if (stub.editorId && ($scope.mode != 'import')) {
+                    $scope.editorUrl = wfContentService.getEditorUrl(stub.editorId)[stub.contentType];
+                } else {
+                    $modalInstance.close({
+                        addToEditor: addToAtomEditor,
+                        stub: $scope.stub
+                    });
+                }
             } else {
-                $modalInstance.close({
-                    addToComposer: addToComposer,
-                    stub: $scope.stub
-                });
+                if(stub.composerId && ($scope.mode != 'import')) {
+                    $scope.composerUrl = config.composerViewContent + '/' + stub.composerId;
+                } else {
+                    $modalInstance.close({
+                        addToComposer: addToComposer,
+                        stub: $scope.stub
+                    });
+                }
             }
 
             $scope.actionSuccess = true;
@@ -195,11 +206,13 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
                 if(err.data.composerId) {
                     $scope.composerUrl = config.composerViewContent + '/' + err.data.composerId;
                 }
+                if(err.data.editorId) {
+                    $scope.editorUrl = wfContentService.getEditorUrl(stub.editorId)[stub.contentType];
+                }
                 if(err.data.stubId) {
                     $scope.stubId = err.data.stubId;
                 }
-            }
-            else {
+            } else {
                 $scope.errorMsg = err.friendlyMessage || err.message || err;
                 $scope.actionSuccess = false;
             }

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -142,10 +142,6 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         const stub = $scope.stub;
         let promise;
 
-        if ((!addToComposer || !addToAtomEditor) && !($scope.mode === "import")) {
-            delete stub.status;
-        }
-
         if ($scope.contentName === 'Atom') {
             stub['contentType'] = $scope.stub.contentType.toLowerCase();
             stub['status'] = stub.status === undefined ? 'Stub' : stub.status;

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -31,7 +31,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     $scope.sections = getSectionsList(sections);
     $scope.statuses = statusLabels;
     $scope.cdesks = _wfConfig.commissioningDesks;
-    $scope.atomTypes = ['Media', 'Story questions'];
+    $scope.atomTypes = ['Media'];
 
     if(mode==='import') {
        $scope.statuses = statusLabels.filter(function(s) { return s.value!=='Stub'});
@@ -136,7 +136,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         );
     };
 
-    $scope.ok = function (addToComposer) {
+    $scope.ok = function (addToComposer, addToAtomEditor) {
         const stub = $scope.stub;
         let promise;
 
@@ -144,16 +144,23 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             delete stub.status;
         }
 
-        if (stub.contentType === 'Atom') {
+        if ($scope.generalContentType === 'Atom') {
             stub['contentType'] = $scope.stub.contentType.toLowerCase();
-        }
-
-        if (addToComposer) {
-            promise = wfContentService.createInComposer(stub);
-        } else if (stub.id) {
-            promise = wfContentService.updateStub(stub);
+            if (addToAtomEditor) {
+                promise = wfContentService.createInMediaAtomMaker(stub);
+            } else if (stub.id) {
+                promise = wfContentService.updateStub(stub);
+            } else {
+                promise = wfContentService.createStub(stub);
+            }
         } else {
-            promise = wfContentService.createStub(stub);
+            if (addToComposer) {
+                promise = wfContentService.createInComposer(stub);
+            } else if (stub.id) {
+                promise = wfContentService.updateStub(stub);
+            } else {
+                promise = wfContentService.createStub(stub);
+            }
         }
 
         $scope.actionInProgress = true;

--- a/public/layouts/dashboard/dashboard-create.js
+++ b/public/layouts/dashboard/dashboard-create.js
@@ -7,7 +7,9 @@ import './dashboard-create.html';
 angular
     .module('wfDashboardCreate', ['wfContentService'])
     .controller('wfDashboardCreateController', ['$scope', 'wfContentService', function ($scope, contentService) {
-        $scope.options = contentService.getTypes();
+        contentService.getTypes().then( (types) => {
+            $scope.options = types;
+        });
 
         $scope.createContent = function(contentType) {
             $scope.$emit('stub:create', contentType);

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -5,9 +5,9 @@ angular.module('wfComposerService', [])
 
 function wfComposerService($http, $q, config, wfHttpSessionService) {
 
-    var request = wfHttpSessionService.request;
+    const request = wfHttpSessionService.request;
 
-    var composerContentFetch = config.composerContentDetails;
+    const composerContentFetch = config.composerContentDetails;
 
     // budget composer url parser - just gets the portion after the last '/'
     function parseComposerId(url) {
@@ -17,14 +17,14 @@ function wfComposerService($http, $q, config, wfHttpSessionService) {
 
     function deepSearch(obj, path) {
         if (path.length === 0) return obj;
-        var next = path[0];
+        const next = path[0];
         if (obj[next]) return deepSearch(obj[next], path.slice(1));
         else return null;
     }
 
 
     // Mapping of workflow content fields to transform functions on composer response
-    var composerParseMap = {
+    const composerParseMap = {
         composerId: (d) => d.id,
         contentType: (d) => d.type,
         headline: (d) => deepSearch(d, ['preview', 'data', 'fields', 'headline', 'data']) || undefined,
@@ -46,7 +46,7 @@ function wfComposerService($http, $q, config, wfHttpSessionService) {
     function parseComposerData(response, target) {
         target = target || {};
 
-        var data = response.data;
+        const data = response.data;
 
         Object.keys(composerParseMap).forEach((key) => {
             target[key] = composerParseMap[key](data);

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -35,7 +35,6 @@ function wfComposerService($http, $q, config, wfHttpSessionService) {
         takenDown: (d) => false, // TODO: takenDown from composer feed
         activeInInCopy: (d) => deepSearch(d, ['toolSettings', 'activeInInCopy', 'data']) === 'true',
         composerProdOffice: (d) => deepSearch(d, ['preview', 'data', 'settings', 'productionOffice', 'data']) || undefined,
-        commentable: (d) => deepSearch(d, ['preview', 'data', 'settings', 'commentable', 'data']) === 'true',
         optimisedForWeb: (d) => deepSearch(d, ['toolSettings', 'seoOptimised', 'data']) === 'true',
         optimisedForWebChanged: (d) => deepSearch(d, ['toolSettings', 'seoChanged', 'data']) === 'true',
         revision: (d) => deepSearch(d, ['contentChangeDetails', 'data', 'revision']),

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -87,10 +87,11 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
 
                     return wfMediaAtomMakerService.create(stub.title).then( (response) => {
 
-                        console.log("this is where we do all the saving", response);
+                        console.log("this is where we do all the saving! We got a response: ", response);
 
                         if (statusOption) {
                             stub['status'] = statusOption;
+                            stub['editorId'] = 'videos/' + response.id;
                         }
 
                         if (stub.id) {

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -18,7 +18,8 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         "liveblog": "Live blog",
                         "gallery": "Gallery",
                         "interactive": "Interactive",
-                        "picture": "Picture"
+                        "picture": "Picture",
+                        "atom": "Atom"
                     }
                 };
 

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -100,18 +100,14 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                  * Creates an atom in the Media Atom Maker. Effectively setting
                  * the editorId to what we get from the response.
                  */
-                createInMediaAtomMaker(stub, statusOption) {
+                createInMediaAtomMaker(stub) {
 
                     return wfMediaAtomMakerService.create(stub.title).then( (response) => {
 
-                        if (statusOption) {
-                            stub['status'] = statusOption;
-                            stub['editorId'] = response.data.id;
-                        }
+                        stub['editorId'] = response.data.id;
 
                         if (stub.id) {
                             return this.updateStub(stub);
-
                         } else {
                             return this.createStub(stub);
                         }

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -31,6 +31,11 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                     });
                 };
 
+                /* what types of stub should be treated as atoms? */
+                getAtomTypes() {
+                    return { "media": true };
+                }
+
                 getEditorUrl(editorId) {
                     return {
                         "media": config.mediaAtomMakerViewAtom + editorId

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -17,17 +17,16 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                 getTypes() {
 
                     return wfFeatureSwitches.getSwitch("support-atoms").then( (isActive) => {
-                        var basicTypes = {
+                        const basicTypes = {
                             "article": "Article",
                             "liveblog": "Live blog",
                             "gallery": "Gallery",
                             "interactive": "Interactive",
                             "picture": "Picture"
                         };
-
-                        if (isActive) basicTypes['atom'] = 'Atom';
-
-                        return basicTypes;
+                        return isActive
+                            ? Object.assign({}, basicTypes, {'atom': 'Atom'})
+                        :  basicTypes;
                     });
                 };
 

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -7,8 +7,8 @@ import './user';
 import './visibility-service';
 
 angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService', 'wfMediaAtomMakerService'])
-    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService',
-        function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService, wfMediaAtomMakerService) {
+    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'config',
+        function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService, wfMediaAtomMakerService, config) {
 
             var httpRequest = wfHttpSessionService.request;
 
@@ -21,6 +21,12 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         "interactive": "Interactive",
                         "picture": "Picture",
                         "atom": "Atom"
+                    }
+                };
+
+                getEditorUrl(editorId) {
+                    return {
+                        "media": config.mediaAtomMakerViewAtom + editorId
                     }
                 };
 
@@ -87,11 +93,11 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
 
                     return wfMediaAtomMakerService.create(stub.title).then( (response) => {
 
-                        console.log("this is where we do all the saving! We got a response: ", response);
+                        console.log("this is where we do all the saving! We got a response with id: ", response.data.id);
 
                         if (statusOption) {
                             stub['status'] = statusOption;
-                            stub['editorId'] = 'videos/' + response.id;
+                            stub['editorId'] = response.data.id;
                         }
 
                         if (stub.id) {

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -1,13 +1,14 @@
 import angular from 'angular';
 
 import './composer-service';
+import './media-atom-maker-service'
 import './http-session-service';
 import './user';
 import './visibility-service';
 
-angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService'])
-    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService',
-        function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService) {
+angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService', 'wfMediaAtomMakerService'])
+    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService',
+        function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService, wfMediaAtomMakerService) {
 
             var httpRequest = wfHttpSessionService.request;
 
@@ -68,6 +69,25 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                     return wfComposerService.create(stub.contentType, stub.commissioningDesks).then( (response) => {
 
                         wfComposerService.parseComposerData(response.data, stub);
+
+                        if (statusOption) {
+                            stub['status'] = statusOption;
+                        }
+
+                        if (stub.id) {
+                            return this.updateStub(stub);
+
+                        } else {
+                            return this.createStub(stub);
+                        }
+                    });
+                }
+
+                createInMediaAtomMaker(stub, statusOption) {
+
+                    return wfMediaAtomMakerService.create(stub.title).then( (response) => {
+
+                        console.log("this is where we do all the saving", response);
 
                         if (statusOption) {
                             stub['status'] = statusOption;

--- a/public/lib/feature-switches.js
+++ b/public/lib/feature-switches.js
@@ -1,9 +1,9 @@
 define([], function () {
 
-    var module = angular.module('wfFeatureSwitches', []);
+    const module = angular.module('wfFeatureSwitches', []);
 
     module.factory('wfFeatureSwitches', ['config', '$http', function(config, $http) {
-        var self = {};
+        const self = {};
 
         // dummy switches - eventually this will come from the server
         // via an API call
@@ -12,11 +12,13 @@ define([], function () {
             return document.cookie.search(cookieName + "=1(;|$)") != -1;
         }
 
-        var staticSwitchData = {
+        const staticSwitchData = {
             "presence-indicator": simpleCookie("presence-indicator"),
-            "incopy-export": simpleCookie("incopy-export")
-        }
-        var switches = new Promise(function(resolve, reject) {
+            "incopy-export": simpleCookie("incopy-export"),
+            "support-atoms": simpleCookie("support-atoms")
+        };
+
+        const switches = new Promise(function (resolve, reject) {
             resolve(staticSwitchData);
         });
 
@@ -31,4 +33,4 @@ define([], function () {
         return self;
 
     }]);
-})
+});

--- a/public/lib/media-atom-maker-service.js
+++ b/public/lib/media-atom-maker-service.js
@@ -1,0 +1,22 @@
+import angular from 'angular';
+
+angular.module('wfMediaAtomMakerService', [])
+    .service('wfMediaAtomMakerService', ['config', 'wfHttpSessionService', wfMediaAtomMakerService]);
+
+function wfMediaAtomMakerService(config, wfHttpSessionService) {
+
+    const request = wfHttpSessionService.request;
+
+    this.create = function createInMediaAtomMaker(title) {
+        console.log("time for some creation", title);
+        console.log("url is", config.mediaAtomMakerNewAtom);
+        return request({
+            method: 'POST',
+            url: config.mediaAtomMakerNewAtom,
+            data: { 'title': title },
+            withCredentials: true
+        });
+    };
+
+}
+

--- a/public/lib/media-atom-maker-service.js
+++ b/public/lib/media-atom-maker-service.js
@@ -8,8 +8,6 @@ function wfMediaAtomMakerService(config, wfHttpSessionService) {
     const request = wfHttpSessionService.request;
 
     this.create = function createInMediaAtomMaker(title) {
-        console.log("time for some creation", title);
-        console.log("url is", config.mediaAtomMakerNewAtom);
         return request({
             method: 'POST',
             url: config.mediaAtomMakerNewAtom,


### PR DESCRIPTION
This feature is behind the `support-atoms` switch. Go to `feature/support-atoms/on` to activate it.

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)

**TODO**
- [ ] Add an atom icon
- [ ] Make sure we are never setting the status to `null`, we should always have a value for status as in the future we will make the column required. This means that the status of a `news list` has to be set to be `Stub`.
- [ ] Hide atoms behind a feature switch