### PR TITLE
Fix CAPI parsing error

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -186,7 +186,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
                 } else {   
                     wfCapiContentService.getCapiContent(contentItem.path)
                         .then((resp) => {
-                        const parsed = wfCapiContentService.parseCapiContentData(resp, contentItem.item.contentType);
+                        const parsed = wfCapiContentService.parseCapiContentData(resp);
                         contentListDrawerController.toggleContent(contentItem, contentListItemElement, parsed);
                     }, (err) => {
                         contentListDrawerController.toggleContent(contentItem, contentListItemElement, wfCapiContentService.emptyCapiContentObject());

--- a/public/lib/capi-content-service.js
+++ b/public/lib/capi-content-service.js
@@ -60,15 +60,14 @@ function wfCapiContentService($http, $q) {
     }
     
     function parseCapiContentData(response) {
-        
-        if (_.get(response.data, 'content')) {
+        if (_.get(response.data, 'response.content')) {
             const resp = response.data.response;
             if (resp) {
                 const content = resp.content;
                 if (content) {
-                    const fields = _.get(response.data.content, 'fields', {});
-                    const elements = _.get(response.data.content, 'elements');
-                    const tags = _.get(response.data.content, 'tags');
+                    const fields = _.get(content, 'fields', {});
+                    const elements = _.get(content, 'elements');
+                    const tags = _.get(content, 'tags');
                     
                     const mainMedia = elements ? getMainMedia(elements): null;
                     


### PR DESCRIPTION
It's hard to tell why this started failing without being changed in a while. The `_.get(response.data, 'content')` was returning `undefined` resulting in the function returning `emptyCapiContentObject` every time.

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)