### PR TITLE
Mlc fix commissioned length

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -176,6 +176,16 @@ object Api extends Controller with PanDomainAuthActions {
     )}
   }
 
+  def putStubCommissionedLength(stubId: Long) = CORSable(atomCorsAble) {
+    APIAuthAction.async { request =>
+      ApiResponseFt[Long](for {
+        json <- ApiUtils.readJsonFromRequestResponse(request.body)
+        status <- ApiUtils.extractDataResponse[Option[Int]](json)
+        id <- PrototypeAPI.updateContentCommissionedLength(stubId, status)
+      } yield id
+      )}
+  }
+
   def putStubStatusByComposerId(composerId: String) = CORSable(defaultCorsAble) {
     APIAuthAction.async { request =>
       ApiResponseFt[String](for {

--- a/common-lib/src/main/scala/com/gu/workflow/api/PrototypeAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/PrototypeAPI.scala
@@ -134,6 +134,13 @@ object PrototypeAPI {
       item <- extractDataResponse[Long](json)
     } yield item
 
+  def updateContentCommissionedLength(stubId: Long, commissionedLength: Option[Int]): ApiResponseFt[Long] =
+    for {
+      res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$stubId/commissionedLength", commissionedLength.asJson))
+      json <- parseBody(res.body)
+      item <- extractDataResponse[Long](json)
+    } yield item
+
   def updateContentStatusByComposerId(composerId: String, status: String): ApiResponseFt[String] =
     for {
       res <- ApiResponseFt.Async.Right(putRequest(s"content/$composerId/status", status.asJson))

--- a/conf/routes
+++ b/conf/routes
@@ -43,6 +43,7 @@ PUT            /api/stubs/:stubId/workingTitle             controllers.Api.putSt
 PUT            /api/stubs/:stubId/priority                 controllers.Api.putStubPriority(stubId: Long)
 PUT            /api/stubs/:stubId/trashed                  controllers.Api.putStubTrashed(stubId: Long)
 PUT            /api/stubs/:stubId/status                   controllers.Api.putStubStatus(stubId: Long)
+PUT            /api/stubs/:stubId/commissionedLength       controllers.Api.putStubCommissionedLength(stubId: Long)
 DELETE         /api/stubs/:stubId                          controllers.Api.deleteStub(stubId: Long)
 
 GET            /api/statuses                               controllers.Api.statusus

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -325,7 +325,9 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             };
 
             $scope.updateCommissionedLength = function (newValue) {
-                return wfComposerService.updateField($scope.contentItem.composerId, "commissionedLength", newValue)
+                updateField("commissionedLength", newValue);
+                if (newValue === "") return wfComposerService.deleteField($scope.contentItem.composerId, "commissionedLength");
+                else return wfComposerService.updateField($scope.contentItem.composerId, "commissionedLength", newValue)
             };
 
             /**

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -110,4 +110,15 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService) {
         return request(req);
     };
 
+    this.deleteField = function (composerId, fieldName, live = false) {
+        let urls = composerUpdateFieldUrl(fieldName, composerId);
+        let url = live ? urls.live : urls.preview;
+        let req = {
+            method: 'DELETE',
+            url: url,
+            withCredentials: true
+        };
+        return request(req);
+    };
+
 }


### PR DESCRIPTION
<!--Your pull request-->

This solves 2 issues:
- When commissioned length was deleted it was sent as an empty string `""` to composer which caused the content to become unstreamable meaning CAPI was loosing updates. We need to send a DELETE request instead.
- When the value is updated we should also save it in the workflow db.

Depends on: https://github.com/guardian/workflow/pull/1048

#### Editorial tools integration tests
The editorial tools integration tests live [here](https://circleci.com/gh/guardian/editorial-tools-integration-tests) and get run every time workflow-frontend is deployed to the CODE environment. You should run them before merging this change to master. The current status of the tests (based off the last thing which was deployed to CODE) is:
[![CircleCI](https://circleci.com/gh/guardian/editorial-tools-integration-tests.svg?style=svg&circle-token=9363dcf360b976f0beb7ec180ab00051c42910f2)](https://circleci.com/gh/guardian/editorial-tools-integration-tests)