### PR TITLE
Display n/a when no print count found

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -131,7 +131,8 @@
                             </div>
                             <div class="drawer__item-wordcount">
                                 <span class="drawer__item-title">Print word count</span>
-                                <span class="drawer__item-content">{{ contentItem.printWordCount || capiData.wordCount }} </span>
+                                <span class="drawer__item-content" ng-class="{'drawer__item-content--empty': !contentItem.printWordCount}">
+                                    {{ contentItem.printWordCount || "n/a" }} </span>
                             </div>
                         </li>
                         <li class="drawer__item" ng-show="contentItem.contentType == 'article'">

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -131,7 +131,7 @@
                             </div>
                             <div class="drawer__item-wordcount">
                                 <span class="drawer__item-title">Print word count</span>
-                                <span class="drawer__item-content">{{ contentItem.printWordCount || "Unknown" }} </span>
+                                <span class="drawer__item-content">{{ contentItem.printWordCount || capiData.wordCount }} </span>
                             </div>
                         </li>
                         <li class="drawer__item" ng-show="contentItem.contentType == 'article'">


### PR DESCRIPTION
Continues https://github.com/guardian/workflow-frontend/pull/194

Currently, when there is no print word count, "Unknown" is displayed. In column view, if there is no print word count, nothing is displayed. Instead of displaying the potentially confusing "Unknown", which mirrors what we would display if we cannot retrieve word count data from CAPI, this PR suggests that we display "n/a":

![Screenshot 2020-05-14 at 17 27 17](https://user-images.githubusercontent.com/12645938/81960070-4c2ace80-9608-11ea-9307-b1625a08cee6.png)

This styling mirrors how we display other fields in the Furniture details view that do not have a relevant value (see Standfirst, Main media, and Caption below):

![Screenshot 2020-05-14 at 17 29 14](https://user-images.githubusercontent.com/12645938/81960194-79777c80-9608-11ea-915b-be7e7002ab3e.png)

Alternatively, we could use the word "None" here too, but I think that may be potentially misleading for users too, as it suggest there is no word count for print.

![Screenshot 2020-05-14 at 17 26 28](https://user-images.githubusercontent.com/12645938/81960065-4b923800-9608-11ea-888b-d89ee20d5793.png)
