### PR TITLE
Fix stub creation

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -81,8 +81,9 @@ object Stub {
   val flatJsonDecoder: Decoder[Stub] = new Decoder[Stub] {
     def apply(c: HCursor): Result[Stub] =
       c.as[ExternalData].fold[Decoder.Result[Stub]](err => Left(DecodingFailure(s"Decoding the flat json - Could not decode externalData: ${err.message}.", c.history)), exData => {
-        val wfLastMod = c.downField("wfLastModified").focus.getOrElse(Json.Null)
-        val updatedLastModCursor = c.downField("lastModified").set(wfLastMod).up
+        val wfLastMod: Json = c.downField("wfLastModified").focus.getOrElse(Json.Null)
+        val updatedLastModCursor =
+          if(wfLastMod != Json.Null) c.downField("lastModified").set(wfLastMod).up else c
         updatedLastModCursor.as[Stub].fold[Decoder.Result[Stub]](err => Left(DecodingFailure(s"Decoding the flat json - Could not decode stub: ${err.message}.", c.history)), stub => {
           Right(stub.copy(externalData = Some(exData)))
         })


### PR DESCRIPTION
Flat encoding of JSON was broken if wfLastModified wasn't set as it was setting lastModified to Null, which creates an invalid circe cursor. This checks and doesn't set lastModified to wflastModifed if the latter is Null.

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)