### PR TITLE
Change decoder from val to def

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -53,8 +53,8 @@ case class Stub(id: Option[Long] = None,
                needsLegal: Flag = Flag.NA,
                note: Option[String] = None,
                prodOffice: String,
-               createdAt: DateTime = DateTime.now(),
-               lastModified: DateTime = DateTime.now(),
+               createdAt: DateTime = DateTime.now,
+               lastModified: DateTime = DateTime.now,
                trashed: Boolean = false,
                commissioningDesks: Option[String] = None,
                editorId: Option[String] = None,
@@ -74,7 +74,7 @@ object Stub {
     }
   }
 
-  val decoder: Decoder[Stub] = deriveDecoder
+  def decoder: Decoder[Stub] = deriveDecoder
 
   // This takes a flat json and converts it to a stub
   val flatJsonDecoder: Decoder[Stub] = new Decoder[Stub] {


### PR DESCRIPTION
<!--Your pull request-->
Using a val causes the default datetime to always be set to the same value every time we create a new stub.

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)