### PR TITLE
Add information about managing workflow admin permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ a single SBT session. Unfortunately you must run a new instance of SBT each time
 This project is setup for continuous deployment on `master`, if you suspect your
 change has not deployed then look for the 
 `Editorial Tools::Workflow::Workflow Frontend` project in RiffRaff.
+
+### Admin Permissions
+
+The `/admin` path allows the user to manage desks and sections. Not all users that have access to workflow have access to admin. Currently admin permissions are managed by adding email addresses to the private conf file stored in s3 and doing a redeploy. Long term this should be changed to used the [permissions app](https://permissions.gutools.co.uk/) so that permissions management is consistent across tools. 


### PR DESCRIPTION
A user has requested to add a section to workflow. This is a rare request so raised questions about who had permission to do this and how permissions are granted. Documenting findings.