### PR TITLE
Adjusts offsets to avoid icon overlap on various resolutions

### DIFF
--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -5,10 +5,11 @@
 // Compact view
 
 $topIconOffset: 8px !default;
-$rightIconOffset: 14px !default;
+$rightIconOffset: 2px !default;
 $topIconOffsetCompact: 3px;
 $rightIconOffsetCompact: 8px;
 $iconsToStack: $textualIconSize / 4px; // Return a number (must divide values with units with values with units)
+$stackOffset: 4px;
 $iconExpandIntervalDistance: 24;
 $iconExpandIntervalDistanceCompact: 18;
 $stackColorLightenIncrement: 14%;
@@ -78,7 +79,7 @@ $iconAnimationEasingFunction: ease-in-out;
 
         @for $i from 1 to $iconsToStack {
             &:nth-of-type(#{$i+1}) {
-                right: ($i * -4) + $rightIconOffset;
+                right: ($i * -$stackOffset) + $rightIconOffset;
                 z-index: $i*-1;
                 .content-list-item__icon--presence {
                     background-color: lighten($c-presence-purple, $i*$stackColorLightenIncrement);


### PR DESCRIPTION
<!-- Start with a description including the what and why of the change -->
At various screen resolutions, presence icons will overlap to the left column due to the absolute position offset. This PR adjusts the offsets to avoid icons overlapping. 

Before:
![PresenceIconsBefore](https://user-images.githubusercontent.com/4633246/82192526-07df4d00-98ec-11ea-94aa-9424dc9478fc.gif)

After:
![PresenceIconsAfter](https://user-images.githubusercontent.com/4633246/82192559-10378800-98ec-11ea-9a70-bb1b7cd48d9e.gif)


<!-- Remember to comment on anything contentious that has already been discussed -->

### How to review and test
<!-- Add some details to help the reviewer meaningfully review and/or test this code -->
This require presence indicators to test, so either deploy the change to Code or setup presence locally. Failing that, you can copy the tag directly into the UL tag in the HTML:
`<li ng-repeat="presence in presences track by presence.email" ng-if="presence.status === 'present'" ng-class="'content-list-item__presence--' + presence.status" class="ng-scope content-list-item__presence--present" style="">
        <a class="content-list-item__icon--presence ng-binding" href="mailto:sam.hession@guardian.co.uk" title="Sam Hession">SH</a>
    </li>`

Adjust the screen resolution and chosen columns to check for overlapping.
