### PR TITLE
show correct links for reader questions

### DIFF
--- a/public/components/content-list-item/templates/links.html
+++ b/public/components/content-list-item/templates/links.html
@@ -1,4 +1,4 @@
-<td class="content-list-item__field--composer" ng-if="contentItem.contentType !== 'media'">
+<td class="content-list-item__field--composer" ng-if="!isSupportedAtomType">
     <a href="{{ contentItem.links.composer }}" title="View in Composer (opens in new window)" target="_blank" ng-if="contentItem.links.composer" ng-click="$event.stopPropagation()">
         <i class="content-list-item__icon--composer" wf-icon="composer"></i>
     </a>
@@ -8,27 +8,34 @@
 </td>
 
 <td class="content-list-item__field--preview">
-    <a href="{{ contentItem.links.preview }}" title="Preview (opens in new window)" target="_blank" ng-if="contentItem.links.preview && contentItem.contentType !== 'media'" ng-click="$event.stopPropagation()">
+    <a href="{{ contentItem.links.preview }}" title="Preview (opens in new window)" target="_blank" ng-if="contentItem.links.preview && !isSupportedAtomType" ng-click="$event.stopPropagation()">
         <i class="content-list-item__icon--preview" wf-icon="preview"></i>
     </a>
-    <span ng-if="!contentItem.links.preview && contentItem.contentType !== 'media'" title="Preview (unavailable)" class="content-list-item__icon--inactive">
+    <span ng-if="!contentItem.links.preview && !isSupportedAtomType" title="Preview (unavailable)" class="content-list-item__icon--inactive">
         <i class="content-list-item__icon--preview" wf-icon="preview" wf-icon-active="false"></i>
     </span>
 </td>
 <td class="content-list-item__field--live">
-    <a href="{{ contentItem.links.live }}" title="View on Live site (opens in new window)" target="_blank" ng-if="contentItem.links.live && contentItem.contentType !== 'media'" ng-click="$event.stopPropagation()">
+    <a href="{{ contentItem.links.live }}" title="View on Live site (opens in new window)" target="_blank" ng-if="contentItem.links.live && !isSupportedAtomType" ng-click="$event.stopPropagation()">
         <i class="content-list-item__icon--live" wf-icon="live-site"></i>
     </a>
-    <span ng-if="!contentItem.links.live && contentItem.contentType !== 'media'" title="View on Live site (unavailable)" class="content-list-item__icon--inactive">
+    <span ng-if="!contentItem.links.live && !isSupportedAtomType" title="View on Live site (unavailable)" class="content-list-item__icon--inactive">
         <i class="content-list-item__icon--live" wf-icon="live-site" wf-icon-active="false"></i>
     </span>
 </td>
 
-<td class="content-list-item__field--media" ng-if="contentItem.contentType === 'media'">
-    <a href="{{ contentItem.links.editor }}" title="View in editor (opens in new window)" target="_blank" ng-if="contentItem.links.editor" ng-click="$event.stopPropagation()">
-        <i class="content-list-item__icon--media" wf-icon="media"></i>
+<td class="content-list-item__field--media" ng-if="isSupportedAtomType">
+    <a href="{{ contentItem.links.editor }}" title="View in editor (opens in new window)" target="_blank" ng-if="contentItem.links.editor" ng-click="$event.stopPropagation()" ng-switch="contentItem.contentType">
+        <i
+          ng-switch-when="media"
+          class="content-list-item__icon--media" wf-icon="media">
+        </i>
+        <i
+          ng-switch-when="storyquestions"
+          class="content-list-item__icon--media" wf-icon="storyquestions">
+        </i>
     </a>
-    <span ng-if="!contentItem.links.editor && contentItem.contentType === 'media'" title="View in editor (unavailable)" class="content-list-item__icon--inactive">
+    <span ng-if="!contentItem.links.editor && isSupportedAtomType" title="View in editor (unavailable)" class="content-list-item__icon--inactive">
         <i class="content-list-item__icon--media" wf-icon="media" wf-icon-active="false"></i>
     </span>
 </td>


### PR DESCRIPTION
The links shown for reader questions on the dashboard were the links specific for articles, not for atoms. This pr makes sure that all supported atom types get atom specific links.