### PR TITLE
Normalise font size for Expanded view

### DIFF
--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -164,15 +164,21 @@
         &--ophan,
         &--created,
         &--incopy,
-        &--wordcount,
-        &--printwordcount,
+        &--wordcount {
+            @extend %fs-data-1;
+        }
+
+        &--printwordcount {
+            @extend %fs-data-1;
+        }
+
         &--commissionedLength,
         &--needsLegal,
         &--optimisedForWeb,
         &--sensitive,
         &--legally-sensitive,
         &--publicationlocation {
-            @extend %fs-data-3;
+            @extend %fs-data-1;
             @extend %content-list__field-padding;
         }
 

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -165,7 +165,7 @@
         &--created,
         &--incopy,
         &--wordcount,
-        &--printwordcount
+        &--printwordcount,
         &--commissionedLength,
         &--needsLegal,
         &--optimisedForWeb,

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -164,14 +164,8 @@
         &--ophan,
         &--created,
         &--incopy,
-        &--wordcount {
-            @extend %fs-data-1;
-        }
-
-        &--printwordcount {
-            @extend %fs-data-1;
-        }
-
+        &--wordcount,
+        &--printwordcount
         &--commissionedLength,
         &--needsLegal,
         &--optimisedForWeb,
@@ -557,4 +551,3 @@
 .planned-print-location, .actual-print-location {
     vertical-align: middle;
 }
-


### PR DESCRIPTION
Currently, in Expanded view, Publication location and both Wordcount fields use larger font. I don’t understand why they do not inherit font sizes like other fields , but overrides like these already exist for Compact view and I just wanted to see if it’s gonna work. Ideally, we wouldn’t have these special cases and font sizes would be consistent by themselves, though, I suppose.

This is a draft to deploy to CODE and see. And for someone, hopefully, to say how this should be done correctly. 

- [x] tested on CODE

This achieves the desired effect:
from:
![image](https://user-images.githubusercontent.com/6032869/83326512-8f25ac80-a26c-11ea-98dd-e712a93a7fbf.png)
to:
![image](https://user-images.githubusercontent.com/6032869/83326517-9f3d8c00-a26c-11ea-8880-c46654821d52.png)

Unfortunately, all overridden text sizes are in pixels (`11px`), while the correctly set ones are in rems (`1.1rem`). This may cause differences when setting font size via browser settings or something…