### PR TITLE
correct url

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -34,7 +34,7 @@ object Config extends AwsInstanceTags {
 
   // TODO do this better!
   lazy val mediaAtomMakerUrlForCode: String = stage match {
-    case "CODE" => s"https://video.${appDomain("DEV")}}" // allow MAM in DEV to call Workflow CODE
+    case "CODE" => s"https://video.${appDomain("DEV")}" // allow MAM in DEV to call Workflow CODE
     case _ => mediaAtomMakerUrl
   }
 


### PR DESCRIPTION
<!--Your pull request-->
Correcting a silly mistake from #90 

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)