### PR TITLE
[Fix, sorting]: Handle empty content when we apply the new content state

### DIFF
--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -336,7 +336,9 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
             $scope.displayingEverything = false;
         }
 
-        $scope.content = $scope.getSortedAndTrimmedContent($scope.originalContent, $scope.contentItemsDisplayed, $scope.totalContentItems);
+        if ($scope.originalContent) {
+          $scope.content = $scope.getSortedAndTrimmedContent($scope.originalContent, $scope.contentItemsDisplayed, $scope.totalContentItems);
+        }
     }
 
     function parseContentForIds(content) {


### PR DESCRIPTION
## What does this change?

The very-recent [`sorting` PR](#253) introduced a common error. AFAIK It doesn't affect the user experience, but it does produce red ink and noise in our logs.

It's caused by the sorting code being called before content is ready. This change ensures that we wait for content before we sort.

## How can we measure success?

Fewer (no!) Sentry logs that look like [this](https://sentry.io/organizations/the-guardian/issues/1739110688/?project=33134&query=is%3Aunresolved).
