### PR TITLE
fix flex sizing and classes on images for sizing

### DIFF
--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -55,7 +55,7 @@
         }
 
         &--wide {
-            flex: 2 0 0;
+            flex: 2.5 0 0;
         }
     }
 
@@ -79,6 +79,7 @@
         list-style: none;
         margin: 0;
         padding: 12px 0 0 12px;
+        flex: 1 0 0;
     }
     
     &__item {
@@ -121,14 +122,16 @@
         max-height: 80px;
         overflow: hidden;
 
-        img {
-            width: 100%;
-        }
-
         @media screen and (max-width: 1400px) {
             max-width: 100px;
         }
     }
+
+
+    &__image {
+        width: 100%;
+    }
+
     &__icon {
         display: inline-block;
         position: relative;

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -53,8 +53,8 @@
                         <li cng-class="{'drawer__section-mainmedia--nopreview': contentItem.mainMediaNoPreview}">
                             <span class="drawer__item-title">Main media</span>
 
-                            <div ng-if="contentItem.mainMediaType == 'image'" class="drawer__section-image-container">
-                                <img ng-src="{{ capiData.mainMediaUrl}}" alt=""/>
+                            <div ng-if="contentItem.mainMediaType == 'image'" class="drawer__image-container">
+                                <img ng-src="{{ capiData.mainMediaUrl}}" class="drawer__image" alt=""/>
                             </div>
                             <div ng-if="contentItem.mainMediaNoPreview" class="drawer__section-image-container">
                                 {{contentItem.mainMediaType}}
@@ -81,8 +81,8 @@
                     <ul class="drawer__column">
                         <li class="drawer__item">
                             <span class="drawer__item-title">Trail picture</span>
-                            <div ng-if="capiData.trailImageUrl" class="drawer__section-image-container">
-                                <img ng-src="{{ capiData.trailImageUrl }}" alt=""/>
+                            <div ng-if="capiData.trailImageUrl" class="drawer__image-container">
+                                <img ng-src="{{ capiData.trailImageUrl }}" class="drawer__image" alt=""/>
                             </div>
                             <div ng-if="!capiData.trailImageUrl" class="drawer__item-content drawer__item-content--empty">
                                 None


### PR DESCRIPTION
## What's up?
The sizing is all waffy on workflow drawers because I got trigger happy with deletions

## What did you do?
Added some flex values and made the images use the class I intended for them all along

### Before
![picture 208](https://user-images.githubusercontent.com/2104095/27085327-d98f9450-5046-11e7-9d5a-5ecb158de2a3.png)

### After
![picture 209](https://user-images.githubusercontent.com/2104095/27085338-e05aded4-5046-11e7-894c-96c16e98a9a7.png)




#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)