### PR TITLE
Use CODE Preferences

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -45,7 +45,11 @@ object Config extends AwsInstanceTags {
   lazy val presenceUrl: String = s"wss://presence.$domain/socket"
   lazy val presenceClientLib: String = s"https://presence.$domain/client/1/lib.js"
 
-  lazy val preferencesUrl: String = s"https://preferences.$domain/preferences"
+  lazy val preferencesUrl: String = stage match {
+    case Prod => s"https://preferences.$domain/preferences"
+    case _ => s"https://preferences.${Code.appDomain}/preferences"
+  }
+
   lazy val tagManagerUrl: String = stage match {
     case Prod => s"https://tagmanager.$domain"
     case _ => s"https://tagmanager.${Code.appDomain}"

--- a/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
@@ -2,7 +2,7 @@ package com.gu.workflow.api
 
 import java.nio.charset.StandardCharsets
 
-import com.gu.workflow.util.Dynamo
+import com.gu.workflow.util.{Dynamo, Stage, Prod}
 import io.circe.syntax._
 import models.{Subscription, SubscriptionEndpoint, SubscriptionUpdate}
 import nl.martijndwars.webpush.{Notification, PushService}
@@ -10,8 +10,12 @@ import play.api.Logger
 
 import scala.collection.JavaConverters._
 
-class SubscriptionsAPI(stage: String, webPushPublicKey: String, webPushPrivateKey: String) extends Dynamo {
-  private val tableName = s"workflow-subscriptions-${if(stage != "PROD") { "CODE" } else { "PROD" }}"
+class SubscriptionsAPI(stage: Stage, webPushPublicKey: String, webPushPrivateKey: String) extends Dynamo {
+  private val tableName = stage match {
+    case Prod => "workflow-subscriptions-PROD"
+    case _ => "workflow-subscriptions-CODE"
+  }
+
   private val table = dynamoDb.getTable(tableName)
 
   private val pushService = new PushService(webPushPublicKey, webPushPrivateKey, "mailto:digitalcms.bugs@guardian.co.uk")

--- a/common-lib/src/main/scala/com/gu/workflow/util/Stage.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/util/Stage.scala
@@ -1,0 +1,30 @@
+package com.gu.workflow.util
+
+sealed trait Stage {
+  def name: String = this match {
+    case Prod => "PROD"
+    case Code => "CODE"
+    case Dev => "DEV"
+  }
+
+  def appDomain: String = this match {
+    case Prod => "gutools.co.uk"
+    case Code => "code.dev-gutools.co.uk"
+    case Dev => "local.dev-gutools.co.uk"
+  }
+
+  override def toString: String = name
+}
+
+object Stage {
+  def apply(value: String): Stage = value.toUpperCase match {
+    case "PROD" => Prod
+    case "CODE" => Code
+    case "DEV" => Dev
+    case other => throw new IllegalStateException(s"invalid stage: $other")
+  }
+}
+
+object Prod extends Stage
+object Code extends Stage
+object Dev extends Stage

--- a/notification/src/main/scala/com/gu/workflow/notification/LocalNotifierApp.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/LocalNotifierApp.scala
@@ -1,10 +1,11 @@
 package com.gu.workflow.notification
 
 import com.gu.workflow.api.SubscriptionsAPI
+import com.gu.workflow.util.Stage
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 object LocalNotifierApp extends App {
-  val stage = sys.env.getOrElse("STAGE", "DEV")
+  val stage: Stage = Stage(sys.env.getOrElse("STAGE", "DEV"))
   val config = new NotifierConfig()
 
   import java.security.Security

--- a/notification/src/main/scala/com/gu/workflow/notification/NotificationLambda.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/NotificationLambda.scala
@@ -5,10 +5,11 @@ import java.security.Security
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.gu.workflow.api.SubscriptionsAPI
+import com.gu.workflow.util.Stage
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 class NotificationLambda extends RequestHandler[Unit, Unit] {
-  private val stage = sys.env("STAGE")
+  private val stage = Stage(sys.env("STAGE"))
 
   private val s3Client = AmazonS3ClientBuilder.standard().build()
   private val config = NotifierConfig(stage, s3Client)

--- a/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
@@ -4,7 +4,7 @@ import java.net.HttpCookie
 
 import com.gu.workflow.api.SubscriptionsAPI
 import com.gu.workflow.lib.QueryString
-import com.gu.workflow.util.SharedSecretAuth
+import com.gu.workflow.util.{Dev, Prod, SharedSecretAuth, Stage}
 import io.circe.parser
 import models.api.ContentResponse
 import models._
@@ -12,18 +12,17 @@ import play.api.Logger
 
 import scala.util.control.NonFatal
 
-class Notifier(stage: String, override val secret: String, subsApi: SubscriptionsAPI) extends SharedSecretAuth {
+class Notifier(stage: Stage, override val secret: String, subsApi: SubscriptionsAPI) extends SharedSecretAuth {
 
   private val appUrl = stage match {
-    case "PROD" => "https://workflow.gutools.co.uk"
-    case "CODE" => "https://workflow.code.dev-gutools.co.uk"
     // TODO MRB: put this back to https://workflow.local.dev-gutools.co.uk
     //           by convincing the JVM that our local dev cert is totes legit
-    case "DEV" => "http://localhost:9090"
+    case Dev => "http://localhost:9090"
+    case stage => s"https://workflow.${stage.appDomain}"
   }
 
   private val composerUrl = stage match {
-    case "PROD" => "https://composer.gutools.co.uk"
+    case Prod => "https://composer.gutools.co.uk"
     case _ => "https://composer.code.dev-gutools.co.uk"
   }
 

--- a/notification/src/main/scala/com/gu/workflow/notification/NotifierConfig.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/NotifierConfig.scala
@@ -3,6 +3,7 @@ package com.gu.workflow.notification
 import java.io.InputStreamReader
 
 import com.amazonaws.services.s3.AmazonS3
+import com.gu.workflow.util.Stage
 import com.typesafe.config.{Config, ConfigFactory}
 
 class NotifierConfig(config: Config = ConfigFactory.load()) {
@@ -13,7 +14,7 @@ class NotifierConfig(config: Config = ConfigFactory.load()) {
 }
 
 object NotifierConfig {
-  def apply(stage: String, s3Client: AmazonS3): NotifierConfig = {
+  def apply(stage: Stage, s3Client: AmazonS3): NotifierConfig = {
     val key = s"$stage/workflow-frontend/application.defaults.conf"
     val obj = s3Client.getObject("workflow-private", key)
 


### PR DESCRIPTION
This allows us to develop Workflow locally w/out needing to run Preferences locally too and use CODE Preferences instead. This will produce a better developer experience.

Requires https://github.com/guardian/editorial-preferences/pull/33.