### PR TITLE
fix stub ref to atom styles

### DIFF
--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -9,7 +9,7 @@ import './visibility-service';
 import './feature-switches';
 
 angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService'])
-    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'config', 'wfFeatureSwitches',
+    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomService', 'config', 'wfFeatureSwitches',
         function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService, wfMediaAtomMakerService, wfAtomWorkshopService, config, wfFeatureSwitches) {
 
             const httpRequest = wfHttpSessionService.request;
@@ -165,7 +165,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                 updateField(contentItem, field, data, contentType) {
 
                     if (field === 'status' && contentItem.status === 'Stub') {
-                        if (wfAtomService.atomTypes.indexOf(contentType) >= 0) {
+                        if (config.atomTypes.indexOf(contentType) >= 0) {
                             return this.createInAtomEditor(contentItem, data);
                         } else {
                             return this.createInComposer(contentItem, data)


### PR DESCRIPTION
fixing the creation of stubs led me to this new problem, the inability to move them

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)