### PR TITLE
Editorial support form validation

### DIFF
--- a/app/views/editorialSupportStatus.scala.html
+++ b/app/views/editorialSupportStatus.scala.html
@@ -58,7 +58,7 @@
                 <status>Add team member</status>
                 <input type="hidden" name="action" value="add_team_member" />
                 <input type="hidden" name="team" value="@teamName" />
-                <input type="text" class="support-admin-text-input" name="name">
+                <input type="text" class="support-admin-text-input" name="name" required />
                 <div class="support-admin-button-container">
                     <input type="submit" class="btn btn-sm btn-info" value="add" />
                 </div>
@@ -69,7 +69,7 @@
                 <status>Delete team member</status>
                 <input type="hidden" name="action" value="delete" />
                 <input type="hidden" name="team" value="@teamName" />
-                <input type="text" class="support-admin-text-input" name="name">
+                <input type="text" class="support-admin-text-input" name="name" required />
                 <div class="support-admin-button-container">
                     <input type="submit" class="btn btn-sm btn-danger" value="delete" />
                 </div>
@@ -85,11 +85,11 @@
                 <input type="hidden" name="action" value="add_front" />
                 <div class="support-staff-row">
                     <label class="support-staff-label">Front</label>
-                    <input type="text" class="support-admin-text-input" name="team">
+                    <input type="text" class="support-admin-text-input" name="team" required />
                 </div>
                 <div class="support-staff-row">
                     <label class="support-staff-label">User</label>
-                    <input type="text" class="support-admin-text-input" name="name">
+                    <input type="text" class="support-admin-text-input" name="name" required />
                 </div>
                 <div class="support-admin-button-container">
                     <input type="submit" class="btn btn-sm btn-info" value="add" />


### PR DESCRIPTION
After #130 it is possible to add a team member with an empty name. If you try the same with a front you get the big red angry Play error screen.

This fix simply adds `required` to the fields so the browser validates them.

NB: the description for a team member and name for a front are deliberately not required since they can be set to empty (an empty name against a front filters it from the list in composer)