### PR TITLE
fix url in drawers

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -39,7 +39,7 @@
                         <li class="drawer__item">
                             <span class="drawer__item-title">URL</span>
                             <span class="drawer__item-content" ng-if="contentItem.path">
-                                <a href="{{ contentItem.path }}">{{
+                                <a href="{{ contentItem.links.live || contentItem.links.preview || contentItem.links.composer }}">{{
                                 contentItem.path }}</a>
                             </span>
                         </li>


### PR DESCRIPTION
<!--Your pull request-->

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)