### PR TITLE
editorial support active users first in list

### DIFF
--- a/app/controllers/EditorialSupportTeamsController.scala
+++ b/app/controllers/EditorialSupportTeamsController.scala
@@ -27,7 +27,10 @@ object EditorialSupportTeamsController extends Controller with PanDomainAuthActi
 
   def getTeams():List[EditorialSupportTeam] = {
     val staff = getStaff()
-    def extractTeam(name: String): EditorialSupportTeam = EditorialSupportTeam(name, staff.filter(x => x.team == name))
+    def extractTeam(name: String): EditorialSupportTeam = {
+      val teamStaff = staff.filter(x => x.team == name).partition(_.active)
+      EditorialSupportTeam(name, teamStaff._1.sortBy(_.name) ::: teamStaff._2.sortBy(_.name))
+    }
     List(extractTeam("Audience"), extractTeam("Fronts"))
   }
 

--- a/app/views/editorialSupportStatus.scala.html
+++ b/app/views/editorialSupportStatus.scala.html
@@ -2,7 +2,7 @@
 
 @renderTeam(team: EditorialSupportTeam) = {
     <ul class="support-list">
-    @for(staff <- team.staff.sortBy(_.name)) {
+    @for(staff <- team.sortActiveFirst.staff) {
         <li class="support-list-item">
             <p class="support-staff-label support-staff-row"><b>@staff.name</b></p>
             <div class="support-staff-row">

--- a/app/views/editorialSupportStatus.scala.html
+++ b/app/views/editorialSupportStatus.scala.html
@@ -2,7 +2,7 @@
 
 @renderTeam(team: EditorialSupportTeam) = {
     <ul class="support-list">
-    @for(staff <- team.sortActiveFirst.staff) {
+    @for(staff <- team.staff) {
         <li class="support-list-item">
             <p class="support-staff-label support-staff-row"><b>@staff.name</b></p>
             <div class="support-staff-row">

--- a/common-lib/src/main/scala/models/EditorialSupportTeams.scala
+++ b/common-lib/src/main/scala/models/EditorialSupportTeams.scala
@@ -10,14 +10,7 @@ object EditorialSupportStaff {
   def fromItem(item: Item) = Json.parse(item.toJSON).as[EditorialSupportStaff]
 }
 
-case class EditorialSupportTeam(name: String, staff: List[EditorialSupportStaff]) {
-
-  def sortActiveFirst: EditorialSupportTeam = {
-    val active = staff.filter(_.active).sortBy(_.name)
-    val inActive = staff.filter(!_.active).sortBy(_.name)
-    EditorialSupportTeam(name, active ::: inActive)
-  }
-}
+case class EditorialSupportTeam(name: String, staff: List[EditorialSupportStaff])
 
 object EditorialSupportTeam { implicit val jf: Format[EditorialSupportTeam] = Json.format[EditorialSupportTeam] }
 

--- a/common-lib/src/main/scala/models/EditorialSupportTeams.scala
+++ b/common-lib/src/main/scala/models/EditorialSupportTeams.scala
@@ -10,7 +10,14 @@ object EditorialSupportStaff {
   def fromItem(item: Item) = Json.parse(item.toJSON).as[EditorialSupportStaff]
 }
 
-case class EditorialSupportTeam(name: String, staff: List[EditorialSupportStaff])
+case class EditorialSupportTeam(name: String, staff: List[EditorialSupportStaff]) {
+
+  def sortActiveFirst: EditorialSupportTeam = {
+    val active = staff.filter(_.active).sortBy(_.name)
+    val inActive = staff.filter(!_.active).sortBy(_.name)
+    EditorialSupportTeam(name, active ::: inActive)
+  }
+}
 
 object EditorialSupportTeam { implicit val jf: Format[EditorialSupportTeam] = Json.format[EditorialSupportTeam] }
 


### PR DESCRIPTION
Push active users to the top of the team lists on the editorial support pages. should make handling larger lists easier