### PR TITLE
Sticky row headings

### DIFF
--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -406,6 +406,7 @@
 // Compact layout
 .content-list--compact {
     .content-list-item__field--working-title,
+    .content-list-item__field--headline,
     .content-list-item__field--notes {
         @include text-truncate;
         max-width: 200px;
@@ -416,10 +417,6 @@
         @include smallScreen {
             @include font-size(11, 14); // Can't extend placeholders (%fs-data-1) into @media so including the font-size mixin directly
             max-width: 160px;
-        }
-
-        @include largeScreen {
-            max-width: 375px;
         }
     }
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -10,6 +10,7 @@ $content-list-icon-size: 14px;
 $compact-display-td-padding: 2px 5px;
 
 $textualIconSize: 22px;
+$tableHeaderRowHeight: 48px;
 
 // Global padding for cells
 %content-list__field-padding {
@@ -29,18 +30,25 @@ $textualIconSize: 22px;
     width: 100%;
     border-bottom: 5px solid $c-grey-100;
 
-    position: relative;
+    thead {
+        th {
+            z-index: 3; // always keep table header on top, even on top of the column selector
+            background-color: $c-white;
+        }
+        tr {
+            height: $tableHeaderRowHeight;
+        }
+    }
 
     &--sticky-row th {
         position: sticky;
         top: 0;
-        background-color: $c-white;
-        z-index: 1;
+        background-color: $c-bluegrey;
 
         &.content-list__group-heading {
-            $tableHeaderRowHeight: 37px; // ideally this would be calculated dynamically
-            top: $tableHeaderRowHeight; // keep `status` row headings below the column header row
-            background-color: $c-bluegrey;
+            // Chrome has a gap between the table header and a group heading row
+            $strangeChromeGap: 1px;
+            top: $tableHeaderRowHeight - $strangeChromeGap;
         }
     }
     // Table header
@@ -285,7 +293,7 @@ $textualIconSize: 22px;
 
 .column-configurator {
     position: absolute;
-    top: 34px;
+    top: $tableHeaderRowHeight;
     right: 6px;
     width: 180px;
     z-index: 2;

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -43,7 +43,7 @@ google-auth-banner .alert {
 
     thead {
         th {
-            z-index: 3; // always keep table header on top, even on top of the column selector
+            z-index: 3;
             background-color: $c-white;
         }
         tr {
@@ -58,6 +58,7 @@ google-auth-banner .alert {
 
         &.content-list__group-heading {
             top: $tableHeaderRowHeight;
+            z-index: 2;
         }
     }
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -341,17 +341,30 @@ google-auth-banner .alert {
         list-style: none;
         padding: 0;
         margin: 0;
+        max-height: 400px;
+        overflow-x: hidden;
+        overflow-y: scroll;
     }
 
     .column-configurator__list-item {
         border-bottom: 1px solid $c-grey-300;
-        padding: 6px 10px;
         .column-configurator__label {
+            padding: 6px 10px;
             color: $c-grey-700;
             font-weight: normal;
             @extend %fs-data-3;
             text-transform: capitalize;
             margin: 0;
+            cursor: pointer;
+            width: 100%;
+
+            input {
+                width: auto;
+            }
+
+            &:hover {
+                background-color: $c-grey-200;
+            }
         }
 
         .column-configurator__label {
@@ -361,6 +374,7 @@ google-auth-banner .alert {
         &:last-child {
             border: none;
         }
+
     }
 }
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -12,6 +12,17 @@ $compact-display-td-padding: 2px 5px;
 $textualIconSize: 22px;
 $tableHeaderRowHeight: 48px;
 
+google-auth-banner .alert {
+    position: sticky;
+    top: 0;
+
+    // reset bootstrap styles
+    margin: 0;
+    z-index: 3;
+    border: none;
+    border-radius: 0;
+}
+
 // Global padding for cells
 %content-list__field-padding {
     padding: 10px 5px;
@@ -46,11 +57,21 @@ $tableHeaderRowHeight: 48px;
         background-color: $c-bluegrey;
 
         &.content-list__group-heading {
-            // Chrome has a gap between the table header and a group heading row
-            $strangeChromeGap: 1px;
-            top: $tableHeaderRowHeight - $strangeChromeGap;
+            top: $tableHeaderRowHeight;
         }
     }
+
+    &--auth-banner-visible &--sticky-row th {
+        // Google auth banner is run through bootstrap,
+        // with padding, it is 52px
+        $googleAuthBannerHeight: 52px;
+        top: $googleAuthBannerHeight;
+
+        &.content-list__group-heading {
+            top: $tableHeaderRowHeight + $googleAuthBannerHeight;
+        }
+    }
+
     // Table header
     &-head {
         &__row {
@@ -163,7 +184,6 @@ $tableHeaderRowHeight: 48px;
 
         &-row {
             background-color:  $c-bluegrey;
-            border-top: 1px solid $c-grey-300;
             border-bottom: 1px solid #ffffff;
         }
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -12,6 +12,10 @@ $compact-display-td-padding: 2px 5px;
 $textualIconSize: 22px;
 $tableHeaderRowHeight: 48px;
 
+// Google auth banner is run through bootstrap,
+// with padding, it is 52px
+$googleAuthBannerHeight: 52px;
+
 google-auth-banner .alert {
     position: sticky;
     top: 0;
@@ -63,9 +67,6 @@ google-auth-banner .alert {
     }
 
     &--auth-banner-visible &--sticky-row th {
-        // Google auth banner is run through bootstrap,
-        // with padding, it is 52px
-        $googleAuthBannerHeight: 52px;
         top: $googleAuthBannerHeight;
 
         &.content-list__group-heading {
@@ -313,9 +314,14 @@ google-auth-banner .alert {
 }
 
 .column-configurator {
-    position: absolute;
-    top: $tableHeaderRowHeight;
-    right: 6px;
+    position: fixed;
+    top: $tableHeaderRowHeight + $topToolbarHeight;
+
+    &--auth-banner-visible {
+        top: $tableHeaderRowHeight + $topToolbarHeight + $googleAuthBannerHeight;
+    }
+
+    right: 15px;
     width: 180px;
     z-index: 2;
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -27,9 +27,21 @@ $textualIconSize: 22px;
 
 .content-list {
     width: 100%;
-    border-top: 5px solid $c-grey-100;
     border-bottom: 5px solid $c-grey-100;
 
+    position: relative;
+
+    &--sticky-row th {
+        position: sticky;
+        top: 0;
+        background-color: $c-white;
+        z-index: 1;
+
+        &.content-list__group-heading {
+            top: 45px;
+            background-color: $c-bluegrey;
+        }
+    }
     // Table header
     &-head {
         &__row {
@@ -197,8 +209,6 @@ $textualIconSize: 22px;
     &--presence-disabled {
       .content-list-head__heading--presence,
       .content-list-item__field--presence {
-        position: relative;
-
         &:after {
           content: "";
           display: block;

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -314,11 +314,20 @@ google-auth-banner .alert {
 }
 
 .column-configurator {
+    $columnConfiguratorBorder: 1px;
+    $columnConfiguratorTopOffset: $tableHeaderRowHeight + $topToolbarHeight + $columnConfiguratorBorder;
+    $columnConfiguratorTopOffsetWithAuth: $columnConfiguratorTopOffset + $googleAuthBannerHeight;
+
     position: fixed;
-    top: $tableHeaderRowHeight + $topToolbarHeight;
+    top: $columnConfiguratorTopOffset;
+
+    max-height: calc(100vh - #{$columnConfiguratorTopOffset});
+    overflow-x: hidden;
+    overflow-y: scroll;
 
     &--auth-banner-visible {
-        top: $tableHeaderRowHeight + $topToolbarHeight + $googleAuthBannerHeight;
+        top: $columnConfiguratorTopOffsetWithAuth;
+        max-height: calc(100vh - #{$columnConfiguratorTopOffsetWithAuth});
     }
 
     right: 15px;
@@ -327,7 +336,7 @@ google-auth-banner .alert {
 
     // _toolbar-sections-dropdown.scss:71
     background-color: #ffffff;
-    border: 1px solid $c-grey-400;
+    border: $columnConfiguratorBorder solid $c-grey-400;
     box-shadow: 2px 1px 5px $c-grey-300;
     display: block;
     -webkit-transition: opacity .35 ease-in-out;
@@ -341,9 +350,6 @@ google-auth-banner .alert {
         list-style: none;
         padding: 0;
         margin: 0;
-        max-height: 400px;
-        overflow-x: hidden;
-        overflow-y: scroll;
     }
 
     .column-configurator__list-item {
@@ -357,6 +363,7 @@ google-auth-banner .alert {
             margin: 0;
             cursor: pointer;
             width: 100%;
+            user-select: none;
 
             input {
                 width: auto;

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -381,9 +381,6 @@ $textualIconSize: 22px;
 }
 
 .content-list__compact-button {
-    position: absolute;
-    bottom: 4px;
-    left: 6px;
     display: block;
     height: 16px;
     width: 16px;

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -38,7 +38,8 @@ $textualIconSize: 22px;
         z-index: 1;
 
         &.content-list__group-heading {
-            top: 45px;
+            $tableHeaderRowHeight: 37px; // ideally this would be calculated dynamically
+            top: $tableHeaderRowHeight; // keep `status` row headings below the column header row
             background-color: $c-bluegrey;
         }
     }

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -5,7 +5,7 @@
 
 <table class="content-list" ng-class="{ 'content-list--compact': compactView.visible, 'content-list--animations-enabled': animationsEnabled, 'content-list--presence-disabled': !presenceIsActive}" infinite-scroll="moreContent()" infinite-scroll-distance="contentItemsLoadingThreshold" infinite-scroll-immediate-check="false" infinite-scroll-parent="true" infinite-scroll-disabled="infiniteScrollDisabled">
     <thead class="content-list-head">
-        <tr class="content-list-head__row">
+        <tr class="content-list-head__row content-list--sticky-row">
             <th class="content-list-head__heading--group content-list-head__heading--notifier" colspan="1">
                 <div class="content-list__compact-button" ng-class="{ 'content-list__compact-button--active': compactView.visible }" ng-click="compactView.visible = !compactView.visible" title="Toggle compact view"></div>
             </th>

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -3,7 +3,7 @@
 
 <wf-content-list-loader event="content.rendered"></wf-content-list-loader>
 
-<table class="content-list" ng-class="{ 'content-list--compact': compactView.visible, 'content-list--animations-enabled': animationsEnabled, 'content-list--presence-disabled': !presenceIsActive}" infinite-scroll="moreContent()" infinite-scroll-distance="contentItemsLoadingThreshold" infinite-scroll-immediate-check="false" infinite-scroll-parent="true" infinite-scroll-disabled="infiniteScrollDisabled">
+<table class="content-list" ng-class="{ 'content-list--compact': compactView.visible, 'content-list--animations-enabled': animationsEnabled, 'content-list--presence-disabled': !presenceIsActive, 'content-list--auth-banner-visible': googleAuthBannerVisible}" infinite-scroll="moreContent()" infinite-scroll-distance="contentItemsLoadingThreshold" infinite-scroll-immediate-check="false" infinite-scroll-parent="true" infinite-scroll-disabled="infiniteScrollDisabled">
     <thead class="content-list-head">
         <tr class="content-list-head__row content-list--sticky-row">
             <th class="content-list-head__heading--group content-list-head__heading--notifier" colspan="1"></th>

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -34,7 +34,7 @@
     </tbody>
 </table>
 
-<div class="column-configurator" ng-show="showColumnMenu">
+<div class="column-configurator" ng-show="showColumnMenu" ng-class="{'column-configurator--auth-banner-visible': googleAuthBannerVisible}">
     <ul class="column-configurator__list">
         <li class="column-configurator__list-item" ng-repeat="col in columns" ng-if="col.name!='titles'">
             <label class="column-configurator__label" for="{{ col.name }}">

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -36,7 +36,7 @@
 
 <div class="column-configurator" ng-show="showColumnMenu" ng-class="{'column-configurator--auth-banner-visible': googleAuthBannerVisible}">
     <ul class="column-configurator__list">
-        <li class="column-configurator__list-item" ng-repeat="col in columns" ng-if="col.name!='titles'">
+        <li class="column-configurator__list-item" ng-repeat="col in columns" ng-if="!col.alwaysShown">
             <label class="column-configurator__label" for="{{ col.name }}">
                 <input class="column-configurator__label" type="checkbox" ng-model="col.active" id="{{ col.name }}" name="{{ col.name }}" ng-change="colChangeSelect()"/>
                 {{ col.prettyName }}

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -10,7 +10,7 @@
                 <div class="content-list__compact-button" ng-class="{ 'content-list__compact-button--active': compactView.visible }" ng-click="compactView.visible = !compactView.visible" title="Toggle compact view"></div>
             </th>
 
-            <th ng-repeat="col in columns" ng-if="::col.active" class="content-list-head__heading--{{ col.name }}" ng-attr-title="{{ getColumnTitle(col) }}" colspan="{{ col.colspan }}" bind-compiled-html="col.labelHTML"></span></th>
+            <th ng-repeat="col in columns" ng-if="::col.active" class="content-list-head__heading--{{ col.name }}" ng-attr-title="{{ getColumnTitle(col) }}" colspan="{{ col.colspan }}" bind-compiled-html="col.labelHTML"></th>
 
             <th class="content-list-head__heading--group content-list-head__heading--notifier content-list-head--button-container" colspan="1">
 
@@ -54,5 +54,5 @@
     <tbody class="content-list-draw__dock">
         <tr wf-content-list-drawer ng-model="contentItem" content-item="contentItem" content-list="contentList" legal-values="contentList.legalValues" status-values="statusValues"></tr>
     </tbody>
-    
+
 </table>

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -6,7 +6,7 @@
 <table class="content-list" ng-class="{ 'content-list--compact': compactView.visible, 'content-list--animations-enabled': animationsEnabled, 'content-list--presence-disabled': !presenceIsActive, 'content-list--auth-banner-visible': googleAuthBannerVisible}" infinite-scroll="moreContent()" infinite-scroll-distance="contentItemsLoadingThreshold" infinite-scroll-immediate-check="false" infinite-scroll-parent="true" infinite-scroll-disabled="infiniteScrollDisabled">
     <thead class="content-list-head">
         <tr class="content-list-head__row content-list--sticky-row">
-            <th class="content-list-head__heading--group content-list-head__heading--notifier" colspan="1"></th>
+            <th class="content-list-head__heading--group content-list-head__heading--notifier" colspan="1">&nbsp;</th>
             <th ng-repeat="col in columns" ng-if="::col.active" class="content-list-head__heading--{{ col.name }}" ng-attr-title="{{ getColumnTitle(col) }}" colspan="{{ col.colspan }}" bind-compiled-html="col.labelHTML"></th>
             <th class="content-list-head__heading--group content-list-head__heading--notifier content-list-head--button-container" colspan="1">
                 <div class="configure-columns" ng-click="$parent.showColumnMenu = !$parent.showColumnMenu" title="Select columns">

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -6,9 +6,7 @@
 <table class="content-list" ng-class="{ 'content-list--compact': compactView.visible, 'content-list--animations-enabled': animationsEnabled, 'content-list--presence-disabled': !presenceIsActive}" infinite-scroll="moreContent()" infinite-scroll-distance="contentItemsLoadingThreshold" infinite-scroll-immediate-check="false" infinite-scroll-parent="true" infinite-scroll-disabled="infiniteScrollDisabled">
     <thead class="content-list-head">
         <tr class="content-list-head__row content-list--sticky-row">
-            <th class="content-list-head__heading--group content-list-head__heading--notifier" colspan="1">
-                <div class="content-list__compact-button" ng-class="{ 'content-list__compact-button--active': compactView.visible }" ng-click="compactView.visible = !compactView.visible" title="Toggle compact view"></div>
-            </th>
+            <th class="content-list-head__heading--group content-list-head__heading--notifier" colspan="1"></th>
 
             <th ng-repeat="col in columns" ng-if="::col.active" class="content-list-head__heading--{{ col.name }}" ng-attr-title="{{ getColumnTitle(col) }}" colspan="{{ col.colspan }}" bind-compiled-html="col.labelHTML"></th>
 

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -7,30 +7,11 @@
     <thead class="content-list-head">
         <tr class="content-list-head__row content-list--sticky-row">
             <th class="content-list-head__heading--group content-list-head__heading--notifier" colspan="1"></th>
-
             <th ng-repeat="col in columns" ng-if="::col.active" class="content-list-head__heading--{{ col.name }}" ng-attr-title="{{ getColumnTitle(col) }}" colspan="{{ col.colspan }}" bind-compiled-html="col.labelHTML"></th>
-
             <th class="content-list-head__heading--group content-list-head__heading--notifier content-list-head--button-container" colspan="1">
-
                 <div class="configure-columns" ng-click="$parent.showColumnMenu = !$parent.showColumnMenu" title="Select columns">
                     <div class="configure-columns__inner"></div>
-
                     <span class="configure-columns__new-indicator configure-columns__new-indicator--animate-on-button" ng-if="$parent.showColumnMenuNewIndicator">New!</span>
-                </div>
-
-                <div class="column-configurator" ng-show="showColumnMenu">
-                    <ul class="column-configurator__list">
-                        <li class="column-configurator__list-item" ng-repeat="col in columns" ng-if="col.name!='titles'">
-                            <label class="column-configurator__label" for="{{ col.name }}">
-                                <input class="column-configurator__label" type="checkbox" ng-model="col.active" id="{{ col.name }}" name="{{ col.name }}" ng-change="colChangeSelect()"/>
-                                {{ col.prettyName }}
-                                <span class="configure-columns__new-indicator" ng-if="col.isNew && showColumnMenuNewIndicator">New!</span>
-                            </label>
-                        </li>
-                        <li class="column-configurator__list-item">
-                            <button class="btn btn-xs btn-info" ng-click="colChange()" ng-disabled="!columnsEdited">Reload to view changes</button>
-                        </li>
-                    </ul>
                 </div>
             </th>
         </tr>
@@ -48,9 +29,22 @@
             </td>
         </tr>
     </tbody>
-
     <tbody class="content-list-draw__dock">
         <tr wf-content-list-drawer ng-model="contentItem" content-item="contentItem" content-list="contentList" legal-values="contentList.legalValues" status-values="statusValues"></tr>
     </tbody>
-
 </table>
+
+<div class="column-configurator" ng-show="showColumnMenu">
+    <ul class="column-configurator__list">
+        <li class="column-configurator__list-item" ng-repeat="col in columns" ng-if="col.name!='titles'">
+            <label class="column-configurator__label" for="{{ col.name }}">
+                <input class="column-configurator__label" type="checkbox" ng-model="col.active" id="{{ col.name }}" name="{{ col.name }}" ng-change="colChangeSelect()"/>
+                {{ col.prettyName }}
+                <span class="configure-columns__new-indicator" ng-if="col.isNew && showColumnMenuNewIndicator">New!</span>
+            </label>
+        </li>
+        <li class="column-configurator__list-item">
+            <button class="btn btn-xs btn-info" ng-click="colChange()" ng-disabled="!columnsEdited">Reload to view changes</button>
+        </li>
+    </ul>
+</div>

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -63,7 +63,7 @@ angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOff
 
                 $rootScope.$watch('contentItemTemplate', () => {
 
-                    var contentListHeading = '<tr class="content-list__group-heading-row" ng-show="currentlySelectedStatusFilters.indexOf(group.title) != -1"><th class="content-list__group-heading" scope="rowgroup" colspan="{{ 9 + columns.length }}"><span class="content-list__group-heading-link">{{ group.title }} <span class="content-list__group-heading-count">{{ group.count || "0" }}</span></span></th></tr>';
+                    var contentListHeading = '<tr class="content-list__group-heading-row content-list--sticky-row" ng-show="currentlySelectedStatusFilters.indexOf(group.title) != -1"><th class="content-list__group-heading" scope="rowgroup" colspan="{{ 9 + columns.length }}"><span class="content-list__group-heading-link">{{ group.title }} <span class="content-list__group-heading-count">{{ group.count || "0" }}</span></span></th></tr>';
 
                     var contentListItemDirective = '<tr wf-content-list-item class="content-list-item content-list-item--{{contentItem.lifecycleStateKey}}" ng-repeat="contentItem in group.items track by contentItem.id" ';
 

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -88,7 +88,13 @@ angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOff
 
 
 function wfContentListController($rootScope, $scope, $anchorScroll, statuses, legalValues, priorities, sections, wfContentService, wfContentPollingService, wfContentItemParser, wfPresenceService, wfColumnService, wfPreferencesService, wfFiltersService) {
-
+    $scope.googleAuthBannerVisible = false;
+    $rootScope.$on('wfGoogleApiService.userIsNotAuthorized', () => {
+        $scope.googleAuthBannerVisible = true;
+    });
+    $rootScope.$on('wfGoogleApiService.userIsAuthorized', () => {
+        $scope.googleAuthBannerVisible = false;
+    });
 
     $scope.presenceIsActive = false;
     $rootScope.$on("presence.connection.error", () => $scope.presenceIsActive = false);

--- a/public/layouts/global/_top-toolbar.scss
+++ b/public/layouts/global/_top-toolbar.scss
@@ -5,8 +5,8 @@
     display: -ms-flexbox;
     display: flex;
 
-    min-height: 50px;
-    max-height: 50px;
+    min-height: $topToolbarHeight;
+    max-height: $topToolbarHeight;
     background-color: $c-bluegrey;
     border-bottom: 1px solid $c-grey-400;
 

--- a/public/layouts/global/_vars.scss
+++ b/public/layouts/global/_vars.scss
@@ -1,3 +1,4 @@
 // Global variables
 
 $dashboardSidebarWidth: 160px;
+$topToolbarHeight: 50px;

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -41,7 +41,11 @@ var templateRoot = '/assets/components/content-list-item/templates/';
 var columnDefaults = [{
     name: 'priority',
     prettyName: 'Priority',
-    labelHTML: '',
+    // Oh hello, yes you're right the `labelHTML` doesn't represent `priority` does it?!
+    // There's a good reason though, principally it's a wider column than the column to the left, notifier.
+    // The notifier column needs to remain slim to not consume valuable real estate.
+    // Add the table compactor toggle here as there is no text here anyway otherwise.
+    labelHTML: '<div class="content-list__compact-button" ng-class="{ \'content-list__compact-button--active\': compactView.visible }" ng-click="compactView.visible = !compactView.visible" title="Toggle compact view"></div>',
     colspan: 1,
     title: '',
     templateUrl: templateRoot + 'priority.html',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -50,7 +50,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'priority.html',
     template: priorityTemplate,
-    active: true
+    active: true,
+    alwaysShown: true
 },{
     name: 'content-type',
     prettyName: 'Content Type',
@@ -68,7 +69,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'title.html',
     template: titleTemplate,
-    active: true
+    active: true,
+    alwaysShown: true
 },{
     name: 'notes',
     prettyName: 'Notes',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -259,6 +259,6 @@ var columnDefaults = [{
     template: lastModifiedByTemplate,
     active: false,
     isNew: true
-}];
+}].map(col => col.labelHTML === '' ? {...col, labelHTML: '&nbsp;'} : col);
 
 export { columnDefaults }


### PR DESCRIPTION
# Problem
We display web, print and commissioned word counts next to each other. As we scroll through the table, the column headers disappear. This means you have to build up positional definitions as they are just three numbers next to each other.

This can be confusing.

# Solution
This PR keeps the column headers in view when scrolling meaning we no longer need to maintain positional definitions.

This creates a simpler experience.

# Screenshots
## Before
![before](https://user-images.githubusercontent.com/836140/82595011-d4771980-9b9c-11ea-9bd8-530ba3e7ccc1.gif)

## After
![after](https://user-images.githubusercontent.com/836140/82595104-f7a1c900-9b9c-11ea-9495-56155c005fb6.gif)

# Contentious changes
- The column compactor toggle has moved across a column, to `priority` (inline comments added)
  - `priority` column is now **always** shown as a result (only 6 out of 2340 people in PROD have turned off this column). This consumes either 26px or 29px depending if in compact mode or not.
- The column selector is now a sibling of the `table` rather than a child. This was the easiest way to get it displaying correctly across browsers.
- The table header is now always `48px`. Previously, the header was `37px` or `48px` depending on whether or not you had the `Web words` or `Print words` column shown as these column titles spanned across two lines. Fixing the height makes calculating the `top` offset for the group headings simpler.

# How to test
- Checkout branch
- Scroll
- Configure columns
- Scroll

You should witness a sticky table header and grouping headers across browsers, regardless of your chosen column configuration.