### PR TITLE
Fix import from composer

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -15,6 +15,7 @@ import play.api.data.Forms._
 import play.api.data.Mapping
 import play.api.libs.json._
 import play.api.mvc._
+import com.gu.workflow.lib.DBToAPIResponse.getResponse
 
 import scala.concurrent.Future
 
@@ -69,7 +70,7 @@ object Api extends Controller with PanDomainAuthActions {
   def getContentByComposerId(composerId: String) = CORSable(defaultCorsAble) {
       APIAuthAction.async { implicit request =>
         ApiResponseFt[Option[Stub]](for {
-          item <- PrototypeAPI.getStubByComposerId(composerId)
+          item <- getResponse(PrototypeAPI.getStubByComposerId(composerId))
         } yield {
           item
         })(Writes.OptionWrites(Stub.flatStubWrites), defaultExecutionContext)
@@ -79,7 +80,7 @@ object Api extends Controller with PanDomainAuthActions {
   def getContentByEditorId(editorId: String) = CORSable(mediaAtomCorsAble) {
     APIAuthAction.async { implicit request =>
       ApiResponseFt[Option[Stub]](for {
-        item <- PrototypeAPI.getStubByEditorId(editorId)
+        item <- getResponse(PrototypeAPI.getStubByEditorId(editorId))
       } yield {
         item
       })(Writes.OptionWrites(Stub.flatStubWrites), defaultExecutionContext)
@@ -89,7 +90,7 @@ object Api extends Controller with PanDomainAuthActions {
   def sharedAuthGetContentById(composerId: String) =
     SharedSecretAuthAction.async {
       ApiResponseFt[Option[Stub]](for {
-        item <- PrototypeAPI.getStubByComposerId(composerId)
+        item <- getResponse(PrototypeAPI.getStubByComposerId(composerId))
       } yield {
         item
       })(Writes.OptionWrites(Stub.flatStubWrites), defaultExecutionContext)
@@ -285,7 +286,7 @@ object Api extends Controller with PanDomainAuthActions {
   }
 
   def sections = CORSable(mediaAtomCorsAble) {
-    AuthAction.async  {request =>
+    AuthAction.async { request =>
       ApiResponseFt[List[Section]](for {
         sections <- SectionsAPI.getSections
       } yield {
@@ -308,12 +309,12 @@ object Api extends Controller with PanDomainAuthActions {
   def toggleEditorialSupportStaff(id: String, status: String) = APIAuthAction {
     val active = status.toBoolean
     EditorialSupportTeamsController.toggleStaffStatus(id, active)
-    Ok(s"Status swithced to ${ if (active) "inactive" else "active" }")
+    Ok(s"Status switched to ${ if (active) "inactive" else "active" }")
   }
 
   def updateEditorialSupportStaffDescription(id: String, description: String) = APIAuthAction {
     EditorialSupportTeamsController.updateStaffDescription(id, description)
-    Ok(s"Descripton updated to '$description'")
+    Ok(s"Description updated to '$description'")
   }
 
   def sharedAuthGetContent = SharedSecretAuthAction.async(getContentBlock)

--- a/common-lib/src/main/scala/com/gu/workflow/lib/DBResponseToAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/DBResponseToAPI.scala
@@ -1,7 +1,10 @@
 package com.gu.workflow.lib
 
+import models.Stub
 import models.api._
 import play.api.libs.json.{Format, Json}
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 case class ContentUpdateChanges(collaboratorsInserted: List[String], stubRowsUpdated: Int)
 object ContentUpdateChanges { implicit val jsonFormats: Format[ContentUpdateChanges] = Json.format[ContentUpdateChanges]}
@@ -23,5 +26,9 @@ object DBToAPIResponse {
     else ApiResponseFt.Right(id)
   }
 
+  def getResponse(res: ApiResponseFt[Option[Stub]]): ApiResponseFt[Option[Stub]] = res.flatMap {
+    case Some(item) => ApiResponseFt.Right[Option[Stub]](Some(item))
+    case None => ApiResponseFt.Left[Option[Stub]](ApiErrors.notFound)
+  }
 
 }


### PR DESCRIPTION
<!--Your pull request-->
The previous `remove v1 api` PR lost some of the functionality. This PR parses API responses to return `not found` when the returned stub is none.

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)