### PR TITLE
Make status field mandatory

### DIFF
--- a/app/lib/Response.scala
+++ b/app/lib/Response.scala
@@ -1,18 +1,16 @@
 package lib
 
+import config.Config
 import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc.{Result, Results}
-
-import scala.concurrent.{ExecutionContext, Future}
-import config.Config
 
 case class ApiError(message: String, friendlyMessage: String, statusCode: Int, statusString: String, data: Option[JsObject] = None)
 
 case class ApiSuccess[T](data: T, status: String = "Ok", statusCode: Int = 200, headers: List[(String,String)]= Nil)
 
 case object ApiError {
-  implicit val apiErrorFormat = Json.format[ApiError]
+  implicit val apiErrorFormat: Format[ApiError] = Json.format[ApiError]
 }
 
 object ApiErrors {
@@ -21,11 +19,11 @@ object ApiErrors {
   lazy val invalidContentSend        = ApiError("InvalidContentType", "could not read json from the request", 400, "badrequest")
   lazy val conflict                  = ApiError("WorkflowContentExists", s"This item is already tracked in Workflow", 409, "conflict")
 
-  def jsonParseError(errMsg: String) = ApiError("JsonParseError", s"failed to parse the json. Error(s): ${errMsg}", 400, "badrequest")
-  def updateError[A](id: A)          = ApiError("UpdateError", s"Item with ID, ${id} does not exist", 404, "notfound")
-  def databaseError(exc: String)     = ApiError("DatabaseError", s"${exc}", 500, "internalservererror")
+  def jsonParseError(errMsg: String, json: String) = ApiError("JsonParseError", s"failed to parse the json. Error(s): $errMsg. Json: $json", 400, "badrequest")
+  def updateError[A](id: A)          = ApiError("UpdateError", s"Item with ID, $id does not exist", 404, "notfound")
+  def databaseError(exc: String)     = ApiError("DatabaseError", s"$exc", 500, "internalservererror")
 
-  def composerItemLinked(id: Long, composerId: String) = {
+  def composerItemLinked(id: Long, composerId: String): ApiError = {
     ApiError("ComposerItemIsLinked", s"This stub is already linked to a composer article", 409, "conflict",
       Some(
         Json.obj(

--- a/app/lib/Response.scala
+++ b/app/lib/Response.scala
@@ -19,7 +19,7 @@ object ApiErrors {
   lazy val invalidContentSend        = ApiError("InvalidContentType", "could not read json from the request", 400, "badrequest")
   lazy val conflict                  = ApiError("WorkflowContentExists", s"This item is already tracked in Workflow", 409, "conflict")
 
-  def jsonParseError(errMsg: String, json: String) = ApiError("JsonParseError", s"failed to parse the json. Error(s): $errMsg. Json: $json", 400, "badrequest")
+  def jsonParseError(errMsg: String) = ApiError("JsonParseError", s"failed to parse the json. Error(s): $errMsg", 400, "badrequest")
   def updateError[A](id: A)          = ApiError("UpdateError", s"Item with ID, $id does not exist", 404, "notfound")
   def databaseError(exc: String)     = ApiError("DatabaseError", s"$exc", 500, "internalservererror")
 

--- a/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala
@@ -42,7 +42,7 @@ object ApiUtils {
   // this function is needed to convert the json into a format that datastore understands.
   def flatStubJsonToStubJson(jsValue: JsValue): ApiResponseFt[JsValue] = {
     jsValue.validate[Stub](flatJsonReads).fold(e => {
-      ApiResponseFt.Left(ApiError("Json conversion failed", s"Failed to convert flat stub into stub with externalData level for datastore with error: $e. Json: $jsValue", 400, "badrequest"))
+      ApiResponseFt.Left(ApiError("Json conversion failed", s"Failed to convert flat stub into stub with externalData level for datastore with error: $e", 400, "badrequest"))
     }, s => ApiResponseFt.Right(Json.toJson(s)(stubWrites)))
   }
 
@@ -69,7 +69,7 @@ object ApiUtils {
       case error@JsError(_) =>
         val errMsg = errorMsgs(error)
         Logger.error(s"JsonParseError failed to parse the json. Error(s): $errMsg 400 badrequest. Json: $jsValue")
-        ApiResponseFt.Left(ApiError("JsonParseError", s"failed to parse the json. Error(s): $errMsg. Json: $jsValue", 400, "badrequest"))
+        ApiResponseFt.Left(ApiError("JsonParseError", s"failed to parse the json. Error(s): $errMsg", 400, "badrequest"))
     }
   }
 

--- a/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala
@@ -42,7 +42,7 @@ object ApiUtils {
   // this function is needed to convert the json into a format that datastore understands.
   def flatStubJsonToStubJson(jsValue: JsValue): ApiResponseFt[JsValue] = {
     jsValue.validate[Stub](flatJsonReads).fold(e => {
-      ApiResponseFt.Left(ApiError("Json conversion failed", s"Failed to convert flat stub into stub with externalData level for datastore with error: $e", 400, "badrequest"))
+      ApiResponseFt.Left(ApiError("Json conversion failed", s"Failed to convert flat stub into stub with externalData level for datastore with error: $e. Json: $jsValue", 400, "badrequest"))
     }, s => ApiResponseFt.Right(Json.toJson(s)(stubWrites)))
   }
 

--- a/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala
@@ -68,8 +68,8 @@ object ApiUtils {
       case JsSuccess(a, _) => ApiResponseFt.Right(a)
       case error@JsError(_) =>
         val errMsg = errorMsgs(error)
-        Logger.error(s"JsonParseError failed to parse the json. Error(s): $errMsg 400 badrequest")
-        ApiResponseFt.Left(ApiError("JsonParseError", s"failed to parse the json. Error(s): $errMsg", 400, "badrequest"))
+        Logger.error(s"JsonParseError failed to parse the json. Error(s): $errMsg 400 badrequest. Json: $jsValue")
+        ApiResponseFt.Left(ApiError("JsonParseError", s"failed to parse the json. Error(s): $errMsg. Json: $jsValue", 400, "badrequest"))
     }
   }
 

--- a/common-lib/src/main/scala/com/gu/workflow/lib/StatusDatabase.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/StatusDatabase.scala
@@ -10,13 +10,13 @@ object StatusDatabase {
 
   val store: Agent[List[Status]] = Agent(List(
     Status.Stub,
-    Status("Writers"),
-    Status("Desk"),
-    Status("Production Editor"),
-    Status("Subs"),
-    Status("Revise"),
-    Status("Final"),
-    Status("Hold")
+    Status.Writers,
+    Status.Desk,
+    Status.ProductionEditor,
+    Status.Subs,
+    Status.Revise,
+    Status.Final,
+    Status.Hold
   ))
 
   def statuses: Future[List[Status]] = store.future()

--- a/common-lib/src/main/scala/models/Status.scala
+++ b/common-lib/src/main/scala/models/Status.scala
@@ -19,11 +19,12 @@ object Status {
   }
   def Stub = Status("Stub")
   def Writers = Status("Writers")
-  def Subs = Status("Subs")
+  def Desk = Status("Desk")
   def ProductionEditor = Status("Production Editor")
+  def Subs = Status("Subs")
   def Revise = Status("Revise")
   def Final = Status("Final")
   def Hold = Status("Hold")
 
-  def All: List[Status] = Writers :: Subs :: ProductionEditor :: Revise :: Final :: Hold :: Nil
+  def All = Stub :: Writers :: Desk :: ProductionEditor :: Subs :: Revise :: Final :: Hold :: Nil
 }

--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -27,7 +27,7 @@ case class Stub(id: Option[Long] = None,
 
 case class ExternalData(path: Option[String] = None,
   lastModified: Option[DateTime] = None,
-  status: Option[Status] = None,
+  status: Status = Status.Writers,
   published: Option[Boolean] = None,
   timePublished: Option[DateTime] = None,
   revision: Option[Long] = None,
@@ -54,7 +54,7 @@ object ExternalData {
   implicit val externalDataJsonReads: Reads[ExternalData] = (
     (__ \ "path").readNullable[String] and
       (__ \ "lastModified").readNullable[DateTime] and
-      (__ \ "status").readNullable[String].map(s => s.map(Status(_))) and
+      (__ \ "status").read[String].map(Status(_)) and
       (__ \ "published").readNullable[Boolean] and
       (__ \ "timePublished").readNullable[DateTime] and
       (__ \ "revision").readNullable[Long] and
@@ -128,7 +128,7 @@ object Stub {
     // because of this bug, the fix is supposed to be released soon https://github.com/playframework/play-json/issues/11
        ((__ \ "path").readNullable[String] and
        (__ \ "lastModified").readNullable[DateTime] and
-       (__ \ "status").readNullable[String].map(s => s.map(Status(_))) and
+       (__ \ "status").read[String].map(Status(_)) and
        (__ \ "published").readNullable[Boolean] and
        (__ \ "timePublished").readNullable[DateTime] and
        (__ \ "revision").readNullable[Long] and

--- a/common-lib/src/main/scala/models/api/ContentResponse.scala
+++ b/common-lib/src/main/scala/models/api/ContentResponse.scala
@@ -8,18 +8,18 @@ case class ContentResponse(content: Map[String, List[Stub]], stubs: List[Stub], 
 
 object ContentResponse {
 
-  private def isStub(s: Stub): Boolean = s.externalData.get.status.isEmpty || s.externalData.get.status.contains(Status.Stub)
+  private def isStub(s: Stub): Boolean = s.externalData.get.status == Status.Stub
 
 
   def statusCountsMap(stubs: List[Stub]): Map[String, Int] = {
-    val statusToCount: Map[String, Int] = stubs.groupBy(stub => stub.externalData.get.status.orElse(None)).collect({case (Some(s), sList) => (s.name, sList.length)})
+    val statusToCount: Map[String, Int] = stubs.groupBy(stub => stub.externalData.get.status).collect({case (s, sList) => (s.name, sList.length)})
     val stubCount: Int = stubs.count(isStub)
     val totalCount: Int = stubs.length
     statusToCount ++ Map("Stub" -> stubCount) ++ Map("total" -> totalCount)
   }
 
   def contentGroupedByStatus(stubs: List[Stub]): Map[String, List[Stub]] = {
-    stubs.groupBy(stub => stub.externalData.get.status.orElse(None)).collect({case (Some(status), stubList) => (status.name, stubList)})
+    stubs.groupBy(stub => stub.externalData.get.status).collect({case (s, stubList) => (s.name, stubList)})
   }
 
   def fromStubItems(stubs: List[Stub]): ContentResponse =
@@ -33,7 +33,7 @@ object ContentResponse {
       }.toSeq:_*)
   }
 
-  implicit val flatStubWrites = Stub.flatStubWrites
-  implicit val contentResponseFormat = Json.writes[ContentResponse]
-  implicit val contentResponseReads = Json.reads[ContentResponse]
+  implicit val flatStubWrites: Writes[Stub] = Stub.flatStubWrites
+  implicit val contentResponseFormat: Writes[ContentResponse] = Json.writes[ContentResponse]
+  implicit val contentResponseReads: Reads[ContentResponse] = Json.reads[ContentResponse]
 }

--- a/common-lib/src/main/scala/models/api/ContentResponse.scala
+++ b/common-lib/src/main/scala/models/api/ContentResponse.scala
@@ -18,9 +18,8 @@ object ContentResponse {
     statusToCount ++ Map("Stub" -> stubCount) ++ Map("total" -> totalCount)
   }
 
-  def contentGroupedByStatus(stubs: List[Stub]): Map[String, List[Stub]] = {
-    stubs.groupBy(stub => stub.externalData.get.status).collect({case (s, stubList) => (s.name, stubList)})
-  }
+  def contentGroupedByStatus(stubs: List[Stub]): Map[String, List[Stub]] =
+    stubs.filter(!isStub(_)).groupBy(stub => stub.externalData.get.status).collect({case (s, stubList) => (s.name, stubList)})
 
   def fromStubItems(stubs: List[Stub]): ContentResponse =
     ContentResponse(contentGroupedByStatus(stubs), stubs.filter(isStub), statusCountsMap(stubs))

--- a/common-lib/src/test/scala/lib/TestData.scala
+++ b/common-lib/src/test/scala/lib/TestData.scala
@@ -23,7 +23,6 @@ object TestData {
   val users: List[User] = List(User("testcake@testcake.com", "test", "cake"), User("google@google.com", "goo", "gle"), User("facebook@facebook.com", "face", "book"))
   val commissioningDesks: List[String] = List("Hogwarts,The Burrow", "Privet Drive,London", "Hogsmeade")
   val path: List[String] = List("path_1", "path_2", "path_3")
-  val status: List[Status] = List(Status("status_1"), Status("status_2"), Status("status_3"))
 
   //select a date anywhere between now and the last 50 days
   def chooseDate: DateTime = DateTime.now().minusHours(random.nextInt(24*50))
@@ -42,7 +41,7 @@ object TestData {
 
   def chooseLong: Long = random.nextLong
 
-  def randomStub = generateRandomStub()
+  def randomStub: Stub = generateRandomStub()
 
   //todo - genericise these methods over types
   def generateTestData(size: Int = 50,
@@ -62,7 +61,7 @@ object TestData {
       lastModified = newLastModified,
       trashed = newTrashed,
       externalData = Some(rs.externalData.fold(ExternalData())(ed => ed.copy(
-        status = Some(Status(newStatus)),
+        status = Status(newStatus),
         lastModified = Some(newLastModified),
         scheduledLaunchDate = lsd,
         embargoedIndefinitely= Some(newEmbargoedIndefinitely)))
@@ -77,7 +76,7 @@ object TestData {
       externalData = Some(s.externalData.fold(ExternalData())(_.copy(
         published = Some(newPublished),
         lastModified = Some(newLastModified),
-        status = Some(Status(newStatus))))))
+        status = Status(newStatus)))))
   }
 
   def generateRandomSizeCollaborators(): List[User] = {
@@ -122,7 +121,7 @@ object TestData {
       commissioningDesks = opt(chooseItem(commissioningDesks)),
       externalData = Some(ExternalData(
         path = opt(chooseItem(path)),
-        status = opt(chooseItem(status)),
+        status = chooseItem(statuses),
         published = pub,
         takenDown = opt(td),
         revision = Some(10)

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -143,9 +143,9 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     $scope.ok = function (addToComposer, addToAtomEditor) {
         const stub = $scope.stub;
         function createItemPromise() {
+            stub['status'] = stub.status === undefined ? 'Stub' : stub.status;
             if ($scope.contentName === 'Atom') {
                 stub['contentType'] = $scope.stub.contentType.toLowerCase();
-                stub['status'] = stub.status === undefined ? 'Stub' : stub.status;
                 if (addToAtomEditor) {
                     return wfContentService.createInMediaAtomMaker(stub);
                 } else if (stub.id) {

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -93,7 +93,6 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
 
                         if (stub.id) {
                             return this.updateStub(stub);
-
                         } else {
                             return this.createStub(stub);
                         }
@@ -146,7 +145,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                  */
                 updateField(contentItem, field, data) {
 
-                    if (field === 'status' && !contentItem.composerId) {
+                    if (field === 'status' && contentItem.status === 'Stub') {
                         return this.createInComposer(contentItem, data)
                     }
 

--- a/test/com/gu/workflow/models/Stub.scala
+++ b/test/com/gu/workflow/models/Stub.scala
@@ -1,10 +1,10 @@
 package com.gu.workflow.models
 
+import com.gu.workflow.test.lib.TestData._
 import lib.ResourcesHelper
 import models._
-import org.scalatest.{Matchers, FreeSpec}
-import play.api.libs.json.{Json, JsSuccess}
-import com.gu.workflow.test.lib.TestData._
+import org.scalatest.{FreeSpec, Matchers}
+import play.api.libs.json.Json
 
 class ContentItemTest extends FreeSpec with Matchers with ResourcesHelper{
   "ContentReads" - {
@@ -38,7 +38,7 @@ class ContentItemTest extends FreeSpec with Matchers with ResourcesHelper{
         stub.section should equal ("100 Voices (Project)")
         stub.contentType should equal ("article")
         stub.composerId should equal (Some("56cc74bfa7c8a951d739c3f4"))
-        stub.externalData.flatMap(_.status) should equal (Some(Status("Writers")))
+        stub.externalData.map(_.status) should equal (Some(Status.Writers))
         stub.externalData.flatMap(_.activeInInCopy) should equal (Some(false))
         stub.externalData.flatMap(_.takenDown) should equal (Some(false))
         stub.externalData.flatMap(_.published) should equal (Some(false))
@@ -68,7 +68,7 @@ class ContentItemTest extends FreeSpec with Matchers with ResourcesHelper{
 
         stub.composerId should equal (Some("56cc7694a7c8a951d739c3f9"))
         stub.contentType should equal ("article")
-        stub.externalData.flatMap(_.status) should equal (Some(Status("Desk")))
+        stub.externalData.map(_.status) should equal (Some(Status.Desk))
         stub.externalData.flatMap(_.activeInInCopy) should equal (Some(true))
         stub.externalData.flatMap(_.takenDown) should equal (Some(false))
         stub.externalData.flatMap(_.optimisedForWebChanged) should equal (Some(false))

--- a/test/models/ContentResponseTest.scala
+++ b/test/models/ContentResponseTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FreeSpec, Matchers}
 
 class ContentResponseTest extends FreeSpec with Matchers {
 
-  def withStatus(st: String): Stub => Stub = c => c.copy(externalData = c.externalData.map(_.copy(status = Some(Status(st)))))
+  def withStatus(st: String): Stub => Stub = c => c.copy(externalData = c.externalData.map(_.copy(status = Status(st))))
 
   "statusCountsMap" -    {
     "should give a map of status to count" in {
@@ -67,7 +67,6 @@ class ContentResponseTest extends FreeSpec with Matchers {
 
       cr.content should equal (contentGroupedByStatus)
       cr.stubs should equal (stubOnly)
-//      ContentResponse.fromStubItems(testData) should equal(ContentResponse(contentGroupedByStatus, stubOnly, statusCountsMap))
     }
   }
 

--- a/test/models/ContentResponseTest.scala
+++ b/test/models/ContentResponseTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FreeSpec, Matchers}
 
 class ContentResponseTest extends FreeSpec with Matchers {
 
-  def withStatus(st: String): Stub => Stub = c => c.copy(externalData = c.externalData.map(_.copy(status = Status(st))))
+  def withStatus(st: String): Stub => Stub = s => s.copy(externalData = s.externalData.map(_.copy(status = Status(st))))
 
   "statusCountsMap" -    {
     "should give a map of status to count" in {
@@ -32,7 +32,7 @@ class ContentResponseTest extends FreeSpec with Matchers {
 
   "contentGroupedByStatus" - {
     "should give map of status to dashboard row" in {
-      val stubOnly = generateTestData(2)
+      val stubOnly = generateTestData(2).map(withStatus("Stub"))
       val writers = generateTestData(3).map(withStatus("Writers"))
       val subs = generateTestData(1).map(withStatus("Subs"))
       val hold = generateTestData(2).map(withStatus("Hold"))


### PR DESCRIPTION
`workflow` work: https://github.com/guardian/workflow/pull/1010

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)