### PR TITLE
Force UTC at encoder time rather than system property

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,20 +1,12 @@
-import java.util.TimeZone
-import play.api.mvc.WithFilters
-import play.api.{Logger, GlobalSettings, Application}
-import play.filters.gzip.GzipFilter
-import lib.{RedirectToHTTPSFilter, LoggingFilter, LogConfig}
 import config.Config
+import lib.{LogConfig, LoggingFilter, RedirectToHTTPSFilter}
+import play.api.mvc.WithFilters
+import play.api.{Application, GlobalSettings}
+import play.filters.gzip.GzipFilter
 
 object Global extends WithFilters(RedirectToHTTPSFilter, new GzipFilter, LoggingFilter) with GlobalSettings {
   override def beforeStart(app: Application) {
 
     LogConfig.init(Config.sessionId)
-
-    /* It's horrible, but this is absolutely necessary for correct interpretation
-     * of datetime columns in prog almost certainly what no sane person ever wants to do.
-     */
-
-    System.setProperty("user.timezone", "UTC")
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
   }
 }

--- a/common-lib/src/main/scala/models/DateFormat.scala
+++ b/common-lib/src/main/scala/models/DateFormat.scala
@@ -1,14 +1,18 @@
 package models
 
 import io.circe.syntax._
-import io.circe.{Decoder, DecodingFailure, Encoder, HCursor}
-import org.joda.time.DateTime
+import io.circe._
+import org.joda.time.format.ISODateTimeFormat
+import org.joda.time.{DateTime, DateTimeZone}
 
 object DateFormat {
-  private val datePattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+  private val formatter = ISODateTimeFormat.dateTime()
 
   implicit val dateTimeEncoder = new Encoder[DateTime] {
-    def apply(d: DateTime) = d.toString(datePattern).asJson
+    def apply(d: DateTime): Json = {
+      val utc = d.withZone(DateTimeZone.UTC)
+      formatter.print(utc).asJson
+    }
   }
   implicit val dateTimeDecoder = new Decoder[DateTime] {
     def apply(c: HCursor): Decoder.Result[DateTime] = {

--- a/test/com/gu/workflow/models/StubTest.scala
+++ b/test/com/gu/workflow/models/StubTest.scala
@@ -8,10 +8,6 @@ import models._
 import org.scalatest.{FreeSpec, Matchers}
 
 class StubTest extends FreeSpec with Matchers with ResourcesHelper {
-  /* It's horrible, but this is absolutely necessary for correct interpretation
-     * of datetime columns in prog almost certainly what no sane person ever wants to do.
-     */
-
   "StubReads" - {
     "should read the minimum required fields for a stub" in {
       val resource = slurp("stub-min-fields.json").getOrElse(


### PR DESCRIPTION
Fixes a flakey test that failed during daylight savings time. It is better to force UTC in code rather than a JVM system property 😃 