### PR TITLE
Add comm length back and fix flaky test

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -33,7 +33,8 @@ case class ExternalData(
                          legallySensitive: Option[Boolean] = None,
                          headline: Option[String] = None,
                          hasMainMedia: Option[Boolean] = None,
-                         commentable: Option[Boolean] = None)
+                         commentable: Option[Boolean] = None,
+                         commissionedLength: Option[Int] = None)
 
 object ExternalData {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
@@ -89,9 +90,8 @@ object Stub {
   // This takes a stub and converts it to a flat json
   val flatJsonEncoder: Encoder[Stub] = new Encoder[Stub] {
     def apply(stub: Stub): Json = {
-      val stubJson = stub.asJson
       (for {
-        stubObj <- stubJson.asObject
+        stubObj <- stub.asJson.asObject
         extDataJson <- stubObj("externalData")
         extDataObj <- extDataJson.asObject
         stubObjWithoutExData = stubObj.remove("externalData")

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -17,7 +17,7 @@ var SETTING_OPEN_SECTION = 'openSection';
  * @param contentService
  * @param prodOfficeService
  */
-export function wfContentListDrawer($rootScope, config, $timeout, $window, contentService, prodOfficeService, featureSwitches, wfGoogleApiService, wfCapiContentService, wfCapiAtomService, wfAtomService, wfSettingsService, composerService) {
+export function wfContentListDrawer($rootScope, config, $timeout, $window, contentService, prodOfficeService, featureSwitches, wfGoogleApiService, wfCapiContentService, wfCapiAtomService, wfAtomService, wfSettingsService, wfComposerService) {
 
     var hiddenClass = 'content-list-drawer--hidden';
 
@@ -324,7 +324,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             };
 
             $scope.updateCommissionedLength = function (newValue) {
-                return composerService.updateField($scope.contentItem.composerId, "commissionedLength", newValue)
+                return wfComposerService.updateField($scope.contentItem.composerId, "commissionedLength", newValue)
             };
 
             /**

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -32,7 +32,7 @@ angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOff
     .directive('wfContentItemUpdateAction', wfContentItemUpdateActionDirective)
     .directive('wfContentListItem', ['$rootScope', 'statuses', 'legalValues', 'sections', 'config', wfContentListItem])
     .controller('wfCommissionedLengthCtrl', ['$scope', wfCommissionedLengthCtrl])
-    .directive('wfContentListDrawer', ['$rootScope', 'config', '$timeout', '$window', 'wfContentService', 'wfProdOfficeService', 'wfFeatureSwitches', 'wfGoogleApiService', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService', 'wfSettingsService', wfContentListDrawer])
+    .directive('wfContentListDrawer', ['$rootScope', 'config', '$timeout', '$window', 'wfContentService', 'wfProdOfficeService', 'wfFeatureSwitches', 'wfGoogleApiService', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService', 'wfSettingsService', 'wfComposerService', wfContentListDrawer])
     .directive("bindCompiledHtml", function($compile, $timeout) {
         return {
             scope: {

--- a/test/com/gu/workflow/models/StubTest.scala
+++ b/test/com/gu/workflow/models/StubTest.scala
@@ -1,5 +1,7 @@
 package com.gu.workflow.models
 
+import java.util.TimeZone
+
 import com.gu.workflow.test.lib.TestData._
 import io.circe.parser.decode
 import io.circe.syntax._
@@ -7,7 +9,14 @@ import lib.ResourcesHelper
 import models._
 import org.scalatest.{FreeSpec, Matchers}
 
-class StubTest extends FreeSpec with Matchers with ResourcesHelper{
+class StubTest extends FreeSpec with Matchers with ResourcesHelper {
+  /* It's horrible, but this is absolutely necessary for correct interpretation
+     * of datetime columns in prog almost certainly what no sane person ever wants to do.
+     */
+
+  System.setProperty("user.timezone", "UTC")
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
   "StubReads" - {
     "should read the minimum required fields for a stub" in {
       val resource = slurp("stub-min-fields.json").getOrElse(
@@ -87,7 +96,7 @@ class StubTest extends FreeSpec with Matchers with ResourcesHelper{
       val flatJson = stub.asJson(Stub.flatJsonEncoder)
 
       flatJson.as[Stub](Stub.flatJsonDecoder).fold(e => fail(s"Should be valid flat stub json: $e"), s => {
-        val stubWithDateFields = s.copy(createdAt = stub.createdAt, lastModified = stub.lastModified)
+        val stubWithDateFields = s.copy(lastModified = stub.lastModified)
         stubWithDateFields should equal (stub)
       })
     }


### PR DESCRIPTION
<!--Your pull request-->
The field got lost in a rebase.

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)