### PR TITLE
allow media atom maker in DEV to hit CODE

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -12,11 +12,15 @@ object Config extends AwsInstanceTags {
   }
   Logger.info(s"running in stage: $stage")
 
-  lazy val domain: String = stage match {
+  def appDomain(appStage: String): String = {
+    appStage match {
       case "PROD" => "gutools.co.uk"
       case "DEV" => "local.dev-gutools.co.uk"
-      case x => x.toLowerCase() + ".dev-gutools.co.uk"
+      case x => s"${x.toLowerCase()}.dev-gutools.co.uk"
     }
+  }
+
+  lazy val domain: String = appDomain(stage)
 
   Logger.info(s"Domain is: $domain")
 
@@ -27,6 +31,12 @@ object Config extends AwsInstanceTags {
   lazy val composerRestorerUrl: String = s"https://restorer.$domain/content"
 
   lazy val mediaAtomMakerUrl: String = s"https://video.$domain"
+
+  // TODO do this better!
+  lazy val mediaAtomMakerUrlForCode: String = stage match {
+    case "CODE" => s"https://video.${appDomain("DEV")}}" // allow MAM in DEV to call Workflow CODE
+    case _ => mediaAtomMakerUrl
+  }
 
   lazy val presenceUrl: String = s"wss://presence.$domain/socket"
   lazy val presenceClientLib: String = s"https://presence.$domain/client/1/lib.js"

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -37,7 +37,6 @@ case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
 object Api extends Controller with PanDomainAuthActions {
 
   val composerUrl: String = Config.composerUrl
-  val mediaAtomMakerUrl: String = Config.mediaAtomMakerUrl
 
   implicit val flatStubWrites: Writes[Stub] = Stub.flatStubWrites
 
@@ -76,7 +75,7 @@ object Api extends Controller with PanDomainAuthActions {
       }
     }
 
-  def getContentByEditorId(editorId: String) = CORSable(composerUrl, mediaAtomMakerUrl) {
+  def getContentByEditorId(editorId: String) = CORSable(composerUrl, Config.mediaAtomMakerUrl, Config.mediaAtomMakerUrlForCode) {
     APIAuthAction.async { implicit request =>
       ApiResponseFt[Option[Stub]](for {
         item <- PrototypeAPI.getStubByEditorId(editorId)
@@ -284,7 +283,7 @@ object Api extends Controller with PanDomainAuthActions {
     }
   }
 
-  def sections = CORSable(composerUrl, mediaAtomMakerUrl) {
+  def sections = CORSable(composerUrl, Config.mediaAtomMakerUrl, Config.mediaAtomMakerUrlForCode) {
     AuthAction.async  {request =>
       ApiResponseFt[List[Section]](for {
         sections <- SectionsAPI.getSections

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -37,6 +37,7 @@ case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
 object Api extends Controller with PanDomainAuthActions {
 
   val composerUrl: String = Config.composerUrl
+  val mediaAtomMakerUrl: String = Config.mediaAtomMakerUrl
 
   implicit val flatStubWrites: Writes[Stub] = Stub.flatStubWrites
 
@@ -75,7 +76,7 @@ object Api extends Controller with PanDomainAuthActions {
       }
     }
 
-  def getContentByEditorId(editorId: String) = CORSable(composerUrl) {
+  def getContentByEditorId(editorId: String) = CORSable(composerUrl, mediaAtomMakerUrl) {
     APIAuthAction.async { implicit request =>
       ApiResponseFt[Option[Stub]](for {
         item <- PrototypeAPI.getStubByEditorId(editorId)
@@ -283,7 +284,7 @@ object Api extends Controller with PanDomainAuthActions {
     }
   }
 
-  def sections = CORSable(composerUrl) {
+  def sections = CORSable(composerUrl, mediaAtomMakerUrl) {
     AuthAction.async  {request =>
       ApiResponseFt[List[Section]](for {
         sections <- SectionsAPI.getSections


### PR DESCRIPTION
allow media atom maker DEV to access `/api/sections` and `/api/atom/:editorId`

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)