### PR TITLE
Fail fast if setup script fails

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 red='\x1B[0;31m'
 
 if [[ -z "$JAVA_HOME" ]]; then


### PR DESCRIPTION
At the moment, the yarn commands in `setup.sh` can fail, but the script will return with `0`. This can result in builds that don't have assets.

`set -e` will ensure that the script fails fast with an error code to halt a build rather than produce one that is incorrect.