### PR TITLE
Make parseComposerData return a promise

### DIFF
--- a/public/components/date-time-picker/date-time-picker.js
+++ b/public/components/date-time-picker/date-time-picker.js
@@ -90,7 +90,6 @@ angular.module('wfDateTimePicker', ['ui.bootstrap.datetimepicker', 'wfDateServic
 
 
                 this.onDatePicked = function (newValue) {
-                    console.log(newValue);
                     $scope.dateValue = wfDateParser.parseDate(newValue);
 
 

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -158,10 +158,6 @@
         </p>
     </div>
 
-    <div class="modal-footer alert alert-info" ng-show="wfComposerState ==='archived'">
-        <p>This content has previously been tracked by Workflow. Import to create a new item.</p>
-    </div>
-
     <div class="modal-footer alert alert-danger" ng-show="actionSuccess === false">
         <p ng-show="contentName !== 'Atom'">Workflow's having difficulty communicating with Composer. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>
         <p ng-show="contentName === 'Atom'">Workflow's having difficulty communicating with the editor for this atom type. Please try again. If the problem persists, please <a href="mailto:central.production@guardian.co.uk ">contact Central Production</a>.</p>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -138,7 +138,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
 
     function importComposerContent(url) {
         wfComposerService.getComposerContent($scope.formData.importUrl)
-            .then((response) => wfComposerService.parseComposerData(response))
+            .then((response) => wfComposerService.parseComposerData(response, $scope.stub))
             .then((contentItem) => {
                 const composerId = contentItem.composerId;
 
@@ -156,8 +156,9 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
                             }
                         });
                 }
-            }
-        );
+            }, (err) => {
+            $scope.actionSuccess = false;
+        });
     }
 
     function importContentAtom(id, atomType) {

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -13,10 +13,13 @@ import 'lib/filters-service';
 import 'lib/prodoffice-service';
 import { punters } from 'components/punters/punters';
 
-const wfStubModal = angular.module('wfStubModal', ['ui.bootstrap', 'legalStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService'])
+const wfStubModal = angular.module('wfStubModal', [
+    'ui.bootstrap', 'legalStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService'])
     .directive('punters', ['$rootScope', 'wfGoogleApiService', punters]);
 
-function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, config, stub, mode, sections, statusLabels, legalStatesService, wfComposerService, wfProdOfficeService, wfContentService, wfPreferencesService, wfFiltersService, sectionsInDesks, wfCapiAtomService) {
+function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, config, stub, mode,
+     sections, statusLabels, legalStatesService, wfComposerService, wfProdOfficeService, wfContentService,
+     wfPreferencesService, wfFiltersService, sectionsInDesks, wfCapiAtomService) {
 
     wfContentService.getTypes().then( (types) => {
         $scope.contentName =
@@ -134,33 +137,24 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     }
 
     function importComposerContent(url) {
-        wfComposerService.getComposerContent($scope.formData.importUrl).then(
-            (composerContent) => {
-                //check validity
-                if (composerContent) {
+        wfComposerService.getComposerContent($scope.formData.importUrl)
+            .then((response) => wfComposerService.parseComposerData(response))
+            .then((contentItem) => {
+                const composerId = contentItem.composerId;
 
-                    const contentItem = wfComposerService.parseComposerData(composerContent.data, $scope.stub);
-                    const composerId = contentItem.composerId;
+                if(composerId) {
+                    $scope.composerUrl = config.composerViewContent + '/' + composerId;
+                    $scope.stub.title = contentItem.headline;
+                    // slice needed because the australian prodOffice is 'AUS' in composer and 'AU' in workflow
+                    $scope.stub.prodOffice  = contentItem.composerProdOffice ? contentItem.composerProdOffice.slice(0,2) : 'UK';
 
-                    if(composerId) {
-                        $scope.composerUrl = config.composerViewContent + '/' + composerId;
-                        $scope.stub.title = contentItem.headline;
-                        // slice needed because the australian prodOffice is 'AUS' in composer and 'AU' in workflow
-                        $scope.stub.prodOffice  = contentItem.composerProdOffice ? contentItem.composerProdOffice.slice(0,2) : 'UK';
-
-                        wfContentService.getById(composerId).then(
-                            (res) => importHandleExisting(res.data.data),
-                            (err) => {
-                                if(err.status === 404) {
-                                    $scope.validImport = true;
-                                    if(err.data.archive) { $scope.wfComposerState = 'archived'; }
-                                }
-                            });
-                    }
-                } else {
-                    $scope.stub.title = null;
-                    $scope.stub.composerId = null;
-                    $scope.stub.contentType = null;
+                    wfContentService.getById(composerId).then(
+                        (res) => importHandleExisting(res.data.data),
+                        (err) => {
+                            if(err.status === 404) {
+                                $scope.validImport = true;
+                            }
+                        });
                 }
             }
         );
@@ -179,7 +173,6 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
                     (err) => {
                         if(err.status === 404) {
                             $scope.validImport = true;
-                            if(err.data.archive) { $scope.wfComposerState = 'archived'; }
                         }
                     }
                 );
@@ -284,7 +277,6 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             $scope.contentUpdateError = true;
 
             if(err.status === 409) {
-                $scope.errorMsg = 'This item is already linked to a composer item.';
                 if(err.data.composerId) {
                     $scope.composerUrl = config.composerViewContent + '/' + err.data.composerId;
                 }
@@ -295,7 +287,6 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
                     $scope.stubId = err.data.stubId;
                 }
             } else {
-                $scope.errorMsg = err.friendlyMessage || err.message || err;
                 $scope.actionSuccess = false;
             }
 

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -53,7 +53,6 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService) {
 
     function parseComposerData(response, target) {
         target = target || {};
-
         if (!response.data || !response.data.data || !response.data.data.id) {
             $log.error("Composer response missing id field. Response: " + JSON.stringify(response) + " \n Stub metadata: " + JSON.stringify(target))
             return Promise.reject({

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -92,18 +92,20 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                  */
                 createInComposer(stub, statusOption) {
 
-                    return wfComposerService.create(stub.contentType, stub.commissioningDesks, stub.commissionedLength).then( (response) => {
+                    return wfComposerService.create(stub.contentType, stub.commissioningDesks, stub.commissionedLength)
+                    .then( (response) => wfComposerService.parseComposerData(response, stub))
+                    .then((updatedStub) => {
 
-                        wfComposerService.parseComposerData(response.data, stub);
+                        // wfComposerService.parseComposerData(response.data, stub);
 
                         if (statusOption) {
-                            stub['status'] = statusOption;
+                            updatedStub['status'] = statusOption;
                         }
 
                         if (stub.id) {
-                            return this.updateStub(stub);
+                            return this.updateStub(updatedStub);
                         } else {
-                            return this.createStub(stub);
+                            return this.createStub(updatedStub);
                         }
                     });
                 }

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -96,8 +96,6 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                     .then( (response) => wfComposerService.parseComposerData(response, stub))
                     .then((updatedStub) => {
 
-                        // wfComposerService.parseComposerData(response.data, stub);
-
                         if (statusOption) {
                             updatedStub['status'] = statusOption;
                         }


### PR DESCRIPTION
...which will be failed if the composer response doesn't contain at least the content id.

The hope is that this will solve some of the problems that we're getting where content appears in workflow without a composer or editor id associated with it.

This change also removes code relating to 'archived' content (no longer a thing) and an unused $scope.errorMsg variable.