### PR TITLE
keep styling consistent in print words column

### DIFF
--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -471,6 +471,7 @@
         &--legally-sensitive,
         &--commissionedLength,
         &--wordcount,
+        &--printwordcount,
         &--last-modified {
             @extend %fs-data-2;
         }


### PR DESCRIPTION
In compact view, keep the font-size and line-height of the print words column the same as the web words column.

It's pretty subtle.

# Was
- font-size: 1.3rem
- line-height: 1.6rem

![image](https://user-images.githubusercontent.com/836140/81973249-c749b000-961b-11ea-8312-1d3e71e731c4.png)

# Now
- font-size: 1.2rem
- line-height: 1.4rem

![image](https://user-images.githubusercontent.com/836140/81973325-e34d5180-961b-11ea-8ad2-7bcb6332b08e.png)
