### PR TITLE
track ci steps in vcs

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+setupNvm() {
+  if ! test -e "$NVM_DIR/nvm.sh"; then
+    echo -e "NVM not found. NVM is required to run this project."
+    exit 1
+  else
+    source "$NVM_DIR/nvm.sh"
+    nvm install
+  fi
+}
+
+buildJs() {
+  echo "##teamcity[compilationStarted compiler='webpack']"
+  setupNvm
+
+  npm install yarn -g
+
+  yarn
+  yarn build
+  echo "##teamcity[compilationFinished compiler='webpack']"
+}
+
+buildSbt() {
+  echo "##teamcity[compilationStarted compiler='sbt']"
+  sbt clean compile test riffRaffNotifyTeamcity
+  echo "##teamcity[compilationFinished compiler='sbt']"
+}
+
+buildJs
+buildSbt


### PR DESCRIPTION
We've had a few builds fail to run `yarn` but not exit 0 and so proceeded to the sbt build and deployed with riffraff. This caused the app to be served without any client side assets, rendering it unusable.

Currently TeamCity is responsible for installing yarn and it doesn't look especially stable. Rather than have TeamCity setup to run multiple different steps, we can simplify it by running one step which is to invoke `./scripts/ci.sh` giving us more control.

Invoking a script in the repo also makes it easier to tweak what CI does across branches.