### PR TITLE
Last modified by column

### DIFF
--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -233,7 +233,8 @@
         &--deadline,
         &--created,
         &--legal,
-        &--last-modified {
+        &--last-modified,
+        &--last-modified-by {
             width: 100px;
         }
 
@@ -261,13 +262,15 @@
 
         &--section,
         &--deadline,
-        &--last-modified {
+        &--last-modified,
+        &--last-modified-by {
             @extend %fs-data-1;
         }
 
         &--deadline,
         &--created,
-        &--last-modified {
+        &--last-modified,
+        &--last-modified-by {
             white-space: nowrap;
         }
 
@@ -472,7 +475,8 @@
         &--commissionedLength,
         &--wordcount,
         &--printwordcount,
-        &--last-modified {
+        &--last-modified,
+        &--last-modified-by {
             @extend %fs-data-2;
         }
 

--- a/public/components/content-list-item/templates/last-modified-by.html
+++ b/public/components/content-list-item/templates/last-modified-by.html
@@ -1,3 +1,3 @@
-<td class="content-list-item__field--last-modified">
+<td class="content-list-item__field--last-modified-by">
     {{ contentItem.lastModifiedBy }}
 </td>

--- a/public/components/content-list-item/templates/last-modified-by.html
+++ b/public/components/content-list-item/templates/last-modified-by.html
@@ -1,0 +1,3 @@
+<td class="content-list-item__field--last-modified">
+    {{ contentItem.lastModifiedBy }}
+</td>

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -51,7 +51,8 @@ $textualIconSize: 22px;
             &--printwordcount,
             &--commissionedLength,
             &--needsLegal,
-            &--last-modified {
+            &--last-modified,
+            &--last-modified-by {
                 padding: 15px 10px 5px 5px;
                 @extend %fs-data-2;
 
@@ -126,6 +127,10 @@ $textualIconSize: 22px;
 
             &--last-modified {
                 min-width: 100px;
+            }
+
+            &--last-modified-by {
+                min-width: 110px;
             }
         }
     }

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -21,6 +21,7 @@ import printWordcountTemplate     from "components/content-list-item/templates/p
 import commissionedLengthTemplate from "components/content-list-item/templates/commissionedLength.html";
 import needsLegalTemplate         from "components/content-list-item/templates/needsLegal.html";
 import lastModifiedTemplate       from "components/content-list-item/templates/last-modified.html";
+import lastModifiedByTemplate       from "components/content-list-item/templates/last-modified-by.html";
 
 /**
  * This array represents the default ordering and display of the content-list-item columns for workflow.
@@ -247,6 +248,15 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'last-modified.html',
     template: lastModifiedTemplate,
+    active: false
+},{
+    name: 'last-modified-by',
+    prettyName: 'Last modified by',
+    labelHTML: 'Last modified by',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'last-modified-by.html',
+    template: lastModifiedByTemplate,
     active: false
 }];
 

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -119,8 +119,7 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'sensitive.html',
     template: sensitiveTemplate,
-    active: false,
-    isNew: true
+    active: false
 },{
     name: 'legallySensitive',
     prettyName: 'Legally sensitive',
@@ -129,8 +128,7 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'legallySensitive.html',
     template: legallySensitiveTemplate,
-    active: false,
-    isNew: true
+    active: false
 },{
     name: 'presence',
     prettyName: 'Presence',
@@ -203,7 +201,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'printwordcount.html',
     template: printWordcountTemplate,
-    active: false
+    active: false,
+    isNew: true
 },{
     name: 'commissionedLength',
     prettyName: 'Commissioned Length',
@@ -248,7 +247,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'last-modified.html',
     template: lastModifiedTemplate,
-    active: false
+    active: false,
+    isNew: true
 },{
     name: 'last-modified-by',
     prettyName: 'Last modified by',
@@ -257,7 +257,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'last-modified-by.html',
     template: lastModifiedByTemplate,
-    active: false
+    active: false,
+    isNew: true
 }];
 
 export { columnDefaults }

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -21,7 +21,7 @@ import printWordcountTemplate     from "components/content-list-item/templates/p
 import commissionedLengthTemplate from "components/content-list-item/templates/commissionedLength.html";
 import needsLegalTemplate         from "components/content-list-item/templates/needsLegal.html";
 import lastModifiedTemplate       from "components/content-list-item/templates/last-modified.html";
-import lastModifiedByTemplate       from "components/content-list-item/templates/last-modified-by.html";
+import lastModifiedByTemplate     from "components/content-list-item/templates/last-modified-by.html";
 
 /**
  * This array represents the default ordering and display of the content-list-item columns for workflow.


### PR DESCRIPTION
<!-- Start with a description including the what and why of the change -->
Users would like to be able to see the person who last modified a piece of content in Workflow without clicking through to the management panel. This PR displays the newly available **last modified by** value to users on the dashboard if they add it to their visible columns. [Trello Card](https://trello.com/c/4CcdXkXC/167-workflow-last-modified-by-new-column-and-details-view)

![image](https://user-images.githubusercontent.com/4633246/82035756-e25a0580-9697-11ea-9b5a-d5b64ad205cb.png)

<!-- Remember to comment on anything contentious that has already been discussed -->
This work follows on from the workflow [PR](https://github.com/guardian/workflow/pull/1056) changes.

### How to review and test
<!-- Add some details to help the reviewer meaningfully review and/or test this code -->
This can be tested either locally using the test data from the Workflow PR or deployed to code to test it end to end. Navigate to the workflow dashboard page, click the column options button in the top right corner of the columns, enable the last modified by column. The user who last modified the content should now be displayed in a column.
