### PR TITLE
fix check for atom editor

### DIFF
--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -62,7 +62,7 @@ function wfContentItemParser(config, statusLabels, sections) {
                 this.live = LIVE_PATH + item.path;
                 this.ophan = OPHAN_PATH + item.path;
             }
-            if (item.contentType === 'media') {
+            if (item.contentType === 'media' && item.editorId) {
                 this.editor = `${config.mediaAtomMakerViewAtom}${item.editorId}`
             }
         }


### PR DESCRIPTION
<!--Your pull request-->

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)