### PR TITLE
Avoids a race condition which would hide certain menu filters

### DIFF
--- a/public/components/sidebar-filter/sidebar-filter.js
+++ b/public/components/sidebar-filter/sidebar-filter.js
@@ -162,7 +162,7 @@ angular.module('wfSidebarFilter', ['wfFiltersService'])
                     updatePreference('listIsOpen', false);
                 } else {
                     $scope.listIsOpen = true;
-                    $scope.list.style.maxHeight = $scope.listHeight + 'px';
+                    $scope.list.style.maxHeight ='none';
                     updatePreference('listIsOpen', true);
                 }
 
@@ -202,12 +202,6 @@ angular.module('wfSidebarFilter', ['wfFiltersService'])
 
                 function setUpListDisplay () {
                     $scope.list = $scope.list || elem[0].querySelector('.sidebar__filter-list');
-
-                    if (!$scope.listHeight) {
-                        $scope.listHeight = $scope.list.offsetHeight;
-                        $scope.list.style.maxHeight = $scope.listHeight + 'px';
-                        getComputedStyle($scope.list).maxHeight; // Force reflow in FF & IE
-                    }
 
                     if (!$scope.listIsOpen) {
                         $scope.list.style.maxHeight = '0px';


### PR DESCRIPTION
## What does this change?
At the moment, there is a race condition for displaying certain filter options. This can result in menu options being hidden from view by a max height. Options such as "Chose Date" can often be hidden as a consequence.

The current behaviour is to determine a max heigh for a given list of filter options once the page is loaded. When a list gets displayed or hidden, the max height is set to either 0 or a predetermined height based on items that were available when the check was run. If the HTML hasn't been loaded by the time this check takes place, the max height will only be big enough to display the items which have been loaded. 

This PR resolves this issue by not attempting to determine a max height to set the options, but instead setting the max height to none. 

This is possibly removing a "fence" and there may be a good reason it was done this way, but I have not been able to find one.
