### PR TITLE
add default section toggle to management and furniture drawers

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -7,6 +7,8 @@
                 <div class="drawer__header" ng-if="openSection === 'furniture'">
                     <i class="drawer__icon" wf-icon="furniture"></i>
                     Furniture
+
+                    <button type="button" class="btn btn-primary btn-xs pull-right"  ng-disabled="defaultSection === 'furniture'" ng-click="setDefaultOpenSection('furniture')">Set default</button>
                 </div>
 
                 <button type="button" class="drawer__header-toggle" ng-if="openSection !== 'furniture'" ng-click="toggleSection('furniture')">
@@ -272,6 +274,8 @@
                 <div class="drawer__header" ng-if="openSection === 'management'">
                     <i class="drawer__icon" wf-icon="management"></i>
                     Management
+
+                    <button type="button" class="btn btn-primary btn-xs pull-right" ng-disabled="defaultSection === 'management'" ng-click="setDefaultOpenSection('management')">Set default</button>
                 </div>
 
                 <button type="button" class="drawer__header-toggle" ng-if="openSection !== 'management'" ng-click="toggleSection('management')">
@@ -365,6 +369,7 @@
                 <div class="drawer__header" ng-if="openSection === 'usages'">
                     <i class="drawer__icon" wf-icon="usages"></i>
                     Usages
+
                 </div>
 
                 <button type="button"  class="drawer__header-toggle" ng-if="openSection !== 'usages'" ng-click="toggleSection('usages')">

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -1,6 +1,9 @@
 import contentListDrawerTemplate from './content-list-drawer.html';
 import _ from 'lodash';
 
+
+var SETTING_OPEN_SECTION = 'openSection';
+
 /**
  * Directive for handling logic around the contentItemRow details drawer.
  *
@@ -14,7 +17,7 @@ import _ from 'lodash';
  * @param contentService
  * @param prodOfficeService
  */
-export function wfContentListDrawer($rootScope, config, $timeout, $window, contentService, prodOfficeService, featureSwitches, wfGoogleApiService, wfCapiContentService, wfCapiAtomService, wfAtomService, wfContentListDrawerAccordionCtrl) {
+export function wfContentListDrawer($rootScope, config, $timeout, $window, contentService, prodOfficeService, featureSwitches, wfGoogleApiService, wfCapiContentService, wfCapiAtomService, wfAtomService, wfSettingsService) {
 
     var hiddenClass = 'content-list-drawer--hidden';
 
@@ -166,8 +169,8 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             $rootScope.$on('contentItem.select', ($event, contentItem, contentListItemElement) => {
                 $scope.awaitingDeleteConfirmation = false;
                 $scope.selectedItem = contentItem;
-                $scope.openSection = 'furniture';
-
+                $scope.defaultSection = getDefaultOpenSection() || 'furniture';
+                $scope.openSection = $scope.defaultSection || 'furniture';
 
                 if (contentItem.status === 'Stub') {
                     $scope.$emit('stub:edit', contentItem.item);
@@ -287,9 +290,18 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
                 $scope.$emit('contentItem.update', msg);
             }
 
+            function getDefaultOpenSection() {
+                return wfSettingsService.get(SETTING_OPEN_SECTION);
+            }
+
             /* Drawer section toggles */
             $scope.toggleSection = function (section) {
                 $scope.openSection = section;
+            }
+
+            $scope.setDefaultOpenSection = function(section) {
+                wfSettingsService.set(SETTING_OPEN_SECTION, section);
+                $scope.defaultSection = section;
             }
 
             $scope.onBeforeSaveNote = function (note) {

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -12,6 +12,7 @@ import 'lib/column-service';
 import 'lib/capi-content-service';
 import 'lib/capi-atom-service';
 import 'lib/atom-service';
+import 'lib/settings-service';
 
 import 'components/editable-field/editable-field';
 
@@ -22,14 +23,14 @@ import { wfContentListDrawer } from 'components/content-list-drawer/content-list
 import { wfLoader } from 'components/loader/loader';
 
 
-angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOfficeService', 'wfPresenceService', 'wfEditableField', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService'])
+angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOfficeService', 'wfPresenceService', 'wfEditableField', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService', 'wfSettingsService'])
     .service('wfContentItemParser', ['config', 'statusLabels', 'sections', wfContentItemParser])
     .filter('getPriorityString', wfGetPriorityStringFilter)
     .controller('wfContentListController', ['$rootScope', '$scope', '$anchorScroll', 'statuses', 'legalValues', 'priorities', 'sections', 'wfContentService', 'wfContentPollingService', 'wfContentItemParser', 'wfPresenceService', 'wfColumnService', 'wfPreferencesService', 'wfFiltersService', wfContentListController])
     .directive('wfContentListLoader', ['$rootScope', wfLoader])
     .directive('wfContentItemUpdateAction', wfContentItemUpdateActionDirective)
     .directive('wfContentListItem', ['$rootScope', 'statuses', 'legalValues', 'sections', wfContentListItem])
-    .directive('wfContentListDrawer', ['$rootScope', 'config', '$timeout', '$window', 'wfContentService', 'wfProdOfficeService', 'wfFeatureSwitches', 'wfGoogleApiService', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService', wfContentListDrawer])
+    .directive('wfContentListDrawer', ['$rootScope', 'config', '$timeout', '$window', 'wfContentService', 'wfProdOfficeService', 'wfFeatureSwitches', 'wfGoogleApiService', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService', 'wfSettingsService', wfContentListDrawer])
     .directive("bindCompiledHtml", function($compile, $timeout) {
         return {
             scope: {


### PR DESCRIPTION
Allows users to set a default open tab in the new drawer.
Uses localstorage to save the users preference.
![picture 248](https://user-images.githubusercontent.com/2104095/28116456-17b6f93c-6701-11e7-9085-e515ad892745.png)



#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)