### PR TITLE
Show usages in atom's drawer

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -168,7 +168,7 @@
                         <li class="drawer__item">
                             <p class="drawer__item-title">Usages</p>
                             <span ng-repeat="usage in capiData.usages">
-                                {{ usage }}
+                                {{ usage.webTitle }} <a href="{{usage.webUrl}}">Guardian</a> <a href="{{usage.composerUrl}}">Composer</a> <a href="{{usage.viewerUrl}}">Viewer</a>
                             </span>
                         </li>
                     </ul>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -140,15 +140,15 @@
                         </li>
                         <li class="drawer__item">
                             <p class="drawer__item-title">Note</p>
-                            <wf-editable class="drawer__item-content" wf-editable-type="textarea" ng-model="contentItem.note" wf-editable-on-update="onBeforeSaveNote(newValue)" wf-editable-maxlength="maxNoteLength">{{
-                                contentItem.note || 'Add note' }}
+                            <wf-editable class="drawer__item-content" wf-editable-type="textarea" ng-model="contentItem.note" wf-editable-on-update="onBeforeSaveNote(newValue)" wf-editable-maxlength="maxNoteLength">
+                                {{ contentItem.note || 'Add note' }}
                             </wf-editable>
                         </li>
                         <li class="drawer__item">
                             <span class="drawer__item-title">URL</span>
                             <span class="drawer__item-content" ng-if="capiData.capiUrl">
-                                <a href="{{ capiData.capiUrl }}">{{
-                                capiData.capiUrl }}</a>
+                                <a href="{{ capiData.capiUrl }}">
+                                    {{ capiData.capiUrl }}</a>
                             </span>
                         </li>
                         <li class="drawer__item">
@@ -164,8 +164,14 @@
                                 {{ contentItem.contentTypeTitle || '-' }}
                             </wf-editable>
                         </li>
-                    </ul>
 
+                        <li class="drawer__item">
+                            <p class="drawer__item-title">Usages</p>
+                            <span ng-repeat="usage in capiData.usages">
+                                {{ usage }}
+                            </span>
+                        </li>
+                    </ul>
                     
                 </div>
 

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -167,9 +167,14 @@
 
                         <li class="drawer__item">
                             <p class="drawer__item-title">Usages</p>
-                            <span ng-repeat="usage in capiData.usages">
-                                {{ usage.webTitle }} <a href="{{usage.webUrl}}">Guardian</a> <a href="{{usage.composerUrl}}">Composer</a> <a href="{{usage.viewerUrl}}">Viewer</a>
-                            </span>
+                            <div class="drawer__item-content" ng-repeat="usage in capiData.usages">
+                                <div>
+                                    {{ usage.webTitle || '-' }}
+                                    <a href="{{ usage.composerUrl }}" target="_blank"><i class="drawer__icon" wf-icon="composer"/></a>
+                                    <a href="{{ usage.viewerUrl }}" target="_blank"><i class="drawer__icon" wf-icon="preview"/></a>
+                                    <a href="{{ usage.webUrl }}" target="_blank"><i class="drawer__icon" wf-icon="live-site"/></a>
+                                </div>
+                            </div>
                         </li>
                     </ul>
                     

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -174,8 +174,12 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
 
                     wfCapiAtomService.getCapiAtom(contentItem.item.editorId, contentItem.item.contentType)
                         .then((resp) => {
-                            const parsed = wfCapiAtomService.parseCapiAtomData(resp, contentItem.item.contentType);
-                            contentListDrawerController.toggleContent(contentItem, contentListItemElement, parsed);
+                            wfCapiAtomService.getCapiAtomUsages(contentItem.item.editorId, contentItem.item.contentType)
+                                .then((usagesResp) => {
+                                    const parsed = wfCapiAtomService.parseCapiAtomData(resp, contentItem.item.contentType);
+                                    parsed['usages'] = usagesResp.data.response.results;
+                                    contentListDrawerController.toggleContent(contentItem, contentListItemElement, parsed);
+                                });
                         }, (err) => {
                             contentListDrawerController.toggleContent(contentItem, contentListItemElement, wfCapiAtomService.emptyCapiAtomObject());
                     });

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -174,10 +174,10 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
 
                     wfCapiAtomService.getCapiAtom(contentItem.item.editorId, contentItem.item.contentType)
                         .then((resp) => {
-                            wfCapiAtomService.getCapiAtomUsages(contentItem.item.editorId, contentItem.item.contentType)
+                            wfCapiAtomService.getAtomUsages(contentItem.item.editorId, contentItem.item.contentType)
                                 .then((usagesResp) => {
                                     const parsed = wfCapiAtomService.parseCapiAtomData(resp, contentItem.item.contentType);
-                                    parsed['usages'] = usagesResp.data.response.results;
+                                    parsed['usages'] = usagesResp;
                                     contentListDrawerController.toggleContent(contentItem, contentListItemElement, parsed);
                                 });
                         }, (err) => {

--- a/public/lib/capi-atom-service.js
+++ b/public/lib/capi-atom-service.js
@@ -2,9 +2,9 @@ import angular from 'angular';
 import _ from 'lodash';
 
 angular.module('wfCapiAtomService', [])
-.service('wfCapiAtomService', ['$http', '$q', wfCapiAtomService]);
+.service('wfCapiAtomService', ['$http', '$q', 'config', 'wfCapiContentService', wfCapiAtomService]);
 
-function wfCapiAtomService($http, $q) {
+function wfCapiAtomService($http, $q, config, wfCapiContentService) {
 
     function emptyCapiAtomObject() {
         return {
@@ -46,6 +46,24 @@ function wfCapiAtomService($http, $q) {
         });
     }
 
+    function getAtomUsages(id, atomType) {
+        return getCapiAtomUsages(id, atomType).then(res => {
+            const usagePaths = res.data.response.results;
+            // the atom usage endpoint in capi only returns article paths,
+            // lookup the articles in capi to get their fields
+            return Promise.all(usagePaths.map(wfCapiContentService.getCapiContent)).then(capiResponse => {
+                const usages = capiResponse.reduce((all, item) => {
+                    let content = item.data.response.content;
+                    content['composerUrl'] = config.composerViewContent + '/' + content.id.substr(content.id.lastIndexOf('/') + 1);
+                    content['viewerUrl'] = config.viewerUrl + '/' + content.id;
+                    all.push(content);
+                    return all;
+                }, []);
+                return usages;
+            });
+        });
+    }
+
     function parseCapiAtomData(response, atomType) {
 
         const allAtomTypes = [
@@ -61,19 +79,14 @@ function wfCapiAtomService($http, $q) {
             const atomId = _.get(response.data.response[atomType]);
             if(atom) {
                 const capiUrl = getUrl(atomId, atomType);
-                const atomWithUrl = Object.assign({}, atom, {capiUrl: capiUrl});
-                return atomWithUrl;
+                return Object.assign({}, atom, {capiUrl: capiUrl});
             }
         }
         return emptyCapiAtomObject();
     }
 
-    function parseCapiUsages(response) {
-
-    }
-
     this.getCapiAtom = getCapiAtom;
-    this.getCapiAtomUsages = getCapiAtomUsages;
+    this.getAtomUsages = getAtomUsages;
     this.parseCapiAtomData = parseCapiAtomData;
     this.emptyCapiAtomObject = emptyCapiAtomObject;
     

--- a/public/lib/capi-atom-service.js
+++ b/public/lib/capi-atom-service.js
@@ -37,6 +37,15 @@ function wfCapiAtomService($http, $q) {
         });
     }
 
+    function getCapiAtomUsages(id, atomType) {
+        return $http({
+            method: 'GET',
+            url: getUrl(id, atomType) + '/usage',
+            withCredentials: true,
+            timeout: 1000
+        });
+    }
+
     function parseCapiAtomData(response, atomType) {
 
         const allAtomTypes = [
@@ -59,7 +68,12 @@ function wfCapiAtomService($http, $q) {
         return emptyCapiAtomObject();
     }
 
+    function parseCapiUsages(response) {
+
+    }
+
     this.getCapiAtom = getCapiAtom;
+    this.getCapiAtomUsages = getCapiAtomUsages;
     this.parseCapiAtomData = parseCapiAtomData;
     this.emptyCapiAtomObject = emptyCapiAtomObject;
     

--- a/public/lib/capi-content-service.js
+++ b/public/lib/capi-content-service.js
@@ -13,14 +13,14 @@ function wfCapiContentService($http, $q) {
             const h = parseInt(asset.typeData.height);
             return h && w ? h * w : null;
         } else return null;
-    };
+    }
     
     
     function getSmallestAsset(assets) {
         return assets.reduceRight(function(l,r) {
             return getSize(l) < getSize(r) ? l : r;
         });
-    };
+    }
     
     function getMainMedia(elements) {
         const mainElements = elements.filter((e) => e.relation === "main");
@@ -36,12 +36,12 @@ function wfCapiContentService($http, $q) {
             }
         }
         return null;
-    };
+    }
     
     function getTagTitles(tags) {
         return tags.map((t) => t.webTitle);
-    };
-    
+    }
+
     function emptyCapiContentObject() {
         return {
             headline: "unknown",
@@ -105,13 +105,8 @@ function wfCapiContentService($http, $q) {
         });
     }
 
-
-    
-    
     this.getCapiContent = getCapiContent;
     this.parseCapiContentData = parseCapiContentData;
     this.emptyCapiContentObject = emptyCapiContentObject;
-    
-    
 }
 


### PR DESCRIPTION
Adds the CAPI calls, no styling yet.

![screen shot 2017-06-08 at 17 20 25](https://user-images.githubusercontent.com/5732563/26939291-d49eb128-4c6e-11e7-9562-5e8b5d7bcf69.jpg)

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)