### PR TITLE
Fix flat json encoder and decoder

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,11 +30,13 @@ object Dependencies {
 
   val logbackDependencies = Seq("net.logstash.logback" % "logstash-logback-encoder" % "4.5")
 
+  val circeVersion = "0.8.0"
+
   val jsonDependencies = Seq(
-    "io.circe" %% "circe-core" % "0.8.0",
-    "io.circe" %% "circe-generic" % "0.8.0",
-    "io.circe" %% "circe-parser" % "0.8.0",
-    "io.circe" %% "circe-generic-extras" % "0.8.0",
+    "io.circe" %% "circe-core" % circeVersion,
+    "io.circe" %% "circe-generic" % circeVersion,
+    "io.circe" %% "circe-parser" % circeVersion,
+    "io.circe" %% "circe-generic-extras" % circeVersion,
     "com.beachape" %% "enumeratum-circe" % "1.5.14"
   )
 }

--- a/test/com/gu/workflow/models/StubTest.scala
+++ b/test/com/gu/workflow/models/StubTest.scala
@@ -1,7 +1,5 @@
 package com.gu.workflow.models
 
-import java.util.TimeZone
-
 import com.gu.workflow.test.lib.TestData._
 import io.circe.parser.decode
 import io.circe.syntax._
@@ -93,8 +91,7 @@ class StubTest extends FreeSpec with Matchers with ResourcesHelper {
       val flatJson = stub.asJson(Stub.flatJsonEncoder)
 
       flatJson.as[Stub](Stub.flatJsonDecoder).fold(e => fail(s"Should be valid flat stub json: $e"), s => {
-        val stubWithDateFields = s.copy(lastModified = stub.lastModified)
-        stubWithDateFields should equal (stub)
+        s should equal (stub)
       })
     }
   }

--- a/test/com/gu/workflow/models/StubTest.scala
+++ b/test/com/gu/workflow/models/StubTest.scala
@@ -14,9 +14,6 @@ class StubTest extends FreeSpec with Matchers with ResourcesHelper {
      * of datetime columns in prog almost certainly what no sane person ever wants to do.
      */
 
-  System.setProperty("user.timezone", "UTC")
-  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
-
   "StubReads" - {
     "should read the minimum required fields for a stub" in {
       val resource = slurp("stub-min-fields.json").getOrElse(


### PR DESCRIPTION
<!--Your pull request-->
The models contain 2 last modified dates:
- one lives in the `Stub` model and represents the `wfLastModified` date
- the other one lives in the `ExternalData` model and represents the `lastModified` date of that piece of content

This PR updates the flat json encoder and decoder to take this into consideration.

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)