### PR TITLE
Aligns the presence and assignee icons size and position

### DIFF
--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -4,7 +4,7 @@
 
 // Compact view
 
-$topIconOffset: 8px !default;
+$topIconOffset: 7px !default;
 $rightIconOffset: 2px !default;
 $topIconOffsetCompact: 3px;
 $rightIconOffsetCompact: 8px;
@@ -117,8 +117,8 @@ $iconAnimationEasingFunction: ease-in-out;
         position: static;
         display: inline-block;
         .content-list-item__icon--presence {
-            width: auto;
-            height: auto;
+            width: 24px;
+            height: 24px;
             text-transform: none;
             @extend %fs-data-2;
             @include border-radius(50px);


### PR DESCRIPTION
<!-- Start with a description including the what and why of the change -->
The presence and assignee icons don't currently align between the columns. This PR adjusts the height and offset so they should align properly. 

Before:
<img width="81" alt="Screenshot 2020-05-18 at 11 06 32" src="https://user-images.githubusercontent.com/4633246/82203702-8b546a80-98fb-11ea-9ec7-6c3e83a724f9.png">

After:
<img width="81" alt="Screenshot 2020-05-18 at 11 10 13" src="https://user-images.githubusercontent.com/4633246/82203709-8e4f5b00-98fb-11ea-9e6d-4a8dae5932b5.png">


<!-- Remember to comment on anything contentious that has already been discussed -->

### How to review and test
<!-- Add some details to help the reviewer meaningfully review and/or test this code -->
Load workflow, find a column with a presence and assignee icon. They should align properly.
