### PR TITLE
Fix main media

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ The Angular frontend and associated Scala API for Workflow.
 
 ### Install
 
+You will need `workflow` and `capi` (API Gateway invocation) credentials from Janus.
+
 In order to run, workflow-frontend needs to talk to the CODE workflow datastore. It does this via an SSH tunnel to a 
 workflow-frontend CODE instance.
 
 - Make sure that you are running the right version of nodejs, (tested and working with v6.1.0). We recommend using [nvm](https://github.com/creationix/nvm) to easily manage multiple versions of node. With this you can use `nvm use` to switch to this version quickly.
 - Run the install script `./scripts/setup.sh`
-
-- In the `conf` folder copy `workflow-frontend-application.local-example.conf` into `workflow-frontend-application.local.conf` and edit it to replace *example.email@guardian.co.uk* by your Guardian email address.
-- Run the script `./scripts/setup-ssh-tunnel.sh` to set up an ssh tunnel to a CODE datastore instance. You will need [marauder]()
-    installed for this script to work. If the script fails, you could also run the command `ssh -f ubuntu@<WORKFLOW-FRONTEND-CODE-INSTANCE> -L 5002:$<DATASTORE-ELB>:80 -N`
+- Download the DEV config: `aws s3 cp s3://workflow-private/DEV/workflow-frontend/applications.defaults.conf conf/workflow-frontend-application.local.conf --profile workflow`
+- Run the script `./scripts/setup-ssh-tunnel.sh` to set up an ssh tunnel to a CODE datastore instance. You will need [ssm-scala](https://github.com/guardian/ssm-scala) installed for this script to work.
 - Run the `setup-app.rb` in the `dev-nginx` repo with the `nginx/nginx-mapping.yml` file in this repo
 
 ### Run

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -63,8 +63,6 @@ object Config extends AwsInstanceTags {
 
   lazy val googleTrackingId: String = config.getConfigStringOrFail("google.tracking.id")
 
-  lazy val appSecret: String = config.getConfigStringOrFail("application.secret")
-
   lazy val no2faUser: String = "composer.test@guardian.co.uk"
 
   lazy val editorialSupportDynamoTable: String = s"editorial-support-${if(stage != "PROD") { "CODE" } else { "PROD" }}"
@@ -74,15 +72,6 @@ object Config extends AwsInstanceTags {
 
   lazy val sessionId: String = UUID.randomUUID().toString
 
-  // logstash conf
-  private lazy val logStashHost: String = "ingest.logs.gutools.co.uk"
-  private lazy val logStashPort: Int = 6379
-  private lazy val logStashEnabled: Boolean = config.getConfigBooleanOrElse("logging.logstash.enabled", true)
-  lazy val logStashConf = LogStashConf(logStashHost, logStashPort, logStashEnabled)
-
   implicit val defaultExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
-
-  lazy val testMode: Boolean = config.getConfigBooleanOrElse("testMode", false)
-
 }

--- a/conf/application.ci.conf
+++ b/conf/application.ci.conf
@@ -26,7 +26,3 @@ presence {
 pandomain {
   domain = "localhost"
 }
-
-logging.logstash.enabled = false
-
-testMode=true

--- a/conf/workflow-frontend-application.local-example.conf
+++ b/conf/workflow-frontend-application.local-example.conf
@@ -1,8 +1,0 @@
-logging.logstash.enabled = false
-api.url="http://localhost:5002/api"
-
-application.admin.whitelist=[
-  "example.email@guardian.co.uk"
-]
-
-google.tracking.id=""

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -60,16 +60,16 @@
                     </ul>
 
                     <ul class="drawer__column">
-                        <li cng-class="{'drawer__section-mainmedia--nopreview': contentItem.mainMediaNoPreview}">
+                        <li cng-class="{'drawer__section-mainmedia--nopreview': capiData.mainMediaType != 'image'}">
                             <span class="drawer__item-title">Main media</span>
 
-                            <div ng-if="contentItem.mainMediaType == 'image'" class="drawer__image-container">
+                            <div ng-if="capiData.mainMediaType == 'image'" class="drawer__image-container">
                                 <img ng-src="{{ capiData.mainMediaUrl}}" class="drawer__image" alt=""/>
                             </div>
                             <div ng-if="contentItem.mainMediaNoPreview" class="drawer__section-image-container">
-                                {{contentItem.mainMediaType}}
+                                {{capiData.mainMediaType}}
                             </div>
-                            <div ng-if="!contentItem.mainMediaType" class="drawer__item-content drawer__item-content--empty">
+                            <div ng-if="!capiData.mainMediaType" class="drawer__item-content drawer__item-content--empty">
                                 None
                             </div>
                             </span>

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -101,9 +101,6 @@ function wfContentItemParser(config, statusLabels, sections) {
 
             this.hasMainMedia = !!(item.hasMainMedia)
 
-            // Currently we don't pull in any preview information about non-image main media
-            this.mainMediaNoPreview = this.mainMediaType && this.mainMediaType !== 'image';
-
             this.trailtext = stripHtml(item.trailtext);
             this.trailImageUrl = item.trailImageUrl;
 

--- a/public/lib/capi-content-service.js
+++ b/public/lib/capi-content-service.js
@@ -29,6 +29,7 @@ function wfCapiContentService($http, $q, wfAtomService) {
             const smallest = getSmallestAsset(mainElements[0].assets);
             if (smallest) {
                 return {
+                    type: mainElements[0].type,
                     url: smallest.file,
                     caption: smallest.typeData.caption,
                     altText: smallest.typeData.altText
@@ -71,6 +72,7 @@ function wfCapiContentService($http, $q, wfAtomService) {
         return {
             headline: "Unknown",
             standfirst: "Unknown",
+            mainMediaType: "",
             mainMediaUrl: "",
             mainMediaCaption: "Unknown",
             mainMediaAltText: "Unknown",
@@ -97,6 +99,7 @@ function wfCapiContentService($http, $q, wfAtomService) {
             return Promise.resolve({
                 headline: fields.headline ? fields.headline : "",
                 standfirst: fields.standfirst ? fields.standfirst : "",
+                mainMediaType: mainMedia ? mainMedia.type : "",
                 mainMediaUrl: mainMedia ? mainMedia.url : "",
                 mainMediaCaption: mainMedia ? mainMedia.caption : "",
                 mainMediaAltText: mainMedia ? mainMedia.altText : "",


### PR DESCRIPTION
The work to simplify the Workflow backend and get some fields from CAPI instead (#36) unfortunately broke the main media preview.

I've fixed this by recreating the old fields from the CAPI data. I've also updated the install instructions that were missing the new credentials and IAM role required to access CAPI when in DEV (post #125).

![613f5d412a025dd8b11443cbcaec7d00](https://user-images.githubusercontent.com/395805/41903588-37addfea-792e-11e8-9e25-24394de388d0.png)
