### PR TITLE
Fix multiple content-type headers

### DIFF
--- a/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala
@@ -21,10 +21,10 @@ object ApiUtils {
     buildRequest(path).delete()
 
   def postRequest(path: String, data: Json = Json.Null): Future[WSResponse] =
-    buildRequest(path).withHeaders("content-type" -> "application/json").post(data.toString())
+    buildRequest(path).withHeaders("Content-Type" -> "application/json").post(data.toString())
 
   def putRequest(path: String, data: Json = Json.Null): Future[WSResponse] =
-    buildRequest(path).withHeaders("content-type" -> "application/json").put(data.toString())
+    buildRequest(path).withHeaders("Content-Type" -> "application/json").put(data.toString())
 
   def getRequest(path: String, params: Option[Seq[(String, String)]] = None):
       Future[WSResponse] =


### PR DESCRIPTION
This was caused because we set 'content-type':

https://github.com/guardian/workflow-frontend/blob/fa90bcb03ef46ab7256796075c131e64b40ab1e0/common-lib/src/main/scala/com/gu/workflow/api/ApiUtils.scala#L24

and the underlying WS library checks for 'Content-Type' and if not present adds it:

```scala
def withBody[T](body: T)(implicit wrt: Writeable[T]): WSRequest = {
    val wsBody = InMemoryBody(wrt.transform(body))
    if (headers.contains("Content-Type")) {
      withBody(wsBody)
    } else {
      wrt.contentType.fold(withBody(wsBody)) { contentType =>
        withBody(wsBody).withHeaders("Content-Type" -> contentType)
      }
    }
}
```

https://github.com/playframework/playframework/blob/d57d3880cdb405c62d6702fd2432b6991ceb3b36/framework/src/play-ws/src/main/scala/play/api/libs/ws/WS.scala#L391

This meant we had two content-type headers:

```
PUT /api/stubs/18776/note HTTP/1.1
content-type: application/json
content-type: text/plain; charset=utf-8
Content-Length: 6
Connection: keep-alive
Host: localhost:9095
Accept: */*
User-Agent: AHC/1.0

"test"
```

This was not a problem until we upgraded the main Workflow code-base to Play 2.6 (https://github.com/guardian/workflow/pull/1051).

The newer version is based off Akka HTTP which has an overly fussy HTTP parser and rejects the request with: "HTTP message must not contain more than one Content-Type header"