### PR TITLE
Allow DEV logs to be shipped to local-elk

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -6,7 +6,9 @@ import play.filters.gzip.GzipFilter
 
 object Global extends WithFilters(RedirectToHTTPSFilter, new GzipFilter, LoggingFilter) with GlobalSettings {
   override def beforeStart(app: Application) {
-
+    if (Config.isDev && Config.localLogShipping) {
+      LogConfig.initLocalLogShipping(Config.sessionId)
+    }
     LogConfig.init(Config.sessionId)
   }
 }

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -15,6 +15,10 @@ object Config extends AwsInstanceTags {
   }
   Logger.info(s"running in stage: $stage")
 
+  lazy val isDev: Boolean = stage == "DEV"
+
+  lazy val localLogShipping: Boolean = sys.env.getOrElse("LOCAL_LOG_SHIPPING", "false").toBoolean
+
   def appDomain(appStage: String): String = {
     appStage match {
       case "PROD" => "gutools.co.uk"

--- a/conf/logger.xml
+++ b/conf/logger.xml
@@ -22,13 +22,6 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%coloredLevel %logger{15} - %message%n%xException{5}</pattern>
-        </encoder>
-    </appender>
-
-
     <logger name="play" level="INFO" />
     <logger name="application" level="DEBUG" />
 
@@ -39,7 +32,6 @@
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
     <root level="ERROR">
-        <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
     </root>
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
     specs2 % Test
   )
 
-  val logbackDependencies = Seq("net.logstash.logback" % "logstash-logback-encoder" % "4.5")
+  val logbackDependencies = Seq("net.logstash.logback" % "logstash-logback-encoder" % "6.3")
 
   val circeVersion = "0.8.0"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,13 @@
 #!/usr/bin/env bash
+
+set -e
+
+for arg in "$@"; do
+  if [ "$arg" == "--ship-logs" ]; then
+    export LOCAL_LOG_SHIPPING=true
+    shift
+  fi
+done
+
 yarn build-dev &
 sbt run


### PR DESCRIPTION
Adds a `--ship-logs` flag to `./scripts/start.sh` to allow local logs to be appended on a TCP appender aka get logs into [local-elk](https://github.com/guardian/local-elk).

An ELK stack provides a much nicer experience for interrogating logs than tailing a file or reading from stdout.

This also removes logging to stdout as it can get very noisy and hard to process.