### PR TITLE
Fail fast if Stage tag is not available in AWS

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -9,6 +9,8 @@ import java.util.UUID
 object Config extends AwsInstanceTags {
   lazy val stage: String = readTag("Stage") match {
     case Some(value) => value
+    // If in AWS and we don't know our stage, fail fast to avoid ending up running an instance with dev config in PROD!
+    case other if instanceId.nonEmpty => throw new IllegalStateException(s"Unable to read Stage tag: $other")
     case None => "DEV" // default to dev stage
   }
   Logger.info(s"running in stage: $stage")


### PR DESCRIPTION
The same problem that we saw in Tag Manager https://github.com/guardian/tagmanager/pull/354. The tags aren't available at start-up so a PROD instance thinks it is in DEV. Nightmare.

This PR tries to defend against it by deliberately throwing an exception at start-up if running in AWS (we have an instance id from the magic 169 metadata service) but no Stage tag. This means we don't default to DEV config and will fail the healthcheck, thus failing the deploy.