### PR TITLE
Update riff-raff.yaml

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -11,7 +11,7 @@ deployments:
     parameters:
       amiTags:
         AmigoStage: PROD
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-xenial-java8-deprecated
         BuiltBy: amigo
       cloudFormationStackName: Workflow-Frontend
       prependStackToCloudFormationStackName: false


### PR DESCRIPTION
In the move to `ssm`, we're removing the ssh-keys role from the AMIs that we use. The AMIgo recipe `editorial-tools-xenial-java8` no longer includes this role.

Explicitly use a deprecated AMIgo image, to make it obvious that this project needs updating.

<!--Your pull request-->

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)