### PR TITLE
editorial support tool changes

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -302,8 +302,12 @@ object Api extends Controller with PanDomainAuthActions {
   }
 
   def addEditorialSupportStaff(name: String, team: String) = APIAuthAction {
-    EditorialSupportTeamsController.createNewStaff(name, team)
-    Ok(s"$name added to $team")
+    if (EditorialSupportTeamsController.checkIfStaffExists(name, team)) {
+      NotModified
+    } else {
+      EditorialSupportTeamsController.createNewStaff(name, team)
+      Ok(s"$name added to $team")
+    }
   }
 
   def toggleEditorialSupportStaff(id: String, status: String) = APIAuthAction {

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -321,5 +321,17 @@ object Api extends Controller with PanDomainAuthActions {
     Ok(s"Description updated to '$description'")
   }
 
+  def deleteEditorialSupportStaff(name: String, team: String) = APIAuthAction {
+    val staff = EditorialSupportTeamsController.findStaff(name, team)
+    staff.size match {
+      case 0 => NotFound
+      case 1 => {
+        EditorialSupportTeamsController.deleteStaff(staff(0).id)
+        Ok(s"$name from $team deleted")
+      }
+      case _ => NotAcceptable
+    }
+  }
+
   def sharedAuthGetContent = SharedSecretAuthAction.async(getContentBlock)
 }

--- a/app/controllers/EditorialSupportTeamsController.scala
+++ b/app/controllers/EditorialSupportTeamsController.scala
@@ -18,7 +18,7 @@ object EditorialSupportTeamsController extends Controller with PanDomainAuthActi
   }
 
   def checkIfStaffExists(name: String, team: String): Boolean = {
-    if (findStaff(name, team).nonEmpty) true else false
+    findStaff(name, team).nonEmpty
   }
 
   def getStaff(): List[EditorialSupportStaff] = {

--- a/app/controllers/EditorialSupportTeamsController.scala
+++ b/app/controllers/EditorialSupportTeamsController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.amazonaws.services.dynamodbv2.document.AttributeUpdate
-import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec
+import com.amazonaws.services.dynamodbv2.document.spec.{DeleteItemSpec, UpdateItemSpec}
 import com.gu.workflow.util.Dynamo
 import config.Config
 import models.{EditorialSupportStaff, EditorialSupportTeam}
@@ -18,7 +18,7 @@ object EditorialSupportTeamsController extends Controller with PanDomainAuthActi
   }
 
   def checkIfStaffExists(name: String, team: String): Boolean = {
-    if (getStaff().count(x => x.name == name && x.team == team) >= 1) true else false
+    if (findStaff(name, team).nonEmpty) true else false
   }
 
   def getStaff(): List[EditorialSupportStaff] = {
@@ -53,6 +53,17 @@ object EditorialSupportTeamsController extends Controller with PanDomainAuthActi
           .withAttributeUpdate(new AttributeUpdate("description").put(description))
       )
     }
+  }
+
+  def findStaff(name: String, team: String): List[EditorialSupportStaff] = {
+    getStaff().filter(x => x.name == name && x.team == team)
+  }
+
+  def deleteStaff(id: String) = {
+    editorialSupportTable.deleteItem(
+      new DeleteItemSpec()
+        .withPrimaryKey("id", id)
+    )
   }
 
 }

--- a/app/controllers/EditorialSupportTeamsController.scala
+++ b/app/controllers/EditorialSupportTeamsController.scala
@@ -17,6 +17,10 @@ object EditorialSupportTeamsController extends Controller with PanDomainAuthActi
     editorialSupportTable.putItem(EditorialSupportStaff(java.util.UUID.randomUUID().toString, name, false, team).toItem)
   }
 
+  def checkIfStaffExists(name: String, team: String): Boolean = {
+    if (getStaff().filter(x => x.name == name).filter(x => x.team == team).size >= 1) true else false
+  }
+
   def getStaff(): List[EditorialSupportStaff] = {
     editorialSupportTable.scan().map(EditorialSupportStaff.fromItem).toList
   }

--- a/app/controllers/EditorialSupportTeamsController.scala
+++ b/app/controllers/EditorialSupportTeamsController.scala
@@ -18,7 +18,7 @@ object EditorialSupportTeamsController extends Controller with PanDomainAuthActi
   }
 
   def checkIfStaffExists(name: String, team: String): Boolean = {
-    if (getStaff().filter(x => x.name == name).filter(x => x.team == team).size >= 1) true else false
+    if (getStaff().count(x => x.name == name && x.team == team) >= 1) true else false
   }
 
   def getStaff(): List[EditorialSupportStaff] = {

--- a/app/views/editorialSupportStatus.scala.html
+++ b/app/views/editorialSupportStatus.scala.html
@@ -1,20 +1,41 @@
 @(audience: EditorialSupportTeam, fronts: EditorialSupportTeam)
 
 @renderTeam(team: EditorialSupportTeam) = {
-@for(staff <- team.staff.sortBy(_.name)) {
-    <ul class="status"><input type="checkbox" id="editorialSupportStatus-@staff.id" onchange="window.toggleStaff('@staff.id')" @if(staff.active){checked} val>
-        <label>@staff.name</label>
-        <input type="text" value="@staff.description" id="editorialSupportDescription-@staff.id" onChange="window.updateStatus('@staff.id','@staff.description')">
+    <ul class="support-list">
+    @for(staff <- team.staff.sortBy(_.name)) {
+        <li class="support-list-item">
+            <p class="support-staff-label support-staff-row"><b>@staff.name</b></p>
+            <div class="support-staff-row">
+                <label class="support-staff-label" for="editorialSupportStatus-@staff.id">Active?</label>
+                <input type="checkbox" id="editorialSupportStatus-@staff.id" onchange="window.toggleStaff('@staff.id')" @if(staff.active){checked} val>
+            </div>
+            <div class="support-staff-row">
+                <label class="support-staff-label" for="editorialSupportDescription-@staff.id">Description</label>
+                <input type="text" class="support-text-input" value="@staff.description" id="editorialSupportDescription-@staff.id" onChange="window.updateStatus('@staff.id','@staff.description')">
+            </div>
+        </li>
+    }
     </ul>
-}
 }
 
 @renderAddStaff(teamName: String) = {
-    <ul class="status">Add new team member<input type="text" id="name-entry-@teamName"><button class="btn btn-lrg btn-info" onclick="window.addNewStaff('@teamName')">add</button></ul>
+    <div class="support-admin-label">
+        <status>Add new team member</status>
+        <input type="text" class="support-admin-text-input" id="name-entry-@teamName">
+        <div class="support-admin-button-container">
+            <button class="btn btn-sm btn-info" onclick="window.addNewStaff('@teamName')">add</button>
+        </div>
+    </div>
 }
 
 @renderDeleteStaff(teamName: String) = {
-    <ul class="status">Delete team member<input type="text" id="delete-name-entry-@teamName"><button class="btn btn-lrg btn-info" onclick="window.deleteStaff('@teamName')">delete</button></ul>
+    <div class="support-admin-label">
+        <status>Delete team member</status>
+        <input type="text" class="support-admin-text-input" id="delete-name-entry-@teamName">
+        <div class="support-admin-button-container">
+            <button class="btn btn-sm btn-info" onclick="window.deleteStaff('@teamName')">delete</button>
+        </div>
+    </div>
 }
 
 @layout("Support") {
@@ -26,15 +47,21 @@
         </div>
 
         <div>
-            <div class="col-lg-3">
+            <div class="col-lg-12">
                 <h2>@audience.name team</h2>
-                @renderTeam(audience)
-                @renderAddStaff(audience.name)
-                @renderDeleteStaff(audience.name)
+                <div class="support-list-wrapper">
+                    @renderTeam(audience)
+                    <h3>Admin</h3>
+                    @renderAddStaff(audience.name)
+                    @renderDeleteStaff(audience.name)
+                </div>
                 <h2>@fronts.name team</h2>
-                @renderTeam(fronts)
-                @renderAddStaff(fronts.name)
-                @renderDeleteStaff(fronts.name)
+                <div class="support-list-wrapper">
+                    @renderTeam(fronts)
+                    <h3>Admin</h3>
+                    @renderAddStaff(fronts.name)
+                    @renderDeleteStaff(fronts.name)
+                </div>
             </div>
         </div>
     </div>

--- a/app/views/editorialSupportStatus.scala.html
+++ b/app/views/editorialSupportStatus.scala.html
@@ -1,7 +1,7 @@
 @(audience: EditorialSupportTeam, fronts: EditorialSupportTeam)
 
 @renderTeam(team: EditorialSupportTeam) = {
-@for(staff <- team.staff) {
+@for(staff <- team.staff.sortBy(_.name)) {
     <ul class="status"><input type="checkbox" id="editorialSupportStatus-@staff.id" onchange="window.toggleStaff('@staff.id')" @if(staff.active){checked} val>
         <label>@staff.name</label>
         <input type="text" value="@staff.description" id="editorialSupportDescription-@staff.id" onChange="window.updateStatus('@staff.id','@staff.description')">

--- a/app/views/editorialSupportStatus.scala.html
+++ b/app/views/editorialSupportStatus.scala.html
@@ -13,6 +13,10 @@
     <ul class="status">Add new team member<input type="text" id="name-entry-@teamName"><button class="btn btn-lrg btn-info" onclick="window.addNewStaff('@teamName')">add</button></ul>
 }
 
+@renderDeleteStaff(teamName: String) = {
+    <ul class="status">Delete team member<input type="text" id="delete-name-entry-@teamName"><button class="btn btn-lrg btn-info" onclick="window.deleteStaff('@teamName')">delete</button></ul>
+}
+
 @layout("Support") {
     <div class="admin">
 
@@ -26,9 +30,11 @@
                 <h2>@audience.name team</h2>
                 @renderTeam(audience)
                 @renderAddStaff(audience.name)
+                @renderDeleteStaff(audience.name)
                 <h2>@fronts.name team</h2>
                 @renderTeam(fronts)
                 @renderAddStaff(fronts.name)
+                @renderDeleteStaff(fronts.name)
             </div>
         </div>
     </div>

--- a/conf/routes
+++ b/conf/routes
@@ -49,6 +49,7 @@ GET            /api/sections                               controllers.Api.secti
 
 GET            /api/editorialSupportTeams                  controllers.Api.editorialSupportTeams
 PUT            /api/editorialSupportTeams                  controllers.Api.addEditorialSupportStaff(name, team)
+DELETE         /api/editorialSupportTeams                  controllers.Api.deleteEditorialSupportStaff(name, team)
 POST           /api/editorialSupportTeams/toggle           controllers.Api.toggleEditorialSupportStaff(id, active)
 POST           /api/editorialSupportTeams/update           controllers.Api.updateEditorialSupportStaffDescription(id, description)
 

--- a/public/components/support-teams/_support-teams.scss
+++ b/public/components/support-teams/_support-teams.scss
@@ -1,0 +1,58 @@
+.support-list {
+  list-style: none;
+  padding: 0;
+  overflow: auto;
+  clear: both;
+}
+
+.support-list-wrapper {
+  padding: 20px 20px 0;
+  background-color: $c-grey-200;
+}
+
+.support-staff-label {
+  display: inline-block;
+  width: 100px;
+  margin-bottom: 0;
+  margin-left: 5px;
+  margin-right: 2px;
+  font-weight: normal;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.support-text-input {
+  padding-left: 5px;
+  display: inline-block;
+}
+
+.support-admin-label {
+  display: inline-block;
+  width: 200px;
+  padding: 0 20px 10px 0;
+  margin-top: 0;
+  font-weight: normal;
+}
+
+.support-list-item {
+  float: left;
+  width: calc(100% / 3 - 20px);
+  padding-bottom: 10px;
+  border-bottom: 1px solid $c-grey-300;
+  margin: 0 20px 10px 0;
+}
+
+.support-admin-button-container {
+  padding: 0 20px 10px 0;
+}
+
+.support-admin-text-input {
+  margin-right: 20px;
+  margin-bottom: 5px;
+  display: inline-block;
+  font-weight: normal;
+}
+
+.support-staff-row:not(:last-child) {
+  margin-bottom: 5px;
+}

--- a/public/editorialsupportteams.js
+++ b/public/editorialsupportteams.js
@@ -6,14 +6,17 @@ function addNewStaff(team) {
     fetch(endpoint, {
         method: 'PUT',
         credentials: 'same-origin'
-    }).then(reloadOnComplete)
+    }).then(function(response) {
+        if (response.status === 304) {
+            alert('Staff member already exists');
+        } else {
+            reloadOnComplete(response);
+        }
+    })
 }
 
 function reloadOnComplete(response) {
-    if (response.status === 304) {
-        alert("Staff member already exists");
-    }
-    else if (response.status === 200) {
+    if (response.status === 200) {
         location.reload();
     }
 }
@@ -36,9 +39,30 @@ function updateStatus(id, startText) {
             credentials: 'same-origin'
         }).then(reloadOnComplete)
     }
+}
 
+function deleteStaff(team) {
+    var text = document.getElementById("delete-name-entry-"+team).value.replace(/[^\w\s.,!?/]/gi, '');
+    var endpoint = `/api/editorialSupportTeams?name=${text}&team=${team}`;
+    fetch(endpoint, {
+        method: 'DELETE',
+        credentials: 'same-origin'
+    }).then(function(response){
+        var status = response.status;
+        if (status === 200) {
+            alert(`${text} from ${team} successfully deleted`);
+            location.reload();
+        }
+        else if (status === 406) {
+            alert(`Cannot delete: ${text} from ${team} is duplicated`);
+        }
+        else if (status === 404) {
+            alert(`Cannot delete: ${text} from ${team} does not exist`);
+        }
+    })
 }
 
 window ? window.addNewStaff = addNewStaff : false
 window ? window.toggleStaff = toggleStaff : false
 window ? window.updateStatus = updateStatus : false
+window ? window.deleteStaff = deleteStaff : false

--- a/public/editorialsupportteams.js
+++ b/public/editorialsupportteams.js
@@ -10,7 +10,10 @@ function addNewStaff(team) {
 }
 
 function reloadOnComplete(response) {
-    if (response.status === 200) {
+    if (response.status === 304) {
+        alert("Staff member already exists");
+    }
+    else if (response.status === 200) {
         location.reload();
     }
 }

--- a/public/main.scss
+++ b/public/main.scss
@@ -8,6 +8,7 @@
 @import "components/icons/icons";
 @import "layouts/dashboard/dashboard";
 @import '~bootstrap/dist/css/bootstrap.css';
+@import "components/support-teams/support-teams";
 
 .main-container {
     // Flexbox prefixes - TODO: Autoprefixer


### PR DESCRIPTION
rework of the /editorialSupport page:

- actually has CSS! thanks @shaundillon 
- users sorted alphabetically, and spread across the page so easier to work with large teams
- can't add duplicates anymore
- can delete users

<img width="1364" alt="screen shot 2017-08-24 at 09 59 01" src="https://user-images.githubusercontent.com/2470816/29659530-886e7444-88b6-11e7-9ec4-daef8cd952c2.png">
