### PR TITLE
Sort workflow columns

### DIFF
--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -116,9 +116,7 @@ function wfContentItemParser(config, statusLabels, sections) {
 
             this.status = item.status || 'Stub';
             this.statusValues = this.status === 'Stub' ? statusLabels : contentStatusValues;
-
-            item.section = sections.filter((section) => section.name === item.section)[0]; // Get section object
-            this.section = item.section;
+            this.section = sections.filter((section) => section.name === item.section)[0]; // Get section object
             this.needsLegal = item.needsLegal;
             this.note = item.note;
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -49,6 +49,7 @@ google-auth-banner .alert {
         th {
             z-index: 3;
             background-color: $c-white;
+            white-space: nowrap;
         }
         tr {
             height: $tableHeaderRowHeight;
@@ -441,6 +442,10 @@ google-auth-banner .alert {
 
 .content-list-head__heading-sort-by {
   cursor: pointer;
+}
+
+.content-list-head__heading-sort-indicator {
+  font-size: 10px;
 }
 
 .content-list__compact-button {

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -439,6 +439,10 @@ google-auth-banner .alert {
     position: relative;
 }
 
+.content-list-head__heading-sort-by {
+  cursor: pointer;
+}
+
 .content-list__compact-button {
     display: block;
     height: 16px;

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -111,8 +111,9 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
 
     $scope.sortColumn = undefined;
     $scope.sortDirection = undefined;
+    const defaultSortColName = 'titles';
+    const sortStates = ['asc', 'desc', undefined];
 
-    const sortStates = ['asc', 'desc', undefined]
     $scope.toggleSortState = columnName => {
       // Reset the sort order if we're toggling a new field
       const sortDirectionIndex = columnName === $scope.sortColumn
@@ -136,6 +137,12 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
 
     wfColumnService.getColumns().then((data) => {
         $scope.columns = data;
+
+        // Apply sort defaults
+        const column = $scope.columns.find(_ => _.name === defaultSortColName);
+        if (column) {
+          $scope.toggleSortState(column.sortField || column.name)
+        }
     });
 
     $scope.getColumnTitle = function(col) {

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -112,7 +112,9 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
     $scope.sortColumn = undefined;
     $scope.sortDirection = undefined;
     const defaultSortColName = 'titles';
-    const sortStates = ['asc', 'desc', undefined];
+    // If we'd prefer to allow people to remove the sort state entirely,
+    // this list can be changed to ['asc', 'desc', undefined]
+    const sortStates = ['asc', 'desc'];
 
     $scope.toggleSortState = columnName => {
       // Reset the sort order if we're toggling a new field

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -34,10 +34,23 @@ import publicationLocationTemplate from "components/content-list-item/templates/
  *      colspan: number, // colspan of this field
  *      title: string, // title attribute contents for the column heading
  *      templateUrl: string // URL for the content-list-item template for this field
+ *      isSortable: boolean // Can the column be sorted by clicking its header?
+ *      sortField: string // The field to sort on, if different from `name`. Can be an item path, e.g. `a.nested.field`
  * }
  */
 
 var templateRoot = '/assets/components/content-list-item/templates/';
+
+const createSortTemplate = (sortField, labelHTML) => `
+    <div ng-click="toggleSortState('${sortField}')" class="content-list-head__heading-sort-by">
+      ${labelHTML}
+      <span ng-switch="getSortDirection('${sortField}')">
+        <span ng-switch-when="asc">🔼</span>
+        <span ng-switch-when="desc">🔽</span>
+        <span ng-switch-default></span>
+      </span>
+    </div>
+`;
 
 var columnDefaults = [{
     name: 'priority',
@@ -71,7 +84,9 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'title.html',
     template: titleTemplate,
     active: true,
-    alwaysShown: true
+    alwaysShown: true,
+    isSortable: true,
+    sortField: 'workingTitle'
 },{
     name: 'notes',
     prettyName: 'Notes',
@@ -80,7 +95,9 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'notes.html',
     template: notesTemplate,
-    active: true
+    active: true,
+    isSortable: true,
+    sortField: 'note'
 },{
     name: 'comments',
     prettyName: 'Comments: On/Off',
@@ -163,7 +180,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'office.html',
     template: officeTemplate,
-    active: true
+    active: true,
+    isSortable: true
 },{
     name: 'deadline',
     prettyName: 'Deadline',
@@ -172,7 +190,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'deadline.html',
     template: deadlineTemplate,
-    active: true
+    active: true,
+    isSortable: true
 },{
     name: 'section',
     prettyName: 'Section',
@@ -181,7 +200,9 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'section.html',
     template: sectionTemplate,
-    active: true
+    active: true,
+    isSortable: true,
+    sortField: 'item.section',
 },{
     name: 'status',
     prettyName: 'Status',
@@ -199,7 +220,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'wordcount.html',
     template: wordcountTemplate,
-    active: false
+    active: false,
+    isSortable: true
 },{
     name: 'printwordcount',
     prettyName: 'Print wordcount',
@@ -209,7 +231,8 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'printwordcount.html',
     template: printWordcountTemplate,
     active: false,
-    isNew: true
+    isNew: true,
+    isSortable: true
 },{
     name: 'publicationlocation',
     prettyName: 'Publication location',
@@ -219,7 +242,8 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'publicationLocation.html',
     template: publicationLocationTemplate,
     active: false,
-    isNew: true
+    isNew: true,
+    isSortable: true
 },{
     name: 'commissionedLength',
     prettyName: 'Commissioned Length',
@@ -228,7 +252,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'commissionedLength.html',
     template: commissionedLengthTemplate,
-    active: false
+    active: false,
+    isSortable: true
 },{
     name: 'links',
     prettyName: 'Open in...',
@@ -265,7 +290,8 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'last-modified.html',
     template: lastModifiedTemplate,
     active: false,
-    isNew: true
+    isNew: true,
+    isSortable: true
 },{
     name: 'last-modified-by',
     prettyName: 'Last modified by',
@@ -275,7 +301,16 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'last-modified-by.html',
     template: lastModifiedByTemplate,
     active: false,
-    isNew: true
-}].map(col => col.labelHTML === '' ? {...col, labelHTML: '&nbsp;'} : col);
+    isNew: true,
+    isSortable: true
+}].map(col => {
+  if (col.labelHTML === '') {
+    return {...col, labelHTML: '&nbsp;'};
+  }
+  if (col.isSortable) {
+    return { ...col, labelHTML: createSortTemplate(col.sortField || col.name, col.labelHTML)}
+  }
+  return col;
+});
 
 export { columnDefaults }

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -220,8 +220,7 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'wordcount.html',
     template: wordcountTemplate,
-    active: false,
-    isSortable: true
+    active: false
 },{
     name: 'printwordcount',
     prettyName: 'Print wordcount',
@@ -231,8 +230,7 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'printwordcount.html',
     template: printWordcountTemplate,
     active: false,
-    isNew: true,
-    isSortable: true
+    isNew: true
 },{
     name: 'publicationlocation',
     prettyName: 'Publication location',
@@ -242,8 +240,7 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'publicationLocation.html',
     template: publicationLocationTemplate,
     active: false,
-    isNew: true,
-    isSortable: true
+    isNew: true
 },{
     name: 'commissionedLength',
     prettyName: 'Commissioned Length',
@@ -252,8 +249,7 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'commissionedLength.html',
     template: commissionedLengthTemplate,
-    active: false,
-    isSortable: true
+    active: false
 },{
     name: 'links',
     prettyName: 'Open in...',
@@ -290,8 +286,7 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'last-modified.html',
     template: lastModifiedTemplate,
     active: false,
-    isNew: true,
-    isSortable: true
+    isNew: true
 },{
     name: 'last-modified-by',
     prettyName: 'Last modified by',
@@ -301,8 +296,7 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'last-modified-by.html',
     template: lastModifiedByTemplate,
     active: false,
-    isNew: true,
-    isSortable: true
+    isNew: true
 }].map(col => {
   if (col.labelHTML === '') {
     return {...col, labelHTML: '&nbsp;'};

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -44,10 +44,15 @@ var templateRoot = '/assets/components/content-list-item/templates/';
 const createSortTemplate = (sortField, labelHTML) => `
     <div ng-click="toggleSortState('${sortField}')" class="content-list-head__heading-sort-by">
       ${labelHTML}
-      <span ng-switch="getSortDirection('${sortField}')">
-        <span ng-switch-when="asc">🔼</span>
-        <span ng-switch-when="desc">🔽</span>
-        <span ng-switch-default></span>
+      <span
+        class="content-list-head__heading-sort-indicator"
+        ng-class="{invisible: !getSortDirection('${sortField}')}"
+        ng-switch="getSortDirection('${sortField}')">
+        <span ng-switch-when="asc">&#9660;</span>
+        <span ng-switch-when="desc">&#9650;</span>
+        <!-- We add a character here and use ng-visible above to prevent -->
+        <!-- sort state from interfering with table header spacing -->
+        <span ng-switch-default>&#9650;</span>
       </span>
     </div>
 `;
@@ -298,13 +303,15 @@ var columnDefaults = [{
     active: false,
     isNew: true
 }].map(col => {
-  if (col.labelHTML === '') {
-    return {...col, labelHTML: '&nbsp;'};
-  }
-  if (col.isSortable) {
-    return { ...col, labelHTML: createSortTemplate(col.sortField || col.name, col.labelHTML)}
-  }
-  return col;
+  const _labelHTML = col.labelHTML === ''
+    ? '&nbsp;'
+    : col.labelHTML;
+
+  const labelHTML = col.isSortable
+    ? createSortTemplate(col.sortField || col.name, _labelHTML)
+    : _labelHTML;
+
+  return {...col, labelHTML};
 });
 
 export { columnDefaults }


### PR DESCRIPTION
## What does this change?

This PR makes some workflow columns sortable on click of the column header.

![sort-workflow-cols](https://user-images.githubusercontent.com/7767575/85062745-eef2e180-b1a0-11ea-8d09-6ee21105daae.gif)

The list of sortable columns can grow as what is represented in the template vs the model is reconciled. The list of columns made sortable by this PR should be clear when reviewing `column-defaults.js`.

## How can we measure success?

Click on the column header of any column referenced as sortable in `column-defaults.js`. You should see an emoji displaying the sort direction on the column. The content should be sorted accordingly.

Toggling through the states should work as expected – asc, desc, none, repeat. Toggling different columns should reset the sort order and add an ascending sort to the current column, removing the previous sort.

## Notes

- Sorting triggers the table's 'new content' highlight UX. This might feel misleading, although it could be difficult to work around – please let me know!
- At the moment, we sort ignoring lowercase, but there's no allowance for natural sort, dates etc. We will probably need to improve this to avoid misleading results in columns that require those kinds of sorting approaches.
- We'll need to model the print location data as a single, sortable value to be able to sort by that value, which I don't think is currently the case. This work probably belongs in another PR – `content-list-item.js` contains the `ContentItemView` class I think we'd need to alter. This should also allow us to simplify the `publicationLocation.html` template, too, by moving the display logic into the model (or – even better – onto the server?)
- This would be an ideal candidate for an integration test 😅 – AFAIK we don't have a framework at the moment for this project, but once one is there ... 😁 

