### PR TITLE
correct string for ga

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -61,7 +61,7 @@ object Config extends AwsInstanceTags {
 
   lazy val viewerUrl: String = s"https://viewer.$domain"
 
-  lazy val googleTrackingId: String = config.getConfigWithDefault("google.tracking.id", "").right.toString()
+  lazy val googleTrackingId: String = config.getConfigStringOrFail("google.tracking.id")
 
   lazy val appSecret: String = config.getConfigStringOrFail("application.secret")
 

--- a/conf/workflow-frontend-application.local-example.conf
+++ b/conf/workflow-frontend-application.local-example.conf
@@ -4,3 +4,5 @@ api.url="http://localhost:5002/api"
 application.admin.whitelist=[
   "example.email@guardian.co.uk"
 ]
+
+google.tracking.id=""


### PR DESCRIPTION
`.right.toString()` does not work in the way I thought it would. This changes the get method and updates the example conf to reflect that it's no longer an optional value.