### PR TITLE
make editorial support API corsable

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -283,8 +283,10 @@ object Api extends Controller with PanDomainAuthActions {
     }
   }
 
-  def editorialSupportTeams = APIAuthAction {
-    Ok(Json.toJson(EditorialSupportTeamsController.getTeams()))
+  def editorialSupportTeams = CORSable(composerUrl) {
+    APIAuthAction {
+      Ok(Json.toJson(EditorialSupportTeamsController.getTeams()))
+    }
   }
 
   def addEditorialSupportStaff(name: String, team: String) = APIAuthAction {


### PR DESCRIPTION
/api/editorialSupportTeams wasn't allowing CORS from composer. now it does