### PR TITLE
refactor print location decoration for simplicity

### DIFF
--- a/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
@@ -43,7 +43,10 @@ object StubAPI {
       res <- ApiResponseFt.Async.Right(getRequest(s"content/$composerId"))
       json <- parseBody(res.body)
       maybeStub <- extractDataResponseOpt[Stub](json)
-      maybeDecoratedStub <- ApiResponseFt.Async.Right(Future.traverse(maybeStub)(stubDecorator.withPrintLocationDescriptions))
+      maybeDecoratedStub <- ApiResponseFt.Async.Right(maybeStub match {
+        case Some(stub) => stubDecorator.withPrintLocationDescriptions(stub).map(Some(_))
+        case _ => Future.successful(None)
+      })
     } yield maybeDecoratedStub
   }
 

--- a/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
@@ -43,10 +43,7 @@ object StubAPI {
       res <- ApiResponseFt.Async.Right(getRequest(s"content/$composerId"))
       json <- parseBody(res.body)
       maybeStub <- extractDataResponseOpt[Stub](json)
-      maybeDecoratedStub <- ApiResponseFt.Async.Right(maybeStub match {
-        case Some(stub) => stubDecorator.withPrintLocationDescriptions(stub).map(Some(_))
-        case _ => Future.successful(None)
-      })
+      maybeDecoratedStub <- ApiResponseFt.Async.Right(Future.traverse(maybeStub)(stubDecorator.withPrintLocationDescriptions))
     } yield maybeDecoratedStub
   }
 

--- a/common-lib/src/main/scala/com/gu/workflow/util/StubDecorator.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/util/StubDecorator.scala
@@ -1,0 +1,66 @@
+package com.gu.workflow.util
+
+import com.gu.workflow.lib.ContentAPI
+import models.Stub
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+case class DecoratedPrintLocation(
+  shortDescription: String,
+  longDescription: Option[String]
+)
+
+class StubDecorator(contentAPI: ContentAPI) {
+  def withPrintLocationDescriptions(stub: Stub): Future[Stub] = {
+    for {
+      initiallyDecorated <- addActualPrintInfo(stub)
+      fullyDecorated <- addPlannedPrintInfo(initiallyDecorated)
+    } yield fullyDecorated
+  }
+
+  private def addActualPrintInfo(stub: Stub): Future[Stub] = {
+    for {
+      maybePrintInfo <- getDecoratedActualInfo(stub)
+    } yield maybePrintInfo.map(printInfo => stub.copy(
+      externalData = stub.externalData.map(extData => extData.copy(
+        longActualPrintLocationDescription = printInfo.longDescription,
+        shortActualPrintLocationDescription = Some(printInfo.shortDescription)
+      ))
+    )).getOrElse(stub)
+  }
+
+  private def addPlannedPrintInfo(stub: Stub): Future[Stub] = {
+    for {
+      maybePrintInfo <- getDecoratedPlannedInfo(stub)
+    } yield maybePrintInfo.map(printInfo => stub.copy(
+      longPlannedPrintLocationDescription = printInfo.longDescription,
+      shortPlannedPrintLocationDescription = Some(printInfo.shortDescription)
+    )).getOrElse(stub)
+  }
+
+  private def getDecoratedActualInfo(stub: Stub): Future[Option[DecoratedPrintLocation]] = stub.externalData match {
+    case Some(externalData) if externalData.actualBookId.isDefined && externalData.actualBookSectionId.isDefined => {
+      getDecoratedPrintLocation(externalData.actualBookId.get, externalData.actualBookSectionId.get)
+    }
+    case _ => Future.successful(None)
+  }
+
+  private def getDecoratedPlannedInfo(stub: Stub): Future[Option[DecoratedPrintLocation]] = {
+    (stub.plannedBookId, stub.plannedBookSectionId) match {
+      case (Some(bookId), Some(bookSectionId)) => getDecoratedPrintLocation(bookId, bookSectionId)
+      case _ => Future.successful(None)
+    }
+  }
+
+  private def getDecoratedPrintLocation(bookId: Long, bookSectionId: Long): Future[Option[DecoratedPrintLocation]] = {
+    for {
+      maybeBook <- contentAPI.getTagInternalName(bookId)
+      maybeBookSection <- contentAPI.getTagInternalName(bookSectionId)
+    } yield (maybeBook, maybeBookSection) match {
+      case (Some(book), Some(bookSection)) => Some(DecoratedPrintLocation(bookSection, Some(s"$book >> $bookSection")))
+      case (_, Some(bookSection)) => Some(DecoratedPrintLocation(bookSection, None))
+      case _ => None
+    }
+  }
+}

--- a/common-lib/src/test/scala/com/gu/workflow/util/StubDecoratorTest.scala
+++ b/common-lib/src/test/scala/com/gu/workflow/util/StubDecoratorTest.scala
@@ -1,0 +1,82 @@
+package com.gu.workflow.util
+
+import com.gu.workflow.lib.ContentAPI
+import com.gu.workflow.test.lib.TestData
+import models.{ExternalData, Stub}
+import org.joda.time.LocalDate
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.OneInstancePerTest
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.{Duration, SECONDS}
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+class StubDecoratorTest extends AnyFreeSpec with MockFactory with Matchers with OneInstancePerTest {
+  val initialStub: Stub = TestData.defaultStub().copy(externalData = None)
+
+  val initialExternalData: ExternalData = ExternalData(
+    actualPublicationId = Some(1L),
+    actualBookId = Some(1L),
+    actualBookSectionId = Some(1L),
+    actualNewspaperPageNumber = Some(1),
+    actualNewspaperPublicationDate = Some(LocalDate.now())
+  )
+
+  class MockableContentApi extends ContentAPI("test", "test")
+
+  val contentApi: ContentAPI = stub[MockableContentApi]
+  (contentApi.getTagInternalName (_: Long)(_:ExecutionContext)).when(*, *).returns(Future.successful(Some("internal-tag-name")))
+
+  val decorator = new StubDecorator(contentApi)
+
+  "A stub with actual print information should be decorated" in {
+    val stub = initialStub.copy(externalData = Some(initialExternalData))
+
+    val decoratedStub = Await.result(decorator.withPrintLocationDescriptions(stub), Duration(5, SECONDS))
+    val decoratedExternalData = decoratedStub.externalData.get
+
+    decoratedExternalData.longActualPrintLocationDescription shouldBe Some("internal-tag-name >> internal-tag-name")
+    decoratedExternalData.shortActualPrintLocationDescription shouldBe Some("internal-tag-name")
+
+    decoratedStub.longPlannedPrintLocationDescription shouldBe None
+    decoratedStub.shortPlannedPrintLocationDescription shouldBe None
+  }
+
+  "A stub with planned print information should be decorated" in {
+    val stub = initialStub.copy(
+      plannedPublicationId = Some(1L),
+      plannedBookId = Some(1L),
+      plannedBookSectionId = Some(1L),
+      plannedNewspaperPageNumber = Some(1),
+      plannedNewspaperPublicationDate = Some(LocalDate.now())
+    )
+
+    val decoratedStub = Await.result(decorator.withPrintLocationDescriptions(stub), Duration(5, SECONDS))
+
+    decoratedStub.longPlannedPrintLocationDescription shouldBe Some("internal-tag-name >> internal-tag-name")
+    decoratedStub.shortPlannedPrintLocationDescription shouldBe Some("internal-tag-name")
+
+    decoratedStub.externalData shouldBe None
+  }
+
+  "A stub with both actual and planned print information should be decorated" in {
+    val stub = initialStub.copy(
+      plannedPublicationId = Some(1L),
+      plannedBookId = Some(1L),
+      plannedBookSectionId = Some(1L),
+      plannedNewspaperPageNumber = Some(1),
+      plannedNewspaperPublicationDate = Some(LocalDate.now())
+    ).copy(externalData = Some(initialExternalData))
+
+    val decoratedStub = Await.result(decorator.withPrintLocationDescriptions(stub), Duration(5, SECONDS))
+
+    val decoratedExternalData = decoratedStub.externalData.get
+
+    decoratedExternalData.longActualPrintLocationDescription shouldBe Some("internal-tag-name >> internal-tag-name")
+    decoratedExternalData.shortActualPrintLocationDescription shouldBe Some("internal-tag-name")
+
+    decoratedStub.longPlannedPrintLocationDescription shouldBe Some("internal-tag-name >> internal-tag-name")
+    decoratedStub.shortPlannedPrintLocationDescription shouldBe Some("internal-tag-name")
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,8 @@ object Dependencies {
     "org.seleniumhq.selenium" % "selenium-java" % "2.35.0" % "test",
     "org.scalatestplus" %% "play" % "1.2.0" % "test",
     "org.apache.httpcomponents" % "httpclient" % "4.5.2",
-    specs2 % Test
+    specs2 % Test,
+    "org.scalamock" %% "scalamock" % "4.4.0" % Test
   )
 
   val logbackDependencies = Seq("net.logstash.logback" % "logstash-logback-encoder" % "6.3")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import PlayKeys._
 
 object Dependencies {
   val awsVersion: String = "1.11.784"
-  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.1.0" % "test"
 
   val notificationDependencies = Seq(
     scalaTest,

--- a/test/com/gu/workflow/models/StubTest.scala
+++ b/test/com/gu/workflow/models/StubTest.scala
@@ -5,9 +5,10 @@ import io.circe.parser.decode
 import io.circe.syntax._
 import lib.ResourcesHelper
 import models._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class StubTest extends FreeSpec with Matchers with ResourcesHelper {
+class StubTest extends AnyFreeSpec with Matchers with ResourcesHelper {
   "StubReads" - {
     "should read the minimum required fields for a stub" in {
       val resource = slurp("stub-min-fields.json").getOrElse(

--- a/test/models/ContentResponseTest.scala
+++ b/test/models/ContentResponseTest.scala
@@ -2,9 +2,10 @@ package models
 
 import com.gu.workflow.test.lib.TestData._
 import models.api.ContentResponse
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ContentResponseTest extends FreeSpec with Matchers {
+class ContentResponseTest extends AnyFreeSpec with Matchers {
 
   def withStatus(st: String): Stub => Stub = s => s.copy(externalData = s.externalData.map(_.copy(status = Status.withName(st))))
 


### PR DESCRIPTION
## What does this change?
The current logic is a bit confusing as it's moving a type of `Future[(Option[String], Option[String])]` around and consequently using positional references, which is hard to follow.

Refactor to:
- push print location decoration into its own class
- introduce DecoratedPrintLocation in place of a tuple of optional strings

## How can we measure success?
Easier to understand the print location logic.

## Images
n/a