### PR TITLE
allow atom apps to change item status

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -165,7 +165,7 @@ object Api extends Controller with PanDomainAuthActions {
     )}
   }
 
-  def putStubStatus(stubId: Long) = CORSable(defaultCorsAble) {
+  def putStubStatus(stubId: Long) = CORSable(atomCorsAble) {
     APIAuthAction.async { request =>
       ApiResponseFt[Long](for {
         json <- ApiUtils.readJsonFromRequestResponse(request.body)


### PR DESCRIPTION
<!--Your pull request-->
related to #118 

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)