### PR TITLE
allow OPTIONS requests from MAM

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -41,7 +41,7 @@ object Api extends Controller with PanDomainAuthActions {
 
   implicit val flatStubWrites: Writes[Stub] = Stub.flatStubWrites
 
-  def allowCORSAccess(methods: String, args: Any*) = CORSable(defaultCorsAble) {
+  def allowCORSAccess(methods: String, args: Any*) = CORSable(mediaAtomCorsAble) {
     Action { implicit req =>
       val requestedHeaders = req.headers("Access-Control-Request-Headers")
       NoContent.withHeaders("Access-Control-Allow-Methods" -> methods, "Access-Control-Allow-Headers" -> requestedHeaders)


### PR DESCRIPTION
<!--Your pull request-->
Missed this in #90, allow MAM in DEV to make an `OPTIONS` call.

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)