### PR TITLE
allow atom apps to get /statuses

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -249,7 +249,7 @@ object Api extends Controller with PanDomainAuthActions {
     NoContent
   }
 
-  def statusus = CORSable(defaultCorsAble)  {
+  def statusus = CORSable(atomCorsAble)  {
     APIAuthAction.async { implicit req =>
       for(statuses <- StatusDatabase.statuses) yield {
         Ok(renderJsonResponse(statuses).asJson.noSpaces)


### PR DESCRIPTION
<!--Your pull request-->
Similar to `/sections`, open the CORS up. This is to allow Atom apps to change the status of an Atom in Workflow directly in the app.

![img](https://media.giphy.com/media/3o6ZsTmzj7K6FfkOas/giphy.gif)

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)