### PR TITLE
allow mam to post to /stubs

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -42,7 +42,7 @@ object Api extends Controller with PanDomainAuthActions {
 
   implicit val flatStubWrites: Writes[Stub] = Stub.flatStubWrites
 
-  def allowCORSAccess(methods: String, args: Any*) = CORSable(defaultCorsAble) {
+  def allowCORSAccess(methods: String, args: Any*) = CORSable(mediaAtomCorsAble) {
     Action { implicit req =>
       val requestedHeaders = req.headers("Access-Control-Request-Headers")
       NoContent.withHeaders("Access-Control-Allow-Methods" -> methods, "Access-Control-Allow-Headers" -> requestedHeaders)
@@ -98,7 +98,7 @@ object Api extends Controller with PanDomainAuthActions {
 
   private val iso8601DateTimeNoMillis: Mapping[DateTime] = jodaDate("yyyy-MM-dd'T'HH:mm:ssZ")
 
-  def createContent() =  CORSable(defaultCorsAble) {
+  def createContent() =  CORSable(mediaAtomCorsAble) {
     APIAuthAction.async { request =>
       ApiResponseFt[models.api.ContentUpdate](for {
         jsValue <- ApiUtils.readJsonFromRequestResponse(request.body)


### PR DESCRIPTION
<!--Your pull request-->
Needed by https://github.com/guardian/media-atom-maker/pull/572/files


#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)