### PR TITLE
remove atom switch, turning it on for everyone

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -56,10 +56,7 @@ object Api extends Controller with PanDomainAuthActions {
       case r: Request[_] => r.queryString
     }
 
-    val supportAtoms = req.cookies.get("support-atoms").fold(false)(cookie => cookie.value == "1")
-    val queryString = if(supportAtoms) qs + ("supportAtoms" -> Seq(supportAtoms.toString)) else qs
-
-    CommonAPI.getStubs(queryString).asFuture.map {
+    CommonAPI.getStubs(qs).asFuture.map {
       case Left(err) => InternalServerError
       case Right(contentResponse) => Ok(Json.toJson(contentResponse))
     }

--- a/app/controllers/Feature.scala
+++ b/app/controllers/Feature.scala
@@ -7,7 +7,7 @@ object Feature extends Controller with PanDomainAuthActions {
   def featureList(implicit request: Request[_]): Map[String, Boolean] = {
     def featureDef(name: String): (String, Boolean) =
       (name, request.cookies.get(name).exists(_.value == "1"))
-    Map(featureDef("incopy-export"), featureDef("support-atoms"))
+    Map(featureDef("incopy-export"))
   }
 
   def makeCookie[A](name: String, value: Boolean => Boolean)

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -8,25 +8,20 @@ import './visibility-service';
 import './feature-switches';
 
 angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService', 'wfMediaAtomMakerService'])
-    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'config', 'wfFeatureSwitches',
-        function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService, wfMediaAtomMakerService, config, wfFeatureSwitches) {
+    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'config',
+        function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService, wfMediaAtomMakerService, config) {
 
             const httpRequest = wfHttpSessionService.request;
 
             class ContentService {
                 getTypes() {
-
-                    return wfFeatureSwitches.getSwitch("support-atoms").then( (isActive) => {
-                        const basicTypes = {
-                            "article": "Article",
-                            "liveblog": "Live blog",
-                            "gallery": "Gallery",
-                            "interactive": "Interactive",
-                            "picture": "Picture"
-                        };
-                        return isActive
-                            ? Object.assign({}, basicTypes, {'atom': 'Atom'})
-                        :  basicTypes;
+                    return Promise.resolve({
+                        "article": "Article",
+                        "liveblog": "Live blog",
+                        "gallery": "Gallery",
+                        "interactive": "Interactive",
+                        "picture": "Picture",
+                        'atom': 'Atom'
                     });
                 };
 

--- a/public/lib/feature-switches.js
+++ b/public/lib/feature-switches.js
@@ -9,18 +9,15 @@ define([], function () {
         // via an API call
 
         function simpleCookie(cookieName) {
-            return document.cookie.search(cookieName + "=1(;|$)") != -1;
+            return document.cookie.search(cookieName + "=1(;|$)") !== -1;
         }
 
         const staticSwitchData = {
             "presence-indicator": simpleCookie("presence-indicator"),
-            "incopy-export": simpleCookie("incopy-export"),
-            "support-atoms": simpleCookie("support-atoms")
+            "incopy-export": simpleCookie("incopy-export")
         };
 
-        const switches = new Promise(function (resolve, reject) {
-            resolve(staticSwitchData);
-        });
+        const switches = Promise.resolve(staticSwitchData);
 
         self.getSwitch = function(sw) {
             return switches.then(function(switches) { return switches[sw]; })
@@ -35,8 +32,8 @@ define([], function () {
             const ca = document.cookie.split(';');
             for(let i=0; i < ca.length; i++) {
                 let c = ca[i];
-                while (c.charAt(0)==' ') c = c.substring(1,c.length);
-                if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+                while (c.charAt(0) === ' ') c = c.substring(1,c.length);
+                if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length,c.length);
             }
             return null;
         };

--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -59,15 +59,15 @@ var filterDefaults = function (statuses, wfFiltersService, wfFeatureSwitches) {
                 { caption: 'Video', value: 'video', icon: 'video' }
             ]
         },
-        (wfFeatureSwitches.getCookie('support-atoms') === '1' ? {
-                title: 'Atom type',
-                namespace: 'atom-type',
-                listIsOpen: false,
-                multi: true,
-                filterOptions: [
-                    { caption: 'Media', value: 'media', icon: 'media' }
-                ]
-            } : {}),
+        {
+            title: 'Atom type',
+            namespace: 'atom-type',
+            listIsOpen: false,
+            multi: true,
+            filterOptions: [
+                { caption: 'Media', value: 'media', icon: 'media' }
+            ]
+        },
         {
             title: 'Created',
             namespace: 'created',


### PR DESCRIPTION
removing it was simpler than setting the cookie value on auth...

TODO:
- [x] test on CODE
- [ ] send comms

<!--Your pull request-->

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)