### PR TITLE
Capi iam preview

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -52,7 +52,7 @@ object Config extends AwsInstanceTags {
     case _ => "https://tagmanager.code.dev-gutools.co.uk"
   }
 
-  lazy val capiPreviewIamUrl: String = config.getConfigStringOrFail("capi.preview.iam-url")
+  lazy val capiPreviewIamUrl: String = config.getConfigStringOrFail("capi.preview.iamUrl")
   lazy val capiPreviewRole: String = config.getConfigStringOrFail("capi.preview.role")
 
   lazy val incopyExportUrl: String = "gnm://composer/export/${composerId}"

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -52,13 +52,8 @@ object Config extends AwsInstanceTags {
     case _ => "https://tagmanager.code.dev-gutools.co.uk"
   }
 
-  lazy val contentApiUrl: String = stage match {
-    case "PROD" => s"https://preview.content.guardianapis.com"
-    case _ => "https://preview.content.code.dev-guardianapis.com"
-  }
-
-  lazy val capiPreviewUsername = config.getConfigStringOrFail("capi.preview.username")
-  lazy val capiPreviewPassword = config.getConfigStringOrFail("capi.preview.password")
+  lazy val capiPreviewIamUrl: String = config.getConfigStringOrFail("capi.preview.iam-url")
+  lazy val capiPreviewRole: String = config.getConfigStringOrFail("capi.preview.role")
 
   lazy val incopyExportUrl: String = "gnm://composer/export/${composerId}"
   lazy val indesignExportUrl: String = "gnm://composerindesign/export/${composerId}"

--- a/app/controllers/CAPIService.scala
+++ b/app/controllers/CAPIService.scala
@@ -8,6 +8,7 @@ import com.gu.contentapi.client.IAMSigner
 import play.api.libs.ws.WS
 import config.Config
 import play.api.mvc.Controller
+import play.api.Play.current
 import com.gu.workflow.util.AWS
 
 object CAPIService extends Controller with PanDomainAuthActions{

--- a/app/controllers/CAPIService.scala
+++ b/app/controllers/CAPIService.scala
@@ -1,20 +1,39 @@
 package controllers
 
-import play.api.libs.ws.{WS, WSAuthScheme, WSResponse}
+import java.net.URI
+
+import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.gu.contentapi.client.IAMSigner
+import play.api.libs.ws.WS
 import config.Config
-import play.api.libs.ws.WSAuthScheme.BASIC
 import play.api.mvc.Controller
-import play.api.Play.current
+import com.gu.workflow.util.AWS
 
 object CAPIService extends Controller with PanDomainAuthActions{
+
+  private val previewSigner = {
+    val capiPreviewCredentials = new AWSCredentialsProviderChain(
+      new ProfileCredentialsProvider("capi"),
+      new STSAssumeRoleSessionCredentialsProvider.Builder(Config.capiPreviewRole, "capi").build()
+    )
+
+    new IAMSigner(
+      credentialsProvider = capiPreviewCredentials,
+      awsRegion = AWS.region.getName
+    )
+  }
 
   def previewCapiProxy(path: String) = APIAuthAction.async { request =>
 
     import scala.concurrent.ExecutionContext.Implicits.global
 
+    val url = s"${Config.capiPreviewIamUrl}/$path?${request.rawQueryString}"
+    val headers = previewSigner.addIAMHeaders(Map.empty, URI.create(url))
+
     val req = WS
-      .url(s"${Config.contentApiUrl}/$path?${request.rawQueryString}")
-      .withAuth(Config.capiPreviewUsername, Config.capiPreviewPassword, BASIC)
+      .url(url)
+      .withHeaders(headers.toSeq: _*)
       .get()
 
     req.map(response => response.status match {

--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -40,7 +40,7 @@ trait PanDomainAuthActions extends AuthActions with PanDomainAuth with Results {
 
   override def awsCredentialsProvider() = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("workflow"),
-    new InstanceProfileCredentialsProvider(),
+    InstanceProfileCredentialsProvider.getInstance(),
     new EnvironmentVariableCredentialsProvider()
   )
 }

--- a/common-lib/src/main/scala/com/gu/workflow/lib/LogConfig.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/LogConfig.scala
@@ -5,6 +5,7 @@ import java.security.SecureRandom
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Logger => LogbackLogger}
 import com.amazonaws.auth.{InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import com.gu.logback.appender.kinesis.KinesisAppender
 import com.gu.workflow.util.{AWS, AwsInstanceTags}
 import net.logstash.logback.layout.LogstashLayout
@@ -54,7 +55,8 @@ object LogConfig extends AwsInstanceTags {
     val random = new SecureRandom()
     val sessionId = s"session${random.nextDouble()}"
 
-    val instanceProvider = new InstanceProfileCredentialsProvider()
-    new STSAssumeRoleSessionCredentialsProvider(instanceProvider, stsRole, sessionId)
+    val instanceProvider = InstanceProfileCredentialsProvider.getInstance
+    val stsClient = AWSSecurityTokenServiceClientBuilder.standard.withCredentials(instanceProvider).build
+    new STSAssumeRoleSessionCredentialsProvider.Builder(stsRole, sessionId).withStsClient(stsClient).build
   }
 }

--- a/common-lib/src/main/scala/com/gu/workflow/util/AWS.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/util/AWS.scala
@@ -3,10 +3,10 @@ package com.gu.workflow.util
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider}
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsyncClient, AmazonCloudWatchAsyncClientBuilder}
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBClient, AmazonDynamoDBClientBuilder}
 import com.amazonaws.services.dynamodbv2.document.DynamoDB
-import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.ec2.{AmazonEC2Client, AmazonEC2ClientBuilder}
 import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
 import com.amazonaws.util.EC2MetadataUtils
 
@@ -16,18 +16,16 @@ object AWS {
 
   lazy val region: Region = Region getRegion Regions.EU_WEST_1
 
-  lazy val EC2Client = region.createClient(classOf[AmazonEC2Client], null, null)
-  lazy val CloudWatch = region.createClient(classOf[AmazonCloudWatchAsyncClient], null, null)
-  lazy val DynamoDb = region.createClient(
-    classOf[AmazonDynamoDBClient],
+  lazy val EC2Client = AmazonEC2ClientBuilder.standard.withRegion(region.getName).build
+  lazy val CloudWatch = AmazonCloudWatchAsyncClientBuilder.standard.withRegion(region.getName).build
+  lazy val DynamoDb = AmazonDynamoDBClientBuilder.standard.withRegion(region.getName).withCredentials(
     new AWSCredentialsProviderChain(
       new EnvironmentVariableCredentialsProvider(),
-      new InstanceProfileCredentialsProvider(),
+      InstanceProfileCredentialsProvider.getInstance(),
       new ProfileCredentialsProvider("workflow"),
       new DefaultAWSCredentialsProviderChain
-    ),
-    null)
-
+    )
+  ).build
 }
 
 trait Dynamo {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,8 @@ object Dependencies {
   val awsDependencies = Seq(
     "com.amazonaws" % "aws-java-sdk" % "1.11.8",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
-    "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.8"
+    "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.8",
+    "com.gu" %% "content-api-client-aws" % "0.5"
   )
 
   val akkaDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val playDependencies = Seq(ws, "com.typesafe.play" %% "play-json" % "2.4.11")
 
   val awsDependencies = Seq(
-    "com.amazonaws" % "aws-java-sdk" % "1.11.8",
+    "com.amazonaws" % "aws-java-sdk" % "1.11.259",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
-    "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.8",
+    "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.259",
     "com.gu" %% "content-api-client-aws" % "0.5"
   )
 


### PR DESCRIPTION
Uses the new IAM-authorised capi preview endpoint.

Also removed some deprecated aws calls (as the new dependency has a newer version of the sdk)