### PR TITLE
set X-Frame-Options header on /login/status

### DIFF
--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -4,6 +4,7 @@ import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.Config
 import play.api.libs.ws.WSClient
 import play.api.mvc._
+import play.filters.headers.SecurityHeadersFilter
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -21,7 +22,7 @@ class Login(
 
   def status = AuthAction { request =>
     val user = request.user
-    Ok(views.html.loginStatus(user.toJson))
+    Ok(views.html.loginStatus(user.toJson)).withHeaders(SecurityHeadersFilter.X_FRAME_OPTIONS_HEADER -> "SAMEORIGIN")
   }
 
   def logout = Action.async { implicit request =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -9,6 +9,12 @@ play {
   application.loader = "AppLoader"
 
   filters {
+    // allow the `/login/status` route to set a non default X_FRAME_OPTIONS header value
+    // the default value is `DENY` `/login/status` needs to be `SAMEORIGIN`
+    // see https://www.playframework.com/documentation/2.7.x/SecurityHeaders#Action-specific-overrides
+    headers {
+      allowActionSpecificHeaders = true
+    }
     cors {
       pathPrefixes = [ "/api/" ]
     }


### PR DESCRIPTION
## What does this change?

From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options).

> The X-Frame-Options HTTP response header can be used to indicate whether or not a browser should be allowed to render a page in a `<frame>`, `<iframe>`, `<embed>` or `<object>`. Sites can use this to avoid click-jacking attacks, by ensuring that their content is not embedded into other sites.

Since Play 2.6, this header is set to `DENY` by default on all routes. Meaning no route can be used in an iframe.

Workflow [iframes](https://github.com/guardian/workflow-frontend/blob/1ef15d9c0d6fec306093a0c5f513d3a54f9b886a/public/lib/user.js#L32-L112) its `/login/status` route as part of its (re)auth flow. With the current `X-Frame-Options` header of `DENY`, this flow is broken and yields a message in the console such as:

> Refused to display '/login/status' in a frame because it set 'X-Frame-Options' to 'deny'.

This PR configures the `/login/status` route specifically, setting its X-Frame-Options header to `SAMEORIGIN`. This allows this route to be iframed by a site on the same domain and thus allows Workflow's (re)auth flow to work again. All other routes continue to use the default value for this header, `DENY`.

This is related to the recent [Play upgrade](https://github.com/guardian/workflow-frontend/pull/217). More information [here](https://www.playframework.com/documentation/2.7.x/SecurityHeaders).

## How can we measure success?
Workflow is able to successfully re-authenticate users without needing a page refresh to be performed.

## How to test
- On PROD
- Open Workflow
- Remove the `guToolsAuth` cookies
- Observe the request to `/login/status` fail due to:
```
Refused to display '/login/status' in a frame because it set 'X-Frame-Options' to 'deny'.
```
- On this branch
- Open Workflow
- Remove the `guToolsAuth` cookies
- Observe the request to `/login/status` succeed

## Images
n/a

- [x] tested on CODE