### PR TITLE
Delete subscriptions

### DIFF
--- a/app/views/subscriptions.scala.html
+++ b/app/views/subscriptions.scala.html
@@ -1,0 +1,19 @@
+@(subscriptions: List[Subscription])
+
+@layout("Notifications") {
+    <div class="admin">
+        <ul class="support-list">
+            @for(sub <- subscriptions) {
+                <li class="support-list-item">
+                    <form method="POST">
+                        <input type="hidden" name="id" value="@Subscription.id(sub)" />
+                        @Subscription.humanReadable(sub.query)
+                        <div class="support-admin-button-container">
+                            <input type="submit" class="btn btn-sm btn-info" value="Delete" />
+                        </div>
+                    </form>
+                </li>
+            }
+        </ul>
+    </div>
+}

--- a/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
@@ -22,8 +22,8 @@ class SubscriptionsAPI(stage: String, webPushPublicKey: String, webPushPrivateKe
     subscription
   }
 
-  def delete(sub: Subscription): Unit = {
-    table.deleteItem("id", Subscription.id(sub.endpoint))
+  def delete(id: String): Unit = {
+    table.deleteItem("id", id)
   }
 
   def getAll(): Iterable[Subscription] = {

--- a/common-lib/src/main/scala/models/Subscription.scala
+++ b/common-lib/src/main/scala/models/Subscription.scala
@@ -10,14 +10,18 @@ import io.circe.parser.decode
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 
+import play.api.data.Forms._
+import play.api.data._
+
 case class SubscriptionKeys(p256dh: String, auth: String)
 case class SubscriptionEndpoint(endpoint: String, keys: SubscriptionKeys)
 // seenIds is optional as it encodes three states:
 //   None          -> we have not seen any content under the given query yet so don't fire notifications
 //   Some(Nil)     -> we last saw no content matching the query
 //   Some(content) -> the content we saw last (ie do a diff and fire notifications)
-case class Subscription(query: Subscription.Query, seenIds: Option[Set[Long]], endpoint: SubscriptionEndpoint)
+case class Subscription(email: String, query: Subscription.Query, seenIds: Option[Set[Long]], endpoint: SubscriptionEndpoint)
 case class SubscriptionUpdate(title: String, body: String, url: Option[String])
+case class DeleteSubscription(id: String)
 
 object Subscription {
   implicit val customConfig: Configuration = Configuration.default.withDefaults
@@ -36,18 +40,37 @@ object Subscription {
 
   type Query = Map[String, Seq[String]]
 
-  def id(endpoint: SubscriptionEndpoint): String = {
+  val form = Form(
+    mapping("id" -> text)
+    (DeleteSubscription.apply)(DeleteSubscription.unapply)
+  )
+
+  def id(sub: Subscription): String = {
     val hasher = Hashing.md5().newHasher()
-    hasher.putString(endpoint.endpoint, StandardCharsets.UTF_8)
-    hasher.putString(endpoint.keys.p256dh, StandardCharsets.UTF_8)
-    hasher.putString(endpoint.keys.auth, StandardCharsets.UTF_8)
+
+    // Sort for stable iteration order to ensure consistent hash
+    val params = sub.query.toList.flatMap { case(k, v) => v.map(k -> _) }.sorted
+    params.foreach { case(k, v) =>
+      hasher.putString(k, StandardCharsets.UTF_8)
+      hasher.putString(v, StandardCharsets.UTF_8)
+    }
+
+    hasher.putString(sub.endpoint.endpoint, StandardCharsets.UTF_8)
+    hasher.putString(sub.endpoint.keys.p256dh, StandardCharsets.UTF_8)
+    hasher.putString(sub.endpoint.keys.auth, StandardCharsets.UTF_8)
 
     hasher.hash().toString
   }
 
+  def humanReadable(query: Query): String = {
+    (query - "email").map { case(k, v) =>
+      s"$k: ${v.mkString(", ")}"
+    }.mkString(" and ")
+  }
+
   def toItem(sub: Subscription): Item =
     Item.fromJSON(sub.asJson.toString())
-      .withString("id", id(sub.endpoint))
+      .withString("id", id(sub))
 
   def fromItem(item: Item): Subscription =
     decode[Subscription](item.toJSON).right.get

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,8 @@ GET            /dashboard                                  controllers.Applicati
 GET            /about                                      controllers.Assets.at(path="/public", file="/static/about.html")
 GET            /editorialSupport                           controllers.Application.editorialSupport
 POST           /editorialSupport                           controllers.Application.updateEditorialSupport
+GET            /subscriptions                              controllers.Notifications.subscriptions
+POST           /subscriptions                              controllers.Notifications.deleteSubscription
 GET            /faqs                                       controllers.Application.faqs
 GET            /troubleshooting                            controllers.Application.troubleshooting
 GET            /training                                   controllers.Application.training

--- a/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
@@ -118,7 +118,7 @@ class Notifier(stage: String, override val secret: String, subsApi: Subscription
       } catch {
         case NonFatal(e) =>
           Logger.error(s"Error sending notification to ${sub.endpoint}. Removing subscription", e)
-          subsApi.delete(sub)
+          subsApi.delete(Subscription.id(sub))
       }
     }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,3 +22,6 @@ addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.2")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+

--- a/public/layouts/dashboard/dashboard-create.js
+++ b/public/layouts/dashboard/dashboard-create.js
@@ -20,9 +20,16 @@ angular
         };
 
         $scope.subscriptionsSupported = subscriptionsSupported();
+        $scope.subscriptionStatus = null;
+
         $scope.registerSubscription = () => {
-            // TODO MRB: show spinner and success or similar
-            registerSubscription();
+            $scope.subscriptionStatus = "Subscribing...";
+
+            registerSubscription().then(() => {
+                $scope.subscriptionStatus = "Subscribed!";
+            }).catch((err) => {
+                $scope.subscriptionStatus = null;
+            });
         };
     }])
     .directive('wfDropdownToggle', ['$document', function($document){

--- a/public/layouts/dashboard/dashboard-user.html
+++ b/public/layouts/dashboard/dashboard-user.html
@@ -34,7 +34,7 @@
         </li>
 
         <li class="dropdown-toolbar__item" ng-if="subscriptionsSupported">
-            <span class="dropdown-toolbar__item-label" href="#" ng-click="registerSubscription()" ng-if="subscriptionStatus">
+            <span class="dropdown-toolbar__item-label" href="#" ng-if="subscriptionStatus">
                 <span class="dropdown-toolbar__item-title" title="{{subscriptionStatus}}">
                     {{subscriptionStatus}}
                 </span>

--- a/public/layouts/dashboard/dashboard-user.html
+++ b/public/layouts/dashboard/dashboard-user.html
@@ -34,8 +34,21 @@
         </li>
 
         <li class="dropdown-toolbar__item" ng-if="subscriptionsSupported">
-            <a class="dropdown-toolbar__item-label" href="#" ng-click="registerSubscription()">
-                <span class="dropdown-toolbar__item-title" title="">Subscribe to this page</span>
+            <span class="dropdown-toolbar__item-label" href="#" ng-click="registerSubscription()" ng-if="subscriptionStatus">
+                <span class="dropdown-toolbar__item-title" title="{{subscriptionStatus}}">
+                    {{subscriptionStatus}}
+                </span>
+            </span>
+            <a class="dropdown-toolbar__item-label" href="#" ng-click="registerSubscription()" ng-if="!subscriptionStatus">
+                <span class="dropdown-toolbar__item-title" title="Subscribe to this page" >
+                    Subscribe to this page
+                </span>
+            </a>
+        </li>
+
+        <li class="dropdown-toolbar__item" ng-if="subscriptionsSupported">
+            <a class="dropdown-toolbar__item-label" href="/subscriptions" target="_blank">
+                <span class="dropdown-toolbar__item-title" title="Manage and remove subscriptions">Manage Subscriptions</span>
             </a>
         </li>
 

--- a/public/lib/notifications.js
+++ b/public/lib/notifications.js
@@ -19,9 +19,9 @@ export function registerServiceWorker() {
 
 export function registerSubscription() {
     // TODO MRB: handle service worker not being registered yet (disable button?)
-    navigator.serviceWorker.getRegistration(serviceWorkerURL).then(({ pushManager }) => {
+    return navigator.serviceWorker.getRegistration(serviceWorkerURL).then(({ pushManager }) => {
         return getBrowserSubscription(pushManager).then((sub) => {
-            saveSubscription(sub, window.location.search);
+            return saveSubscription(sub, window.location.search);
         });
     }).catch(err => {
         console.error("Unable to register subscription", err);
@@ -46,16 +46,17 @@ function getBrowserSubscription(pushManager) {
 }
 
 function saveSubscription(sub, query) {
-    fetch("/api/notifications" + query, {
+    return fetch("/api/notifications" + query, {
         method: "POST",
         body: JSON.stringify(sub),
         headers: { "Content-Type": "application/json" },
         credentials: "include"
     }).then(( { status }) => {
         if(status == 200) {
-            console.log("Saved notification subscription to server")
+            console.log("Saved notification subscription to server");
+            return true;
         } else {
-            throw new Error(`Status ${status}`)   
+            throw new Error(`Status ${status}`);
         }
     }).catch((err) => {
         console.error("Unable to save notification subscription to server", err);


### PR DESCRIPTION
A page to delete existing subscriptions. This is the minimum UI needed to send it out for a PoC amongst some users:

![e5a6e1c889a17f7cd57946d12d8e1ac4](https://user-images.githubusercontent.com/395805/46345055-1277a080-c63b-11e8-9599-8c84a50972df.gif)

There's also feedback on the button when you click subscribe:

![51ba7861894a721f0a4c809072a7f3cf](https://user-images.githubusercontent.com/395805/46345068-1c010880-c63b-11e8-8ae8-80aa51b33d0c.png)

I've also fixed a problem where users could only subscribe to one query at once. This was because we were only hashing the endpoint to construct the subscription ID. Now we hash both the endpoint and query. This means users cannot create duplicate subscriptions.
