### PR TITLE
update presence styling in drawer

### DIFF
--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -121,8 +121,8 @@ $iconAnimationEasingFunction: ease-in-out;
         position: static;
         display: inline-block;
         .content-list-item__icon--presence {
-            width: 24px;
-            height: 24px;
+            width: auto;
+            height: auto;
             text-transform: none;
             @extend %fs-data-2;
             @include border-radius(50px);


### PR DESCRIPTION
# Problem
In the drawer, we're displaying the full name, rather than the initials, for the presence indicator. The background currently doesn't span the entire text, making it unreadable.

# Solution
Allow the background to span the full name to make it more readable.

Presence indicators in the table remain unchanged (they are still a circle with initials).

# Screenshots
## Before
![image](https://user-images.githubusercontent.com/836140/82639902-8cd6a900-9c01-11ea-8825-ba8d3ff828a9.png)

## After
![image](https://user-images.githubusercontent.com/836140/82640210-17b7a380-9c02-11ea-9482-89294c20901e.png)
