### PR TITLE
bump sbt-riffraff-artifact plugin

### DIFF
--- a/project/WorkflowBuild.scala
+++ b/project/WorkflowBuild.scala
@@ -65,7 +65,6 @@ object WorkflowBuild extends Build {
     ),
     debianPackageDependencies := Seq("openjdk-8-jre-headless"),
     riffRaffPackageType := (packageBin in Debian).value,
-    riffRaffBuildIdentifier := Option(System.getenv("CIRCLE_BUILD_NUM")).getOrElse("dev"),
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffArtifactPublishPath := application,
@@ -82,7 +81,6 @@ object WorkflowBuild extends Build {
     javaOptions in Universal ++= Seq(
       "-Dpidfile.path=/dev/null"
     ),
-    riffRaffManifestBranch := Option(System.getenv("CIRCLE_BRANCH")).getOrElse("dev"),
     debianPackageDependencies := Seq("openjdk-8-jre-headless"),
     serverLoading in Debian := Systemd,
     maintainer := "Digital CMS <digitalcms.dev@guardian.co.uk>",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ logLevel := Level.Warn
 // The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.11")


### PR DESCRIPTION
This fixes an issue where RiffRaff doesn't recognise the branch name and reports `unknown`.

Also, we're no longer on Circle!

![img](https://media.giphy.com/media/koTAN2V1PTOzC/giphy.gif)