### PR TITLE
Add print word count

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -24,6 +24,7 @@ case class ExternalData(
                          takenDown: Option[Boolean] = None,
                          timeTakenDown: Option[DateTime] = None,
                          wordCount: Option[Int] = None,
+                         printWordCount: Option[Int] = None,
                          embargoedUntil: Option[DateTime] = None,
                          embargoedIndefinitely: Option[Boolean] = None,
                          scheduledLaunchDate: Option[DateTime] = None,

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -165,6 +165,7 @@
         &--created,
         &--incopy,
         &--wordcount,
+        &--printwordcount,
         &--commissionedLength,
         &--needsLegal,
         &--optimisedForWeb,
@@ -298,6 +299,11 @@
         }
 
         &--wordcount {
+            width: 34px;
+            text-align: center;
+        }
+
+        &--printwordcount {
             width: 34px;
             text-align: center;
         }

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -88,6 +88,7 @@ function wfContentItemParser(config, statusLabels, sections) {
             this.composerId = item.composerId;
             this.editorId = item.editorId;
             this.wordCount = item.wordCount;
+            this.printWordCount = item.printWordCount;
             this.commissionedLength = item.commissionedLength;
 
             this.headline = item.headline;

--- a/public/components/content-list-item/templates/printwordcount.html
+++ b/public/components/content-list-item/templates/printwordcount.html
@@ -1,3 +1,5 @@
-<td class="content-list-item__field--wordcount" title="Web Wordcount">
+<td class="content-list-item__field--printwordcount" title="Print Wordcount">
     <span ng-show="contentItem.contentType == 'article'">{{ contentItem.wordCount }}</span>
 </td>
+
+

--- a/public/components/content-list-item/templates/printwordcount.html
+++ b/public/components/content-list-item/templates/printwordcount.html
@@ -1,5 +1,5 @@
 <td class="content-list-item__field--printwordcount" title="Print Wordcount">
-    <span ng-show="contentItem.contentType == 'article'">{{ contentItem.wordCount }}</span>
+    <span ng-show="contentItem.contentType == 'article'">{{ contentItem.printWordCount }}</span>
 </td>
 
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -48,6 +48,7 @@ $textualIconSize: 22px;
             &--links,
             &--published-state,
             &--wordcount,
+            &--printwordcount,
             &--commissionedLength,
             &--needsLegal {
                 padding: 15px 10px 5px 5px;
@@ -114,7 +115,7 @@ $textualIconSize: 22px;
                 width: 40px;
             }
 
-            &--wordcount {
+            &--printwordcount {
                 width: 40px;
             }
 

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -17,6 +17,7 @@ import notesTemplate              from "components/content-list-item/templates/n
 import linksTemplate              from "components/content-list-item/templates/links.html";
 import publishedStateTemplate     from "components/content-list-item/templates/published-state.html";
 import wordcountTemplate          from "components/content-list-item/templates/wordcount.html";
+import printWordcountTemplate     from "components/content-list-item/templates/printwordcount.html";
 import commissionedLengthTemplate from "components/content-list-item/templates/commissionedLength.html";
 import needsLegalTemplate         from "components/content-list-item/templates/needsLegal.html";
 
@@ -185,12 +186,21 @@ var columnDefaults = [{
     active: true
 },{
     name: 'wordcount',
-    prettyName: 'Wordcount',
-    labelHTML: 'Words',
+    prettyName: 'Web Wordcount',
+    labelHTML: 'Web Words',
     colspan: 1,
     title: '',
     templateUrl: templateRoot + 'wordcount.html',
     template: wordcountTemplate,
+    active: false
+},{
+    name: 'printwordcount',
+    prettyName: 'Print Wordcount',
+    labelHTML: 'Print Words',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'printwordcount.html',
+    template: printWordcountTemplate,
     active: false
 },{
     name: 'commissionedLength',


### PR DESCRIPTION
Composer now supports marking text as webonly or printonly, and sending the resulting different word counts to workflow (see https://github.com/guardian/flexible-content/pull/3478)

This PR provides workflow with the facility to read from workflow backend and display those values in an optional column.