### PR TITLE
Apply styles to broken date pickers

### DIFF
--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -2,7 +2,9 @@
 .drawer {
     display: flex;
     width: 100%;
-
+    * {
+        box-sizing: border-box;
+    }
     // viewport minus the sidebar
 
     &__warning {
@@ -67,6 +69,12 @@
         }
     }
 
+    &__section-data-row {
+        &--editable {
+            cursor: pointer;
+        }
+    }
+
 
     &__header {
         font-weight: bold;
@@ -123,6 +131,9 @@
         padding: 12px 0 0 12px;
         flex: 1 1 0;
         overflow: hidden;
+        &--with-overflow {
+            overflow: visible;
+        }
     }
 
     &__item {

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -352,8 +352,8 @@
                 </button>
 
                 <div class="drawer__inner" ng-class="{'drawer__inner--closed' : openSection !== 'management'}" >
-
-                    <ul class="drawer__column drawer__column--wide">
+                    <!-- We allow overflow here for the datepicker, which will otherwise be occluded by its container -->
+                    <ul class="drawer__column drawer__column--with-overflow drawer__column--wide">
                         <li class="drawer__item">
                             <p class="drawer__item-title">Priority</p>
                             <select ng-model="contentItem.priority" ng-options="p.value as p.name for p in contentList.priorities" wf-content-item-update-action="priority"></select>
@@ -364,7 +364,9 @@
                                 {{ (contentItem.item.due | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime) || 'Add deadline' }}
                             </span>
                             <form ng-show="dateTimeEdit" ng-submit="dateTimeEdit = false">
-                                <div wf-date-time-picker wf-update-on="enter" ng-model="currentDatePickerValue" wf-on-cancel="dateTimeEdit = false; revertDeadline()" wf-cancel-on="blur" wf-on-submit="updateDeadline(); dateTimeEdit = false;" wf-small="true" help-text="true"></div>
+                                <div class="form-group">
+                                    <div wf-date-time-picker wf-update-on="enter" ng-model="currentDatePickerValue" wf-on-cancel="dateTimeEdit = false; revertDeadline()" wf-cancel-on="blur" wf-on-submit="updateDeadline(); dateTimeEdit = false;" help-text="true"></div>
+                                </div>
                             </form>
                         </li>
                         <li class="drawer__item">

--- a/public/components/date-time-picker/_date-time-picker.scss
+++ b/public/components/date-time-picker/_date-time-picker.scss
@@ -1,3 +1,5 @@
+@import '~angular-bootstrap-datetimepicker/src/css/datetimepicker.css';
+
 .date-time-picker__help-text {
     font-size: 85%;
     font-weight: normal;

--- a/public/components/date-time-picker/date-time-picker.html
+++ b/public/components/date-time-picker/date-time-picker.html
@@ -1,5 +1,8 @@
-<label class="date-time-picker__label" for="{{dateTimePicker.textInputId}}" ng-if="label">{{ label }}
-    <span class="date-time-picker__help-text" ng-if="helpText">{{ helpText == 'true' && 'e.g. today 3pm, tomorrow 15:00, tuesday next week 18:00, 2014-08-14' || helpText }}</span></label>
+<label class="date-time-picker__label" for="{{dateTimePicker.textInputId}}" ng-if="label"
+    >{{ label }}
+    <span class="date-time-picker__help-text" ng-if="helpText">{{ helpText == 'true' && 'e.g. today 3pm, tomorrow 15:00, tuesday next week 18:00, 2014-08-14' || helpText }}</span>
+</label>
+<span class="date-time-picker__help-text" ng-if="!label && helpText">{{ helpText == 'true' && 'e.g. today 3pm, tomorrow 15:00, tuesday next week 18:00, 2014-08-14' || helpText }}</span>
 <div class="date-time-picker__group input-group">
 
     <input class="date-time-picker__text-input form-control" type="text" placeholder="{{ placeholderText }}" wf-date-time-field id="{{dateTimePicker.textInputId}}" name="due" wf-on-cancel="onCancel()" wf-on-update="onUpdate()" wf-on-submit="onSubmit()" wf-update-on="{{updateOn}}" wf-cancel-on="{{cancelOn}}" ng-class="{'input-sm': small}">

--- a/public/components/date-time-picker/date-time-picker.js
+++ b/public/components/date-time-picker/date-time-picker.js
@@ -18,7 +18,6 @@
 import angular from 'angular';
 import moment from 'moment';
 import 'angular-bootstrap-datetimepicker';
-import 'angular-bootstrap-datetimepicker/src/css/datetimepicker.css';
 
 // local dependencies
 import 'lib/date-service';


### PR DESCRIPTION
Re-adds a missing stylesheet to the date-time-picker components, which currently look a bit odd, and makes a few tweaks to present them more consistently.