### PR TITLE
Fire notifications when status changes

### DIFF
--- a/app/controllers/Notifications.scala
+++ b/app/controllers/Notifications.scala
@@ -4,7 +4,7 @@ import com.gu.pandomainauth.model.User
 import com.gu.workflow.api.{ApiUtils, SubscriptionsAPI}
 import config.Config
 import models.api.ApiResponseFt
-import models.{Subscription, SubscriptionEndpoint}
+import models.{Subscription, SubscriptionEndpoint, SubscriptionSchedule}
 import play.api.mvc.Controller
 
 object Notifications extends Controller with PanDomainAuthActions {
@@ -18,13 +18,22 @@ object Notifications extends Controller with PanDomainAuthActions {
     Ok(views.html.subscriptions(subs.toList))
   }
 
-  def deleteSubscription = AuthAction(parse.form(Subscription.form)) { request =>
-    val id = request.body.id
+  def updateSubscription = AuthAction(parse.form(Subscription.form)) { request =>
+    val (id, enabled, delete) = request.body
 
-    subsApi.delete(id)
+    if(delete.contains(true)) {
+      val updated = deleteSub(id, request.user)
+      Ok(views.html.subscriptions(updated.toList))
+    } else {
+      subsApi.get(id) match {
+        case Some(before) =>
+          val updated = updateSub(id, enabled, before, request.user)
+          Ok(views.html.subscriptions(updated.toList))
 
-    val updated = getUserSubs(request.user).filterNot { s => Subscription.id(s) == id }
-    Ok(views.html.subscriptions(updated.toList))
+        case None =>
+          NotFound(s"Subscription $id does not exist")
+      }
+    }
   }
 
   def addSubscription = APIAuthAction.async { request =>
@@ -35,10 +44,26 @@ object Notifications extends Controller with PanDomainAuthActions {
       json <- ApiUtils.readJsonFromRequestResponse(request.body)
 
       endpoint <- ApiUtils.extractResponse[SubscriptionEndpoint](json)
-      sub = Subscription(request.user.email, userAgent, qs, endpoint, runtime = None)
+      sub = Subscription(request.user.email, userAgent, qs, endpoint,
+        schedule = SubscriptionSchedule(enabled = true), runtime = None)
 
       _ <- ApiResponseFt.Right(subsApi.put(sub))
     } yield "Done")
+  }
+
+  private def updateSub(id: String, enabled: Boolean, before: Subscription, user: User): Iterable[Subscription] = {
+    val after = before.copy(schedule = before.schedule.copy(enabled = enabled))
+    subsApi.put(after)
+
+    getUserSubs(user).map {
+      case sub if Subscription.id(sub) == id => after
+      case sub => sub
+    }
+  }
+
+  private def deleteSub(id: String, user: User): Iterable[Subscription] = {
+    subsApi.delete(id)
+    getUserSubs(user).filterNot { s => Subscription.id(s) == id }
   }
 
   private def getUserSubs(user: User): Iterable[Subscription] = {

--- a/app/controllers/Notifications.scala
+++ b/app/controllers/Notifications.scala
@@ -29,12 +29,13 @@ object Notifications extends Controller with PanDomainAuthActions {
 
   def addSubscription = APIAuthAction.async { request =>
     val qs: Map[String, Seq[String]] = Api.queryString(request)
+    val userAgent = request.headers.get("User-Agent").getOrElse("unknown")
 
     ApiResponseFt[String](for {
       json <- ApiUtils.readJsonFromRequestResponse(request.body)
 
       endpoint <- ApiUtils.extractResponse[SubscriptionEndpoint](json)
-      sub = Subscription(request.user.email, qs, None, endpoint)
+      sub = Subscription(request.user.email, userAgent, qs, endpoint, runtime = None)
 
       _ <- ApiResponseFt.Right(subsApi.put(sub))
     } yield "Done")

--- a/app/views/subscriptions.scala.html
+++ b/app/views/subscriptions.scala.html
@@ -1,24 +1,40 @@
 @(subscriptions: List[Subscription])
 
+@import helper._
+
 @layout("Notifications") {
     <div class="admin">
         <ul class="support-list">
             @for(sub <- subscriptions) {
                 <li class="support-list-item">
-                    <form method="POST">
-                        <input type="hidden" name="id" value="@Subscription.id(sub)" />
-                        <p>
-                            @Subscription.humanReadable(sub.query)
-                        </p>
-                        <p>
-                            <small>
-                                @sub.userAgent
-                            </small>
-                        </p>
-                        <div class="support-admin-button-container">
+                    <p>
+                        @Subscription.humanReadable(sub.query)
+                    </p>
+                    <p>
+                        <small>
+                        @sub.userAgent
+                        </small>
+                    </p>
+                    <div class="support-admin-button-container">
+                        @if(sub.schedule.enabled) {
+                            @form(action = routes.Notifications.updateSubscription) {
+                                <input type="hidden" name="enabled" value="false" />
+                                <input type="hidden" name="id" value="@Subscription.id(sub)" />
+                                <input type="submit" class="btn btn-sm" value="Disable" />
+                            }
+                        } else {
+                            @form(action = routes.Notifications.updateSubscription) {
+                                <input type="hidden" name="enabled" value="true" />
+                                <input type="hidden" name="id" value="@Subscription.id(sub)" />
+                                <input type="submit" class="btn btn-sm btn-info" value="Enable" />
+                            }
+                        }
+                        @form(action = routes.Notifications.updateSubscription) {
+                            <input type="hidden" name="delete" value="true" />
+                            <input type="hidden" name="id" value="@Subscription.id(sub)" />
                             <input type="submit" class="btn btn-sm btn-info" value="Delete" />
-                        </div>
-                    </form>
+                        }
+                    </div>
                 </li>
             }
         </ul>

--- a/app/views/subscriptions.scala.html
+++ b/app/views/subscriptions.scala.html
@@ -7,7 +7,14 @@
                 <li class="support-list-item">
                     <form method="POST">
                         <input type="hidden" name="id" value="@Subscription.id(sub)" />
-                        @Subscription.humanReadable(sub.query)
+                        <p>
+                            @Subscription.humanReadable(sub.query)
+                        </p>
+                        <p>
+                            <small>
+                                @sub.userAgent
+                            </small>
+                        </p>
                         <div class="support-admin-button-container">
                             <input type="submit" class="btn btn-sm btn-info" value="Delete" />
                         </div>

--- a/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
@@ -6,6 +6,7 @@ import com.gu.workflow.util.Dynamo
 import io.circe.syntax._
 import models.{Subscription, SubscriptionEndpoint, SubscriptionUpdate}
 import nl.martijndwars.webpush.{Notification, PushService}
+import play.api.Logger
 
 import scala.collection.JavaConverters._
 
@@ -37,7 +38,10 @@ class SubscriptionsAPI(stage: String, webPushPublicKey: String, webPushPrivateKe
     val payload = json.getBytes(StandardCharsets.UTF_8)
 
     val notification = new Notification(endpoint.endpoint, endpoint.keys.p256dh, endpoint.keys.auth, payload)
+    val resp = pushService.send(notification)
 
-    pushService.send(notification)
+    if(resp.getStatusLine.getStatusCode != 201) {
+      Logger.error(s"Error sending notification. ${resp.getStatusLine.getStatusCode}. Endpoint: $endpoint")
+    }
   }
 }

--- a/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
@@ -16,6 +16,10 @@ class SubscriptionsAPI(stage: String, webPushPublicKey: String, webPushPrivateKe
 
   private val pushService = new PushService(webPushPublicKey, webPushPrivateKey, "mailto:digitalcms.bugs@guardian.co.uk")
 
+  def get(id: String): Option[Subscription] = {
+    Option(table.getItem("id", id)).map(Subscription.fromItem)
+  }
+
   def put(subscription: Subscription): Subscription = {
     val item = Subscription.toItem(subscription)
 

--- a/common-lib/src/main/scala/models/Subscription.scala
+++ b/common-lib/src/main/scala/models/Subscription.scala
@@ -13,14 +13,22 @@ import io.circe.{Decoder, Encoder}
 import play.api.data.Forms._
 import play.api.data._
 
+// These are the details provided by the browser as registered to the service worker
 case class SubscriptionKeys(p256dh: String, auth: String)
 case class SubscriptionEndpoint(endpoint: String, keys: SubscriptionKeys)
-// seenIds is optional as it encodes three states:
-//   None          -> we have not seen any content under the given query yet so don't fire notifications
-//   Some(Nil)     -> we last saw no content matching the query
-//   Some(content) -> the content we saw last (ie do a diff and fire notifications)
-case class Subscription(email: String, query: Subscription.Query, seenIds: Option[Set[Long]], endpoint: SubscriptionEndpoint)
+
+// runtime is optional as it encodes three states:
+//   None            -> we have not seen any content under the given query yet so don't fire notifications
+//   Some(Map.empty) -> we last saw no content matching the query
+//   Some(content)   -> the content we saw last and the status it was in (ie do a diff and fire notifications)
+case class Subscription(email: String, userAgent: String, query: Subscription.Query, endpoint: SubscriptionEndpoint,
+                        runtime: Option[SubscriptionRuntime])
+
+case class SubscriptionRuntime(seenIds: Map[Long, Status])
+
+// The actual contents of a notification fired and sent to the service worker to actually display on the users machine
 case class SubscriptionUpdate(title: String, body: String, url: Option[String])
+
 case class DeleteSubscription(id: String)
 
 object Subscription {
@@ -31,6 +39,9 @@ object Subscription {
 
   implicit val endpointEncoder: Encoder[SubscriptionEndpoint] = deriveEncoder
   implicit val endpointDecoder: Decoder[SubscriptionEndpoint] = deriveDecoder
+
+  implicit val runtimeEncoder: Encoder[SubscriptionRuntime] = deriveEncoder
+  implicit val runtimeDecoder: Decoder[SubscriptionRuntime] = deriveDecoder
 
   implicit val updateEncoder: Encoder[SubscriptionUpdate] = deriveEncoder
   implicit val updateDecoder: Decoder[SubscriptionUpdate] = deriveDecoder

--- a/conf/routes
+++ b/conf/routes
@@ -13,7 +13,7 @@ GET            /dashboard                                  controllers.Applicati
 GET            /editorialSupport                           controllers.Application.editorialSupport
 POST           /editorialSupport                           controllers.Application.updateEditorialSupport
 GET            /subscriptions                              controllers.Notifications.subscriptions
-POST           /subscriptions                              controllers.Notifications.deleteSubscription
+POST           /subscriptions                              controllers.Notifications.updateSubscription
 GET            /faqs                                       controllers.Application.faqs
 GET            /troubleshooting                            controllers.Application.troubleshooting
 GET            /training                                   controllers.Application.training

--- a/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
@@ -44,11 +44,14 @@ class Notifier(stage: String, override val secret: String, subsApi: Subscription
       oldSeenIds match {
         case Some(existingSeenIds) =>
           val toNotify = calculateToNotify(existingSeenIds, newSeenIds, stubs)
+          Logger.info(s"Previously seen $existingSeenIds. Now seen $newSeenIds")
 
           if (toNotify.isEmpty) {
-            Logger.info(s"Previously seen $existingSeenIds. Now seen $newSeenIds. Not sending any notifications")
+            Logger.info("Not sending any notifications")
+          } else if(!sub.schedule.enabled) {
+            Logger.info("Not sending any notifications as subscription is disabled")
           } else {
-            Logger.info(s"Previously seen $existingSeenIds. Now seen $newSeenIds. Sending notifications for ${toNotify.map(_._2.id)}")
+            Logger.info(s"Sending notifications for ${toNotify.map(_._2.id)}")
 
             notify(toNotify, sub, newSeenIds)
           }

--- a/public/layouts/dashboard/dashboard-create.js
+++ b/public/layouts/dashboard/dashboard-create.js
@@ -7,7 +7,7 @@ import './dashboard-create.html';
 
 angular
     .module('wfDashboardCreate', ['wfContentService'])
-    .controller('wfDashboardCreateController', ['$scope', 'wfContentService', function ($scope, contentService) {
+    .controller('wfDashboardCreateController', ['$scope', '$rootScope', 'wfContentService', function ($scope, $rootScope, contentService) {
         contentService.getTypes().then( (types) => {
             $scope.options = types;
         });
@@ -31,6 +31,11 @@ angular
                 $scope.subscriptionStatus = null;
             });
         };
+
+        // Mild hack to allow subscribing again if the filters change.
+        $rootScope.$on("getContent", () => {
+            $scope.subscriptionStatus = null;
+        });
     }])
     .directive('wfDropdownToggle', ['$document', function($document){
         return {


### PR DESCRIPTION
Notifications previously only fired when something entered a view. After this PR they fire whenever anything in the view changes status as well. This means people can cover both "Subs" and "Production Editor" in a single subscription.

You can also enable/disable subscriptions. This will help people avoid spam over weekends/days off as well as have different subscriptions when they are working on different desks.

Finally I fixed a small frontend bug where the "Subscribed!" text would stay until you reloaded the page, even if you changed the filters to subscribe to something else.

NB: this is a breaking database change. I will manually migrate over existing subscriptions.