### PR TITLE
Display web and print word count in Furniture panel

### DIFF
--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -171,6 +171,11 @@
                 color: $c-grey-400;
             }
         }
+
+        &-wordcount {
+            padding: 0 2px;
+            display: inline-block;
+          }
     }
 
     &__mainmedia {

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -131,7 +131,7 @@
                             </div>
                             <div class="drawer__item-wordcount">
                                 <span class="drawer__item-title">Print word count</span>
-                                <span class="drawer__item-content">{{ contentItem.printWordCount }} </span>
+                                <span class="drawer__item-content">{{ contentItem.printWordCount || "Unknown" }} </span>
                             </div>
                         </li>
                         <li class="drawer__item" ng-show="contentItem.contentType == 'article'">

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -125,8 +125,14 @@
                             </span>
                         </li>
                         <li class="drawer__item" ng-show="contentItem.contentType == 'article'">
-                            <span class="drawer__item-title">Word count</span>
-                            <span class="drawer__item-content">{{ capiData.wordCount }} </span>
+                            <div class="drawer__item-wordcount">
+                                <span class="drawer__item-title">Web word count</span>
+                                <span class="drawer__item-content">{{ capiData.wordCount }} </span>
+                            </div>
+                            <div class="drawer__item-wordcount">
+                                <span class="drawer__item-title">Print word count</span>
+                                <span class="drawer__item-content">{{ contentItem.printWordCount }} </span>
+                            </div>
                         </li>
                         <li class="drawer__item" ng-show="contentItem.contentType == 'article'">
                             <span class="drawer__item-title">Commissioned Length</span>


### PR DESCRIPTION
Continues #190 by adding the print word count to the Furniture panel in Workflow. 

I'd love to name the CSS class `wordcount` something more generic, if anyone has any suggestions.

Before: 
![Screenshot 2020-05-12 at 11 41 56](https://user-images.githubusercontent.com/12645938/81674757-9e6fc200-9445-11ea-86ed-f02f97b50515.png)

After:
![Screenshot 2020-05-12 at 11 41 15](https://user-images.githubusercontent.com/12645938/81674721-8bf58880-9445-11ea-8d3a-d28f5c49b7de.png)
