### PR TITLE
query by media

### DIFF
--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -56,7 +56,7 @@ var filterDefaults = function (statuses, wfFiltersService, wfFeatureSwitches) {
                 { caption: 'Interactive', value: 'interactive', icon: 'interactive' },
                 { caption: 'Liveblog', value: 'liveblog', icon: 'liveblog' },
                 { caption: 'Picture', value: 'picture', icon: 'picture' },
-                { caption: 'Video', value: 'video', icon: 'video' }
+                { caption: 'Video', value: 'video,media', icon: 'video' }
             ]
         },
         {


### PR DESCRIPTION
Video atoms have type `media` and video pages have type `video`. We should query by both types when the users selects the video type filter. When composer video pages are no longer tracked in workflow, we can discuss removing `video` from the filter value.