### PR TITLE
Add sessionId to logging and sentry, remove user data from sentry

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -8,7 +8,7 @@ import config.Config
 object Global extends WithFilters(RedirectToHTTPSFilter, new GzipFilter, LoggingFilter) with GlobalSettings {
   override def beforeStart(app: Application) {
 
-    LogConfig.init()
+    LogConfig.init(Config.sessionId)
 
     /* It's horrible, but this is absolutely necessary for correct interpretation
      * of datetime columns in prog almost certainly what no sane person ever wants to do.

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -4,6 +4,7 @@ import com.gu.workflow.lib.{Config => config}
 import com.gu.workflow.util.AwsInstanceTags
 import lib.LogStashConf
 import play.Logger
+import java.util.UUID
 
 object Config extends AwsInstanceTags {
   lazy val stage: String = readTag("Stage") match {
@@ -68,6 +69,8 @@ object Config extends AwsInstanceTags {
 
   lazy val atomTypes: List[String] = List("media", "storyquestions")
   lazy val contentTypes: List[String] = List("article", "liveblog", "gallery", "interactive", "picture", "video", "audio")
+
+  lazy val sessionId: String = UUID.randomUUID().toString
 
   // logstash conf
   private lazy val logStashHost: String = "ingest.logs.gutools.co.uk"

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -112,7 +112,8 @@ object Application extends Controller with PanDomainAuthActions {
         ("indesignExportUrl", Json.fromString(Config.indesignExportUrl)),
         ("composerRestorerUrl", Json.fromString(Config.composerRestorerUrl)),
         ("commissioningDesks", commissioningDesks.map(t => LimitedTag(t.id, t.externalName)).asJson),
-        ("atomTypes", Config.atomTypes.asJson)
+        ("atomTypes", Config.atomTypes.asJson),
+        ("sessionId", Json.fromString(Config.sessionId))
       )
 
       Ok(views.html.app(title, Some(user), config, Config.presenceClientLib))

--- a/common-lib/src/main/scala/com/gu/workflow/lib/LogConfig.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/LogConfig.scala
@@ -22,7 +22,7 @@ object LogConfig extends AwsInstanceTags {
   val config: Configuration = play.api.Play.configuration
   val loggingPrefix = "aws.kinesis.logging"
 
-  def init() = {
+  def init(sessionId: String) = {
     for {
       stack <- readTag("Stack")
       app <- readTag("App")
@@ -30,10 +30,9 @@ object LogConfig extends AwsInstanceTags {
       stream <- config.getString(s"$loggingPrefix.streamName")
     } yield {
       val context = rootLogger.getLoggerContext
-
       val layout = new LogstashLayout()
       layout.setContext(context)
-      layout.setCustomFields(s"""{"stack":"$stack","app":"$app","stage":"$stage"}""")
+      layout.setCustomFields(s"""{"stack":"$stack","app":"$app","stage":"$stage", "sessionId":"$sessionId"}""")
       layout.start()
 
       val appender = new KinesisAppender[ILoggingEvent]()

--- a/public/app.js
+++ b/public/app.js
@@ -157,7 +157,8 @@ angular.module('workflow',
             'mediaAtomMakerViewAtom': _wfConfig.mediaAtomMaker.view,
             'atomWorkshopNewAtom': _wfConfig.atomWorkshop.create,
             'atomWorkshopViewAtom': _wfConfig.atomWorkshop.view,
-            'atomTypes': _wfConfig.atomTypes
+            'atomTypes': _wfConfig.atomTypes,
+            'sessionId': _wfConfig.sessionId
         }
     )
     .constant({ 'statuses': _wfConfig.statuses })

--- a/public/components/sentry/sentry.js
+++ b/public/components/sentry/sentry.js
@@ -13,18 +13,18 @@ import angular from 'angular';
 
 import 'raven-js/plugins/angular';
 
-import 'lib/user';
 
-angular.module('wfSentry', ['ngRaven', 'wfUser'])
+angular.module('wfSentry', ['ngRaven'])
 
     // Raven's angular module requires "RavenConfig" to be declared
-    .service('RavenConfig', ['wfEnvironment', 'wfUser', function(wfEnvironment, wfUser) {
+    .service('RavenConfig', ['wfEnvironment', function(wfEnvironment) {
 
-        raven.setUserContext({
-            'email': wfUser.email,
-            'first_name': wfUser.firstName,
-            'last_name': wfUser.lastName
+        raven.setExtraContext({
+          session_id: _wfConfig.sessionId
         });
+
+      // Note: this isn't required, but guarantees the user context is empty when an error is sent to sentry.
+        raven.setUserContext();
 
         return {
             'dsn': wfEnvironment.sentry.url,


### PR DESCRIPTION
This follows the same idea in composer. I create a session ID in config, pass it to both the log config and the client so we can relate sentry issues to a user via Kibana if we need to.

If anyone knows a nicer way of sharing between workflow-frontend and common-lib, let me know. This obviously means there's a divergence in the common libs.
