### PR TITLE
allow atom tools to hit priority endpoint

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -220,7 +220,7 @@ object Api extends Controller with PanDomainAuthActions with SharedSecretAuth {
     )}
   }
 
-  def putStubPriority(stubId: Long) = CORSable(defaultCorsAble) {
+  def putStubPriority(stubId: Long) = CORSable(atomCorsAble) {
     APIAuthAction.async { request =>
       ApiResponseFt[Long](for {
         json <- ApiUtils.readJsonFromRequestResponse(request.body)


### PR DESCRIPTION
CORS is fun

We need to explicitly allow access from Atom Tools, similar to the [status update endpoint](https://github.com/guardian/workflow-frontend/blob/master/app/controllers/Api.scala#L173)