### PR TITLE
add print info filter to UI

### DIFF
--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -243,7 +243,8 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         'incopy' : modelParams['incopy'] || null,
                         'composerId' : modelParams['composerId'] || null,
                         'editorId' : modelParams['editorId'] || null,
-                        'trashed': modelParams['trashed'] || null
+                        'trashed': modelParams['trashed'] || null,
+                        'hasPrintInfo': modelParams['hasPrintInfo'] || null,
                     };
 
                     return params;

--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -175,6 +175,16 @@ var filterDefaults = function (statuses, wfFiltersService) {
             filterOptions: [
                 { caption: 'Trashed', value: 'true'}
             ]
+        },
+        {
+            title: 'Print Info',
+            namespace: 'hasPrintInfo',
+            listIsOpen: false,
+            multi: false,
+            filterOptions: [
+                { caption: 'Has print info', value: 'true' },
+                { caption: 'No print info', value: 'false' }
+            ]
         }
     ].filter(notEmpty);
 };

--- a/public/lib/filters-service.js
+++ b/public/lib/filters-service.js
@@ -145,6 +145,11 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                     $rootScope.$broadcast('getContent');
                 });
 
+                $rootScope.$on('filtersChanged.hasPrintInfo', function(event, data) {
+                    self.update('hasPrintInfo', data);
+                    $rootScope.$broadcast('getContent');
+                });
+
             }
 
             init() {
@@ -183,7 +188,8 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                         'trashed'      : params['trashed'],
                         'plan-start-date': params['plan-start-date'],
                         'plan-end-date': params['plan-end-date'],
-                        'editorId'     :params['editorId']
+                        'editorId'     :params['editorId'],
+                        'hasPrintInfo': params['hasPrintInfo']
                     };
 
                     $rootScope.currentlySelectedStatusFilters = self.transformStatusList(self.filters['status']);


### PR DESCRIPTION
This is just the UI aspect of this feature. The query string makes its way to the backend of Workflow Frontend and gets sent to Workflow; the second part of this feature is to allow Workflow to accept the new `hasPrintInfo` query-string.

Requires https://github.com/guardian/workflow/pull/1059.

![image](https://user-images.githubusercontent.com/836140/82909548-55e5f780-9f61-11ea-8f6c-10703a4fd3c8.png)

![has-print-info](https://user-images.githubusercontent.com/836140/83109891-1979df00-a0ba-11ea-996f-fec0e0fffc7f.gif)
