### PR TITLE
add --debug flag to start script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,11 +3,22 @@
 set -e
 
 for arg in "$@"; do
+  if [ "$arg" == "--debug" ]; then
+    IS_DEBUG=true
+    shift
+  fi
+
   if [ "$arg" == "--ship-logs" ]; then
     export LOCAL_LOG_SHIPPING=true
     shift
   fi
 done
 
+EXTRA_SBT_ARGS=""
+if [[ $IS_DEBUG == true ]]; then
+  EXTRA_SBT_ARGS="-jvm-debug 5005"
+fi
+
 yarn build-dev &
-sbt run
+# shellcheck disable=SC2086
+sbt $EXTRA_SBT_ARGS run


### PR DESCRIPTION
Passing the `--debug` arg will allow a remote debugger to be attached to port 5005, allowing you to use breakpoints etc. to provide a richer experience vs. logs/printlns.

Builds on https://github.com/guardian/workflow-frontend/pull/197 (mainly because I couldn't deal with the conflict it would create otherwise).