### PR TITLE
remove any possible undefined values from list

### DIFF
--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -306,7 +306,7 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
             }
         });
 
-        return contentItemIds;
+        return contentItemIds.filter(Boolean);
     }
 
     // =============================================================================== //


### PR DESCRIPTION
CP have reported missing Presence indicators in Workflow; this is the only change I can see that was removed in the recent refactoring of this function in #101 - https://github.com/guardian/workflow-frontend/pull/101/files#diff-8447e48858281da6bc2f39bf52cfa625L299

<!--Your pull request-->

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)