### PR TITLE
When switch is on set supportAtoms parameter to true

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -49,9 +49,16 @@ object Api extends Controller with PanDomainAuthActions {
 
   // can be hidden behind multiple auth endpoints
   private def getContentBlock[R] = { implicit req: R =>
-    val qs = req match {
-      case r: UserRequest[_] => r.queryString + ("email" -> Seq(r.user.email))
-      case r: Request[_] => r.queryString
+    val qs: Map[String, Seq[String]] = req match {
+      case r: UserRequest[_] =>
+        val query = r.queryString + ("email" -> Seq(r.user.email))
+
+        val supportAtoms = r.cookies.get("support-atoms").fold(false)(cookie => cookie.value == "1")
+        if(supportAtoms) query + ("supportAtoms" -> Seq(supportAtoms.toString)) else query
+
+      case r: Request[_] =>
+        val supportAtoms = r.cookies.get("support-atoms").fold(false)(cookie => cookie.value == "1")
+        if(supportAtoms) r.queryString + ("supportAtoms" -> Seq(supportAtoms.toString)) else r.queryString
     }
     CommonAPI.getStubs(qs).asFuture.map {
       case Left(err) => InternalServerError

--- a/app/controllers/Feature.scala
+++ b/app/controllers/Feature.scala
@@ -1,6 +1,5 @@
 package controllers
 
-import play.api.libs.json.{JsBoolean, JsObject}
 import play.api.mvc._
 
 object Feature extends Controller with PanDomainAuthActions {


### PR DESCRIPTION
This sends the value of the `support-atoms` feature switch to the backend. When it's `off` we should exclude atoms when querying.

https://github.com/guardian/workflow/pull/1008

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)