### PR TITLE
add editor id to filters to query stubs by editor id

### DIFF
--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -230,6 +230,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         'assigneeEmail': modelParams['assigneeEmail'] || null,
                         'incopy' : modelParams['incopy'] || null,
                         'composerId' : modelParams['composerId'] || null,
+                        'editorId' : modelParams['editorId'] || null,
                         'trashed': modelParams['trashed'] || null
                     };
 

--- a/public/lib/filters-service.js
+++ b/public/lib/filters-service.js
@@ -182,7 +182,8 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                         'news-list'    : params['news-list'],
                         'trashed'      : params['trashed'],
                         'plan-start-date': params['plan-start-date'],
-                        'plan-end-date': params['plan-end-date']
+                        'plan-end-date': params['plan-end-date'],
+                        'editorId'     :params['editorId']
                     };
 
                     $rootScope.currentlySelectedStatusFilters = self.transformStatusList(self.filters['status']);


### PR DESCRIPTION
Allows for passing editorId parameter for the stubs endpoint in workflow. 

Linked to https://github.com/guardian/workflow/pull/1028
https://trello.com/c/rOymNax4/122-open-workflow-to-individual-atom
