### PR TITLE
Adds the lastModifiedBy value to stub common-lib model

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -15,6 +15,7 @@ import org.joda.time.DateTime
 case class ExternalData(
                          path: Option[String] = None,
                          lastModified: Option[DateTime] = None,
+                         lastModifiedBy: Option[String] = None,
                          status: Status = Status.Writers,
                          published: Option[Boolean] = None,
                          timePublished: Option[DateTime] = None,


### PR DESCRIPTION
This is an accompanying change to a [PR](https://github.com/guardian/workflow/pull/1056) in Workflow. It adds the `lastModifiedBy` value to the common library, allowing it to be displayed in the frontend through existing JS code.