### PR TITLE
Improve "create new" modal behaviour

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -114,6 +114,9 @@
     </div>
 
     <div class="modal-footer" ng-if="mode !== 'import'" ng-hide="actionInProgress || (actionSuccess && composerUrl)">
+        <button type="submit" class="btn btn-default" id="testing-do-generic-submit" ng-click="submit(stubForm)" ng-show="false">
+            Submit
+        </button>
         <div class="pull-left">
             <button type="button" class="btn btn-default pull-left" data-dismiss="modal" ng-click="delete()" ng-if="stub.id">Delete</button>
             <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="cancel()">Cancel</button>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -4,7 +4,7 @@
 </div>
 
 <form name="stubForm">
-    <fieldset ng-disabled="actionSuccess">
+    <fieldset>
     <input type="hidden" ng-model="stub.id"/>
     <div class="modal-body">
         <div class="form-group" ng-if="mode === 'import'">

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -128,7 +128,7 @@
             <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && contentName !== 'Atom'">
                 Create new
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false,addToAtomEditor=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentName === 'Atom' && stub.status !== 'Stub'">
+            <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentName === 'Atom' && stub.status !== 'Stub'">
                 Create atom
             </button>
         </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -122,10 +122,10 @@
             <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="cancel()">Cancel</button>
         </div>
         <div class="pull-right">
-            <button type="submit" class="btn btn-default" id="testing-create-stub" ng-click="ok(addToComposer=false,addToAtomEditor=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
+            <button type="button" class="btn btn-default" id="testing-create-stub" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
                 Save stub
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="ok(addToComposer=true,addToAtomEditor=false)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && contentName !== 'Atom'">
+            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && contentName !== 'Atom'">
                 Create new
             </button>
             <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="ok(addToComposer=false,addToAtomEditor=true)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentName === 'Atom' && stub.status !== 'Stub'">

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -135,7 +135,7 @@
     </div>
 
     <div class="modal-footer" ng-if="mode === 'import'" ng-hide="actionInProgress">
-        <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="cancel()">Cancel</button>
+        <button type="button" class="btn btn-default pull-left" data-dismiss="modal" ng-click="cancel()">Cancel</button>
         <button type="submit" class="btn btn-primary" id="testing-import-from-composer" ng-click="ok()" ng-disabled="stubForm.$invalid || !validImport">
             Import <span ng-show="importHandler">from {{importHandler.name}}</span>
         </button>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -244,6 +244,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
                 window.open($scope.composerUrl, "_blank");
             if ($scope.editorUrl)
                 window.open($scope.editorUrl, "_blank");
+            $scope.cancel()
         }
         else {
             const addToComposer = $scope.stub.status !== 'Stub' && $scope.contentName !== 'Atom';

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -239,11 +239,17 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     $scope.submit = function (form) {
         if (form.$invalid)
             return;  // Form is not ready to submit
-        if ($scope.actionSuccess)
-            return;  // Form has already been submitted
-        const addToComposer = $scope.stub.status !== 'Stub' && $scope.contentName !== 'Atom';
-        const addToAtomEditor = !addToComposer && $scope.contentName === 'Atom' && $scope.stub.status !== 'Stub';
-        $scope.ok(addToComposer, addToAtomEditor);
+        if ($scope.actionSuccess) { // Form has already been submitted successfully
+            if ($scope.composerUrl)
+                window.open($scope.composerUrl, "_blank");
+            if ($scope.editorUrl)
+                window.open($scope.editorUrl, "_blank");
+        }
+        else {
+            const addToComposer = $scope.stub.status !== 'Stub' && $scope.contentName !== 'Atom';
+            const addToAtomEditor = !addToComposer && $scope.contentName === 'Atom' && $scope.stub.status !== 'Stub';
+            $scope.ok(addToComposer, addToAtomEditor);
+        }
     };
 
     $scope.ok = function (addToComposer, addToAtomEditor) {

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -236,6 +236,16 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         }
     };
 
+    $scope.submit = function (form) {
+        if (form.$invalid)
+            return;  // Form is not ready to submit
+        if ($scope.actionSuccess)
+            return;  // Form has already been submitted
+        const addToComposer = $scope.stub.status !== 'Stub' && $scope.contentName !== 'Atom';
+        const addToAtomEditor = !addToComposer && $scope.contentName === 'Atom' && $scope.stub.status !== 'Stub';
+        $scope.ok(addToComposer, addToAtomEditor);
+    };
+
     $scope.ok = function (addToComposer, addToAtomEditor) {
         const stub = $scope.stub;
         function createItemPromise() {


### PR DESCRIPTION
## What does this change?

Currently, pressing enter cancels the modal.  This change improves behaviour such that pressing enter on the modal does the default (displayed button) action.

## How can we measure success?

No behavioural changes other than the improved modal behaviour.

## Images
