### PR TITLE
Use correct atom endpoint

### DIFF
--- a/common-lib/src/main/scala/com/gu/workflow/api/CommonAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/CommonAPI.scala
@@ -53,7 +53,7 @@ object CommonAPI {
 
   def getStubsByEditorId(editorId: String): ApiResponseFt[Option[Stub]] =
     for {
-      res <- ApiResponseFt.Async.Right(getRequest(s"content/editor/$editorId"))
+      res <- ApiResponseFt.Async.Right(getRequest(s"atom/$editorId"))
       itemRes <- extractDataResponseOpt[Stub](res.json)
     } yield itemRes
 


### PR DESCRIPTION
<!--Your pull request-->

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)