### PR TITLE
Use defaultHtml for video preview

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -247,15 +247,10 @@
 
                     </ul>
 
-                    <ul class="drawer__column drawer__column--wide" ng-if="capiData.youtubeUrl">
+                    <ul class="drawer__column drawer__column--wide" ng-if="capiData.defaultHtml">
                         <li class="drawer__item">
                             <p class="drawer__item-title">Video preview</p>
-                            <iframe
-                                className="drawer__item"
-                                ng-src="{{capiData.youtubeUrl | wfTrustedUrl}}"
-                                allowFullScreen
-                                frameBorder="0"
-                                />
+                            <div ng-bind-html="capiData.defaultHtml | wfTrustedHtml" />
                         </li>
                     </ul>
                     

--- a/public/lib/capi-atom-service.js
+++ b/public/lib/capi-atom-service.js
@@ -75,6 +75,8 @@ function wfCapiAtomService($http, $q, config, wfCapiContentService, wfAtomServic
 
     function parseCapiAtomData(response, atomType) {
         const atom = _.get(response.data.response[atomType].data, atomType);
+        atom.defaultHtml = response.data.response[atomType].defaultHtml;
+
         const atomId = _.get(response.data.response[atomType], 'id');
         if(atom) {
             return parseAtom(atom, atomType, atomId);

--- a/public/lib/filters-service.js
+++ b/public/lib/filters-service.js
@@ -3,11 +3,11 @@ import angular from 'angular';
 import _ from 'lodash';
 
 import './date-service';
-import './trusted-url';
+import './trusted-html';
 
-angular.module('wfFiltersService', ['wfDateService', 'wfTrustedUrl'])
-    .factory('wfFiltersService', ['$rootScope', '$location', '$state', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfPreferencesService', 'wfTrustedUrlFilter',
-        function($rootScope, $location, $state, wfDateParser, wfFormatDateTimeFilter, wfPreferencesService, wfTrustedUrlFilter) {
+angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
+    .factory('wfFiltersService', ['$rootScope', '$location', '$state', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfPreferencesService', 'wfTrustedHtmlFilter',
+        function($rootScope, $location, $state, wfDateParser, wfFormatDateTimeFilter, wfPreferencesService, wfTrustedHtmlFilter) {
 
         class FiltersService
         {

--- a/public/lib/trusted-html.js
+++ b/public/lib/trusted-html.js
@@ -1,0 +1,8 @@
+import angular from 'angular';
+
+angular.module('wfTrustedHtml', [])
+  .filter('wfTrustedHtml', ['$sce', function ($sce) {
+    return function(url) {
+        return $sce.trustAsHtml(url);
+    };
+}]);

--- a/public/lib/trusted-url.js
+++ b/public/lib/trusted-url.js
@@ -1,8 +1,0 @@
-import angular from 'angular';
-
-angular.module('wfTrustedUrl', [])
-  .filter('wfTrustedUrl', ['$sce', function ($sce) {
-    return function(url) {
-        return $sce.trustAsResourceUrl(url);
-    };
-}]);


### PR DESCRIPTION
Ronseal. We were previously assuming all media atoms were YouTube videos. After this change we'll just render what we're given, automatically supported self-hosted videos.

Depends on https://github.com/guardian/media-atom-maker/pull/505 otherwise the YouTube video is the wrong size

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)