### PR TITLE
WIP: Phrase subscriptions

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,12 +1,15 @@
+import java.security.Security
+
 import config.Config
 import lib.{LogConfig, LoggingFilter, RedirectToHTTPSFilter}
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import play.api.mvc.WithFilters
 import play.api.{Application, GlobalSettings}
 import play.filters.gzip.GzipFilter
 
 object Global extends WithFilters(RedirectToHTTPSFilter, new GzipFilter, LoggingFilter) with GlobalSettings {
   override def beforeStart(app: Application) {
-
     LogConfig.init(Config.sessionId)
+    Security.addProvider(new BouncyCastleProvider())
   }
 }

--- a/app/views/subscriptions.scala.html
+++ b/app/views/subscriptions.scala.html
@@ -37,6 +37,15 @@
                     </div>
                 </li>
             }
+
+            <form id="add-word-form">
+                <li class="support-list-item">
+                    <p>Add phrase</p>
+                    <input type="text" placeholder="eg Robert Maxwell" required />
+                    <input type="submit" value="Add" />
+                </li>
+            </form>
         </ul>
     </div>
+    <script src="@routes.Assets.versioned("build/subs.bundle.js")"></script>
 }

--- a/common-lib/src/main/scala/models/Subscription.scala
+++ b/common-lib/src/main/scala/models/Subscription.scala
@@ -8,23 +8,24 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.parser.decode
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, ObjectEncoder}
 import play.api.data.Forms._
 import play.api.data._
-import play.api.data.format.Formatter
 
 // These are the details provided by the browser as registered to the service worker
 case class SubscriptionKeys(p256dh: String, auth: String)
 case class SubscriptionEndpoint(endpoint: String, keys: SubscriptionKeys)
 
-// runtime is optional as it encodes three states:
+case class Subscription(email: String, userAgent: String, query: SubscriptionQuery, endpoint: SubscriptionEndpoint, schedule: SubscriptionSchedule)
+
+sealed trait SubscriptionQuery
+// seenIds is optional as it encodes three states:
 //   None            -> we have not seen any content under the given query yet so don't fire notifications
 //   Some(Map.empty) -> we last saw no content matching the query
 //   Some(content)   -> the content we saw last and the status it was in (ie do a diff and fire notifications)
-case class Subscription(email: String, userAgent: String, query: Subscription.Query, endpoint: SubscriptionEndpoint,
-                        schedule: SubscriptionSchedule, runtime: Option[SubscriptionRuntime])
+case class WorkflowQuery(query: Map[String, Seq[String]], seenIds: Option[Map[Long, Status]]) extends SubscriptionQuery
+case class PhraseQuery(word: String, seenInContent: Map[String, Long]) extends SubscriptionQuery
 
-case class SubscriptionRuntime(seenIds: Map[Long, Status])
 case class SubscriptionSchedule(enabled: Boolean)
 
 // The actual contents of a notification fired and sent to the service worker to actually display on the users machine
@@ -39,19 +40,34 @@ object Subscription {
   implicit val endpointEncoder: Encoder[SubscriptionEndpoint] = deriveEncoder
   implicit val endpointDecoder: Decoder[SubscriptionEndpoint] = deriveDecoder
 
-  implicit val runtimeEncoder: Encoder[SubscriptionRuntime] = deriveEncoder
-  implicit val runtimeDecoder: Decoder[SubscriptionRuntime] = deriveDecoder
-
   implicit val scheduleEncoder: Encoder[SubscriptionSchedule] = deriveEncoder
   implicit val scheduleDecoder: Decoder[SubscriptionSchedule] = deriveDecoder
 
   implicit val updateEncoder: Encoder[SubscriptionUpdate] = deriveEncoder
   implicit val updateDecoder: Decoder[SubscriptionUpdate] = deriveDecoder
 
+  implicit val workflowQueryEncoder: ObjectEncoder[WorkflowQuery] = deriveEncoder
+  implicit val workflowQueryDecoder: Decoder[WorkflowQuery] = deriveDecoder
+
+  implicit val wordQueryEncoder: ObjectEncoder[PhraseQuery] = deriveEncoder
+  implicit val wordQueryDecoder: Decoder[PhraseQuery] = deriveDecoder
+
+  implicit val subscriptionQueryEncoder: ObjectEncoder[SubscriptionQuery] = ObjectEncoder.instance {
+    case q: WorkflowQuery => q.asJsonObject.add("type", "workflow".asJson)
+    case q: PhraseQuery => q.asJsonObject.add("type", "phrase".asJson)
+  }
+
+  implicit val subscriptionQueryDecoder: Decoder[SubscriptionQuery] = for {
+    tpe <- Decoder[String].prepare(_.downField("type"))
+    ret <- tpe match {
+      case "workflow" => Decoder[WorkflowQuery]
+      case "phrase" => Decoder[PhraseQuery]
+      case other => Decoder.failedWithMessage(s"Invalid query type $other")
+    }
+  } yield ret
+
   implicit val encoder: Encoder[Subscription] = deriveEncoder
   implicit val decoder: Decoder[Subscription] = deriveDecoder
-
-  type Query = Map[String, Seq[String]]
 
   val form = Form(
     tuple(
@@ -64,9 +80,13 @@ object Subscription {
   def id(sub: Subscription): String = {
     val hasher = Hashing.md5().newHasher()
 
+    val params = sub.query match {
+      case WorkflowQuery(q, _) => q.toList.flatMap { case(k, v) => v.map(k -> _) }
+      case PhraseQuery(w, _) => List(w -> w)
+    }
+
     // Sort for stable iteration order to ensure consistent hash
-    val params = sub.query.toList.flatMap { case(k, v) => v.map(k -> _) }.sorted
-    params.foreach { case(k, v) =>
+    params.sorted.foreach { case(k, v) =>
       hasher.putString(k, StandardCharsets.UTF_8)
       hasher.putString(v, StandardCharsets.UTF_8)
     }
@@ -78,10 +98,14 @@ object Subscription {
     hasher.hash().toString
   }
 
-  def humanReadable(query: Query): String = {
-    (query - "email").map { case(k, v) =>
-      s"$k: ${v.mkString(", ")}"
-    }.mkString(" and ")
+  def humanReadable(query: SubscriptionQuery): String = query match {
+    case WorkflowQuery(params, _) =>
+      (params - "email").map { case(k, v) =>
+        s"$k: ${v.mkString(", ")}"
+      }.mkString(" and ")
+
+    case PhraseQuery(phrase, _) =>
+      s"""phrase: "$phrase""""
   }
 
   def toItem(sub: Subscription): Item =

--- a/conf/webpack.conf.js
+++ b/conf/webpack.conf.js
@@ -8,7 +8,8 @@ module.exports = {
     entry: {
         app: './public/app.js',
         sw: './public/sw.js',
-        admin: './public/admin.js'
+        admin: './public/admin.js',
+        subs: './public/subs.js'
     },
     output: {
         filename: '[name].bundle.js',

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,6 +55,6 @@ object Dependencies {
   )
 
   val webPushDependencies = Seq(
-    "nl.martijndwars" % "web-push" % "3.1.1"
+    "nl.martijndwars" % "web-push" % "4.0.0"
   )
 }

--- a/public/layouts/dashboard/dashboard-create.js
+++ b/public/layouts/dashboard/dashboard-create.js
@@ -25,7 +25,7 @@ angular
         $scope.registerSubscription = () => {
             $scope.subscriptionStatus = "Subscribing...";
 
-            registerSubscription().then(() => {
+            registerSubscription(window.location.search).then(() => {
                 $scope.subscriptionStatus = "Subscribed!";
             }).catch((err) => {
                 $scope.subscriptionStatus = null;

--- a/public/lib/notifications.js
+++ b/public/lib/notifications.js
@@ -17,11 +17,11 @@ export function registerServiceWorker() {
     }
 }
 
-export function registerSubscription() {
+export function registerSubscription(query) {
     // TODO MRB: handle service worker not being registered yet (disable button?)
     return navigator.serviceWorker.getRegistration(serviceWorkerURL).then(({ pushManager }) => {
         return getBrowserSubscription(pushManager).then((sub) => {
-            return saveSubscription(sub, window.location.search);
+            return saveSubscription(sub, query);
         });
     }).catch(err => {
         console.error("Unable to register subscription", err);

--- a/public/subs.js
+++ b/public/subs.js
@@ -1,0 +1,16 @@
+import { registerServiceWorker, registerSubscription } from './lib/notifications';
+
+console.log("Welcome to the subscriptions admin page");
+registerServiceWorker();
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.getElementById("add-word-form").onsubmit = (e) => {
+        e.preventDefault();
+        registerSubscription(`?phrase=${e.target[0].value}`).then(() => {
+            window.location.reload();
+        }).catch(err => {
+            window.alert("Error adding phrase subscription");
+            console.error(err);
+        });
+    }
+});


### PR DESCRIPTION
Extends Workflow notifications to fire when certain phrases are used in content.

TODO
- [x] CRUD UI for managing subscriptions
- [ ] Turn the `notifications` project into an app and consume CAPI events
   - Change existing behaviour to trigger from SNS updates?
   - Retain seen in content time per sub to avoid spamming notifications on every save for the same phrase
    - Cache subscriptions (update every N invocations?) to avoid heavy dynamo I/O
- [ ] Add [event source mapping](https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html) trigger in Cloudformation