### PR TITLE
Fixes title links for both atoms and composer articles

### DIFF
--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -66,7 +66,7 @@ function wfContentItemParser(config, statusLabels, sections) {
                 this.live = LIVE_PATH + item.path;
                 this.ophan = OPHAN_PATH + item.path;
             }
-            if (item.contentType === 'media') {
+            if (item.contentType === 'media' && item.editorId) {
                 this.editor = `${config.mediaAtomMakerViewAtom}${item.editorId}`
             }
         }

--- a/public/components/content-list-item/templates/title.html
+++ b/public/components/content-list-item/templates/title.html
@@ -1,6 +1,9 @@
 <th id="testing-content-list-item-title" class="content-list-item__field--{{ contentList.showHeadline ? 'headline' : 'working-title' }}" scope="row" title="Working title: {{ contentItem.workingTitle }}{{ contentItem.headline ? '&#10;&#10;Headline: ' + contentItem.headline : '' }}">
     <abbr class="content-list-item__headline-toggle" title="{{ contentList.showHeadline && contentItem.headline ? 'Headline' : 'Working title'}}. (Click to toggle Headlines)" ng-click="contentList.showHeadline = !contentList.showHeadline; $event.stopPropagation()">{{
         contentList.showHeadline && contentItem.headline ? 'HL' : 'WT' }}</abbr>
-    <a id="testing-content-list-item-title-anchor-text" ng-href="{{ contentItem.links.editor }}" ng-click="contentList.editItem(contentItem); $event.stopPropagation()" target="_blank">{{
+    <a ng-if="contentItem.contentType !== 'media'" id="testing-content-list-item-title-anchor-text" ng-href="{{ contentItem.links.composer }}" ng-click="contentList.editItem(contentItem); $event.stopPropagation()" target="_blank">{{
+        contentList.showHeadline && contentItem.headline ? contentItem.headline : contentItem.workingTitle }}</a>
+
+    <a ng-if="contentItem.contentType === 'media'" id="testing-content-list-item-title-anchor-text" ng-href="{{ contentItem.links.editor }}" ng-click="contentList.editItem(contentItem); $event.stopPropagation()" target="_blank">{{
         contentList.showHeadline && contentItem.headline ? contentItem.headline : contentItem.workingTitle }}</a>
 </th>


### PR DESCRIPTION
as per https://trello.com/c/SzASKxq9/136-you-cant-click-through-to-a-composer-article-in-workflow-via-the-title-only-through-the-composer-icon-not-sure-if-this-is-expect

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)