### PR TITLE
Show all teams in the edit page

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -277,10 +277,10 @@ object Api extends Controller with PanDomainAuthActions {
       val staff = EditorialSupportTeamsController.listStaff().filter(_.name.nonEmpty)
       val teams = EditorialSupportStaff.groupByTeams(staff)
 
-      val audience = EditorialSupportStaff.getTeam("Audience", teams)
       val fronts = EditorialSupportStaff.groupByPerson(EditorialSupportStaff.getTeam("Fronts", teams))
+      val other = teams.filterNot(_.name == "Fronts")
 
-      Ok(List(audience, fronts).asJson.noSpaces)
+      Ok((other :+ fronts).asJson.noSpaces)
     }
   }
 


### PR DESCRIPTION
Allow all teams to be edited in the editorial support page. As a side effect, this lets one create a new team by seeding the initial member in the dynamo table.