### PR TITLE
Restricts the number of presence icons that can stack to three

### DIFF
--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -77,10 +77,15 @@ $iconAnimationEasingFunction: ease-in-out;
             @include transition(color $iconAnimationTransTime, background-color $iconAnimationTransTime $iconAnimationEasingFunction);
         }
 
-        @for $i from 1 to $iconsToStack {
+        @for $i from 1 to $iconsToStack + 50 {
+            &:nth-of-type(#{$i+1}){
+                z-index: $i*-1;
+            }
+        }
+
+        @for $i from 1 to 3 {
             &:nth-of-type(#{$i+1}) {
                 right: ($i * -$stackOffset) + $rightIconOffset;
-                z-index: $i*-1;
                 .content-list-item__icon--presence {
                     background-color: lighten($c-presence-purple, $i*$stackColorLightenIncrement);
                     color: rgba(255, 255, 255, 0);
@@ -94,7 +99,6 @@ $iconAnimationEasingFunction: ease-in-out;
             // ensure all icons shown when expanded
             &:nth-of-type(#{$i+1}) {
                 right: ($i * $iconExpandIntervalDistance) + $rightIconOffset;
-                z-index: $i*-1;
                 .content-list-item__icon--presence {
                     background-color: $c-presence-purple;
                     color: rgba(255, 255, 255, 1);


### PR DESCRIPTION
<!-- Start with a description including the what and why of the change -->
The number of presence icons that can display is currently unlimited, which can cause them to overlap into other columns. This PR restricts the number to three to avoid overlapping issues. This should not effect the expand behaviour. 

Before:
![PresenceIconsBeforeII](https://user-images.githubusercontent.com/4633246/82203168-dae66680-98fa-11ea-9035-7c62bb71d2b3.gif)

After:
![PresenceIconsAfterII](https://user-images.githubusercontent.com/4633246/82203184-df128400-98fa-11ea-9d4b-89d70a4e006d.gif)


<!-- Remember to comment on anything contentious that has already been discussed -->

### How to review and test
<!-- Add some details to help the reviewer meaningfully review and/or test this code -->
This can be tested locally or deployed and tested on code. To get multiple presence icons, copy the LI tag into the UL tag multiple time in the HTML. Open the dashboard page, observe the number of presence icons and hover over to check they expand correctly. This should work at various resolutions.
