### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Angular frontend and associated Scala API for Workflow.
 In order to run, workflow-frontend needs to talk to the CODE workflow datastore. It does this via an SSH tunnel to a 
 workflow-frontend CODE instance.
 
-- Make sure that you are running the right version of nodejs, (tested and working with v6.1.0). We recommend using [nvm](https://github.com/creationix/nvm) to easily manage multiple versions of node. With this you can use `nvm use` to switch to this version quickly.
+- Make sure that you are running the right version of nodejs (tested and working with v6.1.0). We recommend using [nvm](https://github.com/creationix/nvm) to easily manage multiple versions of node. With this you can use `nvm use` to switch to this version quickly.
 - Run the install script `./scripts/setup.sh`
 
 - In the `conf` folder copy `workflow-frontend-application.local-example.conf` into `workflow-frontend-application.local.conf` and edit it to replace *example.email@guardian.co.uk* by your Guardian email address.
@@ -16,4 +16,4 @@ workflow-frontend CODE instance.
 
 ### Run
 
-To run workflow-frontend, run the start stript `./scripts/start.sh`. Then navigate to https://workflow.local.dev-gutools.co.uk
+To run workflow-frontend, run the start script `./scripts/start.sh`. Then navigate to https://workflow.local.dev-gutools.co.uk


### PR DESCRIPTION
Typo found and a minor fix (proposal).

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)