### PR TITLE
rename Atoms in the "create new" dropdown

### DIFF
--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -22,7 +22,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         "gallery": "Gallery",
                         "interactive": "Interactive",
                         "picture": "Picture",
-                        'atom': 'Atom'
+                        "atom": "Video/Atom"
                     });
                 };
 


### PR DESCRIPTION
We've received the following request:

> Using the "Create new Atom" function in Workflow creates a video atom. This has led to confusion as people expect it to go to the Atom menu from where you can choose timeline/quick guide etc.
> 
> Could this be renamed "Create Video Atom" or better link to the Atom dashboard?

Ultimately, we probably want to link to https://atomworkshop.code.dev-gutools.co.uk/create and get rid of this form or allow more atoms to be created without leaving workflow. This is just a quick fix until we have time to properly investigate.
Before:
<img width="125" alt="screen shot 2018-08-07 at 12 27 21" src="https://user-images.githubusercontent.com/5154737/43773317-4284b27e-9a3d-11e8-82eb-6986c401489d.png">

After:
<img width="115" alt="screen shot 2018-08-07 at 12 25 37" src="https://user-images.githubusercontent.com/5154737/43773264-180e0d56-9a3d-11e8-9c20-8e8ba6cf6640.png">
