### PR TITLE
update presence ids to handle atoms too

### DIFF
--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -292,12 +292,21 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
         });
     }
 
-    function parseContentForComposerIds(content) {
-        let contentItems = _.flatten(content.map((c) => c.items));
-        let filteredItems = contentItems.filter((item) => item !== undefined);
-        let composerIds = filteredItems.map((item) => item.composerId);
-        let filteredComposerIds = composerIds.filter((item) => item !== undefined);
-        return filteredComposerIds;
+    function parseContentForIds(content) {
+        const contentItems = _.flatten(content.map((c) => c.items));
+        const filteredItems = contentItems.filter((item) => item !== undefined);
+
+        const contentItemIds = filteredItems.map(item => {
+            if (item.composerId) {
+                return item.composerId;
+            }
+
+            if (item.contentType && item.editorId) {
+                return `${item.contentType}-${item.editorId}`;
+            }
+        });
+
+        return contentItemIds;
     }
 
     // =============================================================================== //
@@ -333,7 +342,7 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
                 doContentTrimAndSetContent();
 
                 (function setUpPresenceContentIds () {
-                    $scope.contentIds = parseContentForComposerIds($scope.content);
+                    $scope.contentIds = parseContentForIds($scope.content);
                 })();
 
                 $scope.$emit('content.render', {


### PR DESCRIPTION
atoms are registered in presence as `type-id`, this is stored in the item contentType and item editorId fields, which is different from Composer content.

![image](https://user-images.githubusercontent.com/836140/30592917-a296c0d0-9d40-11e7-845a-79f9761b12ab.png)


<!--Your pull request-->

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)