### PR TITLE
Fix section selection for modal so it works with custom desks

### DIFF
--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -109,16 +109,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
      * @returns Filtered list of sections
      */
     function getSectionsList (sections) {
-        const deskId = wfFiltersService.get('desk');
-
-        if (deskId) {
-            const sectionsIdsInThisDesk = sectionsInDesks.filter((el) => el.deskId === parseInt(deskId, 10));
-            if (sectionsIdsInThisDesk.length > 0) {
-                const setSectionsIdsInThisDesk = new Set(sectionsIdsInThisDesk[0].sectionIds);
-                sections = sections.filter((el) => setSectionsIdsInThisDesk.has(el.id))
-            }
-        }
-        return sections;
+        return sections.filter(({selected})=>selected);
     }
 
     $scope.legalStates = legalStatesService.getLegalStates();


### PR DESCRIPTION
## What does this change?

This changes the section dropdown in the create modal to work with custom desks. 
Previously it used the selected desk and filtered the sections off that, but the selection state is already *in* the section model. 

## How can we measure success?

Section selection will be limited to selected sections.




## Images
![Kapture 2020-06-21 at 14 05 57](https://user-images.githubusercontent.com/2670496/85225332-5b035e80-b3c8-11ea-81c7-98e8f19a5dfc.gif)