### PR TITLE
fix spacing on content list links

### DIFF
--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -158,6 +158,7 @@
         &--legal,
         &--status,
         &--composer,
+        &--media,
         &--preview,
         &--live,
         &--ophan,

--- a/public/components/content-list-item/templates/links.html
+++ b/public/components/content-list-item/templates/links.html
@@ -6,37 +6,38 @@
                     <i class="content-list-item__icon--composer" wf-icon="composer" wf-icon-active="false"></i>
                 </span>
 </td>
-<td class="content-list-item__field--preview"  ng-if="contentItem.contentType !== 'media'">
-    <a href="{{ contentItem.links.preview }}" title="Preview (opens in new window)" target="_blank" ng-if="contentItem.links.preview" ng-click="$event.stopPropagation()">
+
+<td class="content-list-item__field--preview">
+    <a href="{{ contentItem.links.preview }}" title="Preview (opens in new window)" target="_blank" ng-if="contentItem.links.preview && contentItem.contentType !== 'media'" ng-click="$event.stopPropagation()">
         <i class="content-list-item__icon--preview" wf-icon="preview"></i>
     </a>
-                <span ng-if="!contentItem.links.preview" title="Preview (unavailable)" class="content-list-item__icon--inactive">
-                    <i class="content-list-item__icon--preview" wf-icon="preview" wf-icon-active="false"></i>
-                </span>
+    <span ng-if="!contentItem.links.preview && contentItem.contentType !== 'media'" title="Preview (unavailable)" class="content-list-item__icon--inactive">
+        <i class="content-list-item__icon--preview" wf-icon="preview" wf-icon-active="false"></i>
+    </span>
 </td>
-<td class="content-list-item__field--live"  ng-if="contentItem.contentType !== 'media'">
-    <a href="{{ contentItem.links.live }}" title="View on Live site (opens in new window)" target="_blank" ng-if="contentItem.links.live" ng-click="$event.stopPropagation()">
+<td class="content-list-item__field--live">
+    <a href="{{ contentItem.links.live }}" title="View on Live site (opens in new window)" target="_blank" ng-if="contentItem.links.live && contentItem.contentType !== 'media'" ng-click="$event.stopPropagation()">
         <i class="content-list-item__icon--live" wf-icon="live-site"></i>
     </a>
-                <span ng-if="!contentItem.links.live" title="View on Live site (unavailable)" class="content-list-item__icon--inactive">
-                    <i class="content-list-item__icon--live" wf-icon="live-site" wf-icon-active="false"></i>
-                </span>
+    <span ng-if="!contentItem.links.live && contentItem.contentType !== 'media'" title="View on Live site (unavailable)" class="content-list-item__icon--inactive">
+        <i class="content-list-item__icon--live" wf-icon="live-site" wf-icon-active="false"></i>
+    </span>
 </td>
 
-<td class="content-list-item__field--media"  ng-if="contentItem.contentType === 'media'">
+<td class="content-list-item__field--media" ng-if="contentItem.contentType === 'media'">
     <a href="{{ contentItem.links.editor }}" title="View in editor (opens in new window)" target="_blank" ng-if="contentItem.links.editor" ng-click="$event.stopPropagation()">
         <i class="content-list-item__icon--media" wf-icon="media"></i>
     </a>
-                <span ng-if="!contentItem.links.editor" title="View in editor (unavailable)" class="content-list-item__icon--inactive">
-                    <i class="content-list-item__icon--media" wf-icon="media" wf-icon-active="false"></i>
-                </span>
+    <span ng-if="!contentItem.links.editor && contentItem.contentType === 'media'" title="View in editor (unavailable)" class="content-list-item__icon--inactive">
+        <i class="content-list-item__icon--media" wf-icon="media" wf-icon-active="false"></i>
+    </span>
 </td>
 
 <td class="content-list-item__field--ophan">
     <a href="{{ contentItem.links.ophan }}" title="View in Ophan (opens in new window)" target="_blank" ng-if="contentItem.links.ophan" ng-click="$event.stopPropagation()">
         <i class="content-list-item__icon--ophan" wf-icon="ophan"></i>
     </a>
-                <span ng-if="!contentItem.links.ophan" title="View in Ophan (unavailable)" class="content-list-item__icon--inactive">
-                    <i class="content-list-item__icon--ophan" wf-icon="ophan" wf-icon-active="false"></i>
-                </span>
+    <span ng-if="!contentItem.links.ophan" title="View in Ophan (unavailable)" class="content-list-item__icon--inactive">
+        <i class="content-list-item__icon--ophan" wf-icon="ophan" wf-icon-active="false"></i>
+    </span>
 </td>


### PR DESCRIPTION
## Before
![picture 223](https://user-images.githubusercontent.com/2104095/27544286-98ab8e92-5a84-11e7-8ab8-5e9dcf5e044b.png)

## After
![picture 222](https://user-images.githubusercontent.com/2104095/27544302-a0d147a6-5a84-11e7-948f-66f293ca4ffa.png)


## Alignment
I know it's aligned to the right, but this maintains the correct spacing on the drawer without doubling up all of the fields


#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)