### PR TITLE
Last modified column

### DIFF
--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -232,7 +232,8 @@
 
         &--deadline,
         &--created,
-        &--legal {
+        &--legal,
+        &--last-modified {
             width: 100px;
         }
 
@@ -259,12 +260,14 @@
         }
 
         &--section,
-        &--deadline {
+        &--deadline,
+        &--last-modified {
             @extend %fs-data-1;
         }
 
         &--deadline,
-        &--created {
+        &--created,
+        &--last-modified {
             white-space: nowrap;
         }
 
@@ -467,7 +470,8 @@
         &--sensitive,
         &--legally-sensitive,
         &--commissionedLength,
-        &--wordcount {
+        &--wordcount,
+        &--last-modified {
             @extend %fs-data-2;
         }
 

--- a/public/components/content-list-item/templates/last-modified.html
+++ b/public/components/content-list-item/templates/last-modified.html
@@ -1,0 +1,3 @@
+<td class="content-list-item__field--last-modified">
+    {{ contentItem.lastModified | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime:'ddd DD MMM HH:mm' }}
+</td>

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -50,7 +50,8 @@ $textualIconSize: 22px;
             &--wordcount,
             &--printwordcount,
             &--commissionedLength,
-            &--needsLegal {
+            &--needsLegal,
+            &--last-modified {
                 padding: 15px 10px 5px 5px;
                 @extend %fs-data-2;
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -123,6 +123,10 @@ $textualIconSize: 22px;
             &--titles {
                 min-width: 200px;
             }
+
+            &--last-modified {
+                min-width: 100px;
+            }
         }
     }
 

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -20,6 +20,7 @@ import wordcountTemplate          from "components/content-list-item/templates/w
 import printWordcountTemplate     from "components/content-list-item/templates/printwordcount.html";
 import commissionedLengthTemplate from "components/content-list-item/templates/commissionedLength.html";
 import needsLegalTemplate         from "components/content-list-item/templates/needsLegal.html";
+import lastModifiedTemplate       from "components/content-list-item/templates/last-modified.html";
 
 /**
  * This array represents the default ordering and display of the content-list-item columns for workflow.
@@ -238,6 +239,15 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'needsLegal.html',
     template: needsLegalTemplate,
     active: true
+},{
+    name: 'last-modified',
+    prettyName: 'Last modified',
+    labelHTML: 'Last modified',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'last-modified.html',
+    template: lastModifiedTemplate,
+    active: false
 }];
 
 export { columnDefaults }


### PR DESCRIPTION
<!-- Start with a description including the what and why of the change -->
"_It's not easy to see at a glance when an article has most recently been modified in Composer, from Workflow, nor the last person to touch it._" - [Trello](https://trello.com/c/4zpbltH1/88-expose-workflows-last-modified-as-a-column-off-by-default)

This PR adds a **Last Modified** column to the workflow display, this should make it easier to see what content has been edited most recently. The column displays the same value that is currently visible in the management panel.

![image](https://user-images.githubusercontent.com/4633246/81711418-9296f680-946b-11ea-916a-829a4b14baa6.png)

<!-- Remember to comment on anything contentious that has already been discussed -->

### How to review and test
<!-- Add some details to help the reviewer meaningfully review and/or test this code -->
Open workflow, select the column options button (top right column heading icon), add the **Last Modified** column. It should now show the value where available. 
