### PR TITLE
More obvious button colours

### DIFF
--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -242,6 +242,44 @@
             &:not(:last-child) {
                 border-right: 1px solid $c-grey-200;
             }
+
+            &--discreet {
+                &:hover {
+                    background-color: $c-grey-400;
+                }
+            }
+
+            &--action {
+                background-color: $c-highlight-blue;
+
+                &:hover {
+                    background-color: darken($c-highlight-blue, 10%);
+                }
+            }
+
+            &--danger {
+                background-color: $c-red;
+
+                &:hover {
+                    background-color: darken($c-red, 10%);
+                }
+            }
+
+            &--action, &--danger {
+                color: white;
+
+                a {
+                    color: white;
+
+                    &:hover {
+                        color: white;
+                    }
+                }
+
+                .drawer__icon svg {
+                    fill: white;
+                }
+            }
         }
 
         &-icon {

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -523,32 +523,32 @@
 
         <div class="drawer__toolbar">
 
-            <span class="drawer__toolbar-item" ng-class="{'drawer__control--confirm': awaitingDeleteConfirmation}" ng-click="deleteContentItem(!contentItem.item.trashed)" title="{{ contentItem.item.trashed ? 'Restore' : 'Trash' }}" ng-class="{'drawer__control-item--restore': contentItem.item.trashed}">
+            <span class="drawer__toolbar-item drawer__toolbar-item--danger" ng-class="{'drawer__control--confirm': awaitingDeleteConfirmation}" ng-click="deleteContentItem(!contentItem.item.trashed)" title="{{ contentItem.item.trashed ? 'Restore' : 'Trash' }}" ng-class="{'drawer__control-item--restore': contentItem.item.trashed}">
                 <i ng-if="!contentItem.item.trashed" class="drawer__icon drawer__toolbar-icon" wf-icon="delete"></i>
                 {{ contentItem.item.trashed ? 'Restore' : 'Trash' }}
             </span>
             <div class="drawer__toolbar-item drawer__toolbar-item--spacer">
                 &nbsp;
             </div>
-            <span class="drawer__toolbar-item">
+            <span class="drawer__toolbar-item drawer__toolbar-item--action">
                 <a href="{{ composerRestorerUrl }}" target="_blank" class="drawer__item-content" title="View versions">
                     <i class="drawer__icon drawer__toolbar-icon" wf-icon="view-versions"></i>
                     View versions
                 </a>
             </span>
-            <span class="drawer__toolbar-item">
+            <span class="drawer__toolbar-item drawer__toolbar-item--action">
                 <a href="{{ indesignExportUrl }}" class="drawer__item-content" title="{{ contentItem.linkedWithIncopy ? 'Resend' : 'Send' }} to InDesign">
                     <i class="drawer__icon drawer__toolbar-icon" wf-icon="indesign"></i>
                     {{ contentItem.linkedWithIncopy ? "Resend" : "Send" }} to InDesign
                 </a>
             </span>
-            <span class="drawer__toolbar-item">
+            <span class="drawer__toolbar-item drawer__toolbar-item--action">
                 <a href="{{ incopyExportUrl }}" class="drawer__item-content" title="{{ contentItem.linkedWithIncopy ? 'Resend' : 'Send' }} to InCopy">
                     <i class="drawer__icon drawer__toolbar-icon" wf-icon="incopy"></i>
                     {{ contentItem.linkedWithIncopy ? "Resend" : "Send" }} to InCopy
                 </a>
             </span>
-            <span class="drawer__toolbar-item" ng-click="contentListDrawerController.hide()" title="Close details">
+            <span class="drawer__toolbar-item drawer__toolbar-item--discreet" ng-click="contentListDrawerController.hide()" title="Close details">
                 <i class="drawer__icon drawer__toolbar-icon" wf-icon="cross"></i>
                 Close details
             </span>


### PR DESCRIPTION
![workflow-buttons](https://user-images.githubusercontent.com/1652187/48631880-72da5b80-e9b7-11e8-82ac-2eda321488b8.gif)

Simple PR to update button colours to make them more obvious: https://trello.com/c/E9dtVIhO/557-make-buttons-to-send-to-incopy-and-indesign-from-workflow-more-obvious