### PR TITLE
remove ordering by active from editorial support page

### DIFF
--- a/app/controllers/EditorialSupportTeamsController.scala
+++ b/app/controllers/EditorialSupportTeamsController.scala
@@ -28,8 +28,8 @@ object EditorialSupportTeamsController extends Controller with PanDomainAuthActi
   def getTeams():List[EditorialSupportTeam] = {
     val staff = getStaff()
     def extractTeam(name: String): EditorialSupportTeam = {
-      val teamStaff = staff.filter(x => x.team == name).partition(_.active)
-      EditorialSupportTeam(name, teamStaff._1.sortBy(_.name) ::: teamStaff._2.sortBy(_.name))
+      val teamStaff = staff.filter(x => x.team == name)
+      EditorialSupportTeam(name, teamStaff.sortBy(_.name))
     }
     List(extractTeam("Audience"), extractTeam("Fronts"))
   }


### PR DESCRIPTION
it turns out that this is really annoying the audience team, and fronts don't like it either, so going to just order alphabetically

will merge and release once Peter Martin has confirmed that Fronts are definitely ok for this to go