### PR TITLE
Fix video creation

### DIFF
--- a/app/lib/AtomEditorConfig.scala
+++ b/app/lib/AtomEditorConfig.scala
@@ -8,7 +8,7 @@ trait AtomEditorConfig {
 }
 
 object MediaAtomMakerConfig extends AtomEditorConfig {
-  lazy val newContentUrl: String = Config.mediaAtomMakerUrl+ "/api2/workflow/atoms"
+  lazy val newContentUrl: String = Config.mediaAtomMakerUrl+ "/api/workflow/atoms"
   lazy val viewContentUrl: String = Config.mediaAtomMakerUrl + "/videos/"
 }
 


### PR DESCRIPTION
Ronseal. https://github.com/guardian/media-atom-maker/pull/822 renamed the endpoint from `apiv2` to `api`.