### PR TITLE
disable sidebar filters

### DIFF
--- a/public/lib/filters-service.js
+++ b/public/lib/filters-service.js
@@ -253,7 +253,7 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
             }
 
             postUpdate() {
-                if (this.filters['composerId'] || this.filters['text']) {
+                if (this.filters['composerId'] || this.filters['text'] || this.filters['editorId']) {
                     $rootScope.$broadcast("search-mode.enter");
                 } else {
                     $rootScope.$broadcast("search-mode.exit");


### PR DESCRIPTION
disable side bar filters when looking at individual atom, maintaining UX when looking at individual composer piece

this is important because it prevents a situation where:
- we're filtering to view only atom X
- we then add an "article" filter
- nothing appears because atom X is not an article

disabling the left hand filters when looking at an individual item means you have to clear/reset your search for them to become active again

How does this work? The `wfDashboardSidebarController` controller is listening to [`search-mode.*` and reacts accordingly](https://github.com/guardian/workflow-frontend/blob/master/public/layouts/dashboard/dashboard-sidebar.js#L28).

Before:
![workflow](https://user-images.githubusercontent.com/836140/30421761-b56c2006-9935-11e7-8d8a-89318f40a349.gif)

After:
![image](https://user-images.githubusercontent.com/836140/30421713-8315cce2-9935-11e7-8496-b384122c9a04.png)

<!--Your pull request-->

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)