### PR TITLE
Add more sortable columns

### DIFF
--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -1,8 +1,8 @@
 
-var OPHAN_PATH = 'https://dashboard.ophan.co.uk/summary?path=/',
+const OPHAN_PATH = 'https://dashboard.ophan.co.uk/summary?path=/',
     LIVE_PATH = 'http://www.theguardian.com/';
 
-function wfContentItemParser(config, statusLabels, sections) {
+function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
     /*jshint validthis:true */
 
     function getFullOfficeString(office) {
@@ -179,7 +179,60 @@ function wfContentItemParser(config, statusLabels, sections) {
             this.plannedNewspaperPageNumber = item.plannedNewspaperPageNumber;
             this.plannedNewspaperPublicationDate = item.plannedNewspaperPublicationDate;
 
+            // These are derived values used for display purposes.
+            const {
+              shortPrintLocationDescription,
+              newspaperPageNumber,
+              newspaperPublicationDate,
+              longPrintLocationDescription,
+              printLocationType
+            } = this.getPrintValues(item);
+
+            if (shortPrintLocationDescription) {
+              const newspaperPageNumberStr = newspaperPageNumber
+                ? `p. ${newspaperPageNumber}`
+                : '';
+              this.printLocationDisplayString = `${shortPrintLocationDescription}<br />${newspaperPageNumberStr} ${wfFormatDateTime(newspaperPublicationDate, 'DD MMMM')}`;
+              // We use 8601 dates to make the date sortable.
+              this.printLocationSortString = `${shortPrintLocationDescription} ${newspaperPageNumberStr} ${wfFormatDateTime(newspaperPublicationDate, 'ISO8601')}`
+              this.longPrintLocationDescription = longPrintLocationDescription;
+              this.printLocationType = printLocationType;
+            }
+
             this.item = item;
+        }
+
+        getPrintValues(item) {
+          const printLocationType = this.getPrintLocationType(item);
+          if (printLocationType === 'actual') {
+            return {
+              longPrintLocationDescription: item.longActualPrintLocationDescription,
+              shortPrintLocationDescription: item.shortActualPrintLocationDescription,
+              newspaperPageNumber: item.actualNewspaperPageNumber,
+              newspaperPublicationDate: new Date(item.actualNewspaperPublicationDate),
+              printLocationType
+            }
+          }
+          if (printLocationType === 'planned') {
+            return {
+                longPrintLocationDescription: item.longPlannedPrintLocationDescription,
+                shortPrintLocationDescription: item.shortPlannedPrintLocationDescription,
+                newspaperPageNumber: item.plannedNewspaperPageNumber,
+                newspaperPublicationDate: new Date(item.plannedNewspaperPublicationDate),
+                printLocationType
+            }
+          }
+          return {}; // For easy destructuring in the caller;
+        }
+
+        getPrintLocationType(item) {
+          if (item.shortActualPrintLocationDescription) {
+            return 'actual';
+          }
+          if (item.shortPlannedPrintLocationDescription) {
+            return 'planned';
+          }
+          return undefined;
         }
 
         lifecycleState(item) {

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -143,6 +143,7 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
             this.lifecycleStateKey  = lifecycleState.key;
             this.lifecycleStateSupl = lifecycleState.supl;
             this.lifecycleStateSuplDate = lifecycleState.suplDate;
+            this.lifecycleStateSortString = `${lifecycleState.display}-${lifecycleState.suplDate}`;
 
             this.links = new ContentItemLinks(item);
             this.path = item.path;
@@ -194,7 +195,7 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
                 : '';
               this.printLocationDisplayString = `${shortPrintLocationDescription}<br />${newspaperPageNumberStr} ${wfFormatDateTime(newspaperPublicationDate, 'DD MMMM')}`;
               // We use 8601 dates to make the date sortable.
-              this.printLocationSortString = `${shortPrintLocationDescription} ${newspaperPageNumberStr} ${wfFormatDateTime(newspaperPublicationDate, 'ISO8601')}`
+              this.printLocationSortString = `${shortPrintLocationDescription}-${newspaperPageNumberStr}-${wfFormatDateTime(newspaperPublicationDate, 'ISO8601')}`
               this.longPrintLocationDescription = longPrintLocationDescription;
               this.printLocationType = printLocationType;
             }

--- a/public/components/content-list-item/templates/publicationLocation.html
+++ b/public/components/content-list-item/templates/publicationLocation.html
@@ -1,25 +1,9 @@
 <td class="content-list-item__field--publicationlocation" title="Publication location">
     <span ng-show="contentItem.contentType == 'article'">
-        <div ng-if="contentItem.shortActualPrintLocationDescription"
-             class="actual-print-location"
-             title="{{ contentItem.longActualPrintLocationDescription }}">
-            {{ contentItem.shortActualPrintLocationDescription }}
-            <br/>
-            <span ng-if="contentItem.actualNewspaperPageNumber">
-                p. {{ contentItem.actualNewspaperPageNumber }},
-            </span>
-            {{ contentItem.actualNewspaperPublicationDate | wfFormatDateTime:'DD MMM'}}
-        </div>
-        <div
-                ng-if="!(contentItem.shortActualPrintLocationDescription) && contentItem.shortPlannedPrintLocationDescription"
-                class="planned-print-location"
-                title="{{ contentItem.longPlannedPrintLocationDescription }}">
-            {{ contentItem.shortPlannedPrintLocationDescription }}
-            <br/>
-            <span ng-if="contentItem.plannedNewspaperPageNumber">
-                p. {{ contentItem.plannedNewspaperPageNumber }},
-            </span>
-            {{ contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'DD MMM'}}
+        <div ng-if="!!contentItem.printLocationDisplayString"
+          class="{{contentItem.printLocationType}}-print-location"
+          title="{{ contentItem.longPrintLocationDescription }}"
+          ng-bind-html="contentItem.printLocationDisplayString | wfTrustedHtml">
         </div>
     </span>
 </td>

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -266,7 +266,7 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
      */
     $scope.getSortedAndTrimmedContent = (content, trimTo) => {
       const { content: newContent } = content.reduce(({ itemsRemaining, content }, group) => {
-        // Avoid hydrating and sorted if we're not rendering any of these items
+        // Avoid hydrating and sorting if we're not rendering any of these items
         if (!itemsRemaining) {
           return {
             itemsRemaining,

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -26,7 +26,7 @@ import { wfLoader } from 'components/loader/loader';
 
 
 angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOfficeService', 'wfPresenceService', 'wfEditableField', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService', 'wfSettingsService', 'wfComposerService'])
-    .service('wfContentItemParser', ['config', 'statusLabels', 'sections', wfContentItemParser])
+    .service('wfContentItemParser', ['config', 'wfFormatDateTimeFilter', 'statusLabels', 'sections', wfContentItemParser])
     .filter('getPriorityString', wfGetPriorityStringFilter)
     .controller('wfContentListController', ['$rootScope', '$scope', '$anchorScroll', 'statuses', 'legalValues', 'priorities', 'sections', 'wfContentService', 'wfContentPollingService', 'wfContentItemParser', 'wfPresenceService', 'wfColumnService', 'wfPreferencesService', 'wfFiltersService', wfContentListController])
     .directive('wfContentListLoader', ['$rootScope', wfLoader])

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -226,7 +226,7 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'wordcount.html',
     template: wordcountTemplate,
-    active: false,
+    active: true,
     isSortable: true,
     sortField: 'wordCount'
 },{
@@ -237,7 +237,7 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'printwordcount.html',
     template: printWordcountTemplate,
-    active: false,
+    active: true,
     isNew: true,
     isSortable: true,
     sortField: 'printWordCount'
@@ -249,8 +249,10 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'publicationLocation.html',
     template: publicationLocationTemplate,
-    active: false,
-    isNew: true
+    active: true,
+    isNew: true,
+    isSortable: true,
+    sortField: 'printLocationSortString'
 },{
     name: 'commissionedLength',
     prettyName: 'Commissioned Length',
@@ -259,7 +261,7 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'commissionedLength.html',
     template: commissionedLengthTemplate,
-    active: false,
+    active: true,
     isSortable: true
 },{
     name: 'links',
@@ -296,9 +298,10 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'last-modified.html',
     template: lastModifiedTemplate,
-    active: false,
+    active: true,
     isNew: true,
-    isSortable: true
+    isSortable: true,
+    sortField: 'lastModified'
 },{
     name: 'last-modified-by',
     prettyName: 'Last modified by',
@@ -307,9 +310,10 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'last-modified-by.html',
     template: lastModifiedByTemplate,
-    active: false,
+    active: true,
     isNew: true,
-    isSortable: true
+    isSortable: true,
+    sortField: 'lastModifiedBy'
 }].map(col => {
   const _labelHTML = col.labelHTML === ''
     ? '&nbsp;'

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -48,8 +48,8 @@ const createSortTemplate = (sortField, labelHTML) => `
         class="content-list-head__heading-sort-indicator"
         ng-class="{invisible: !getSortDirection('${sortField}')}"
         ng-switch="getSortDirection('${sortField}')">
-        <span ng-switch-when="asc">&#9660;</span>
-        <span ng-switch-when="desc">&#9650;</span>
+        <span ng-switch-when="desc">&#9660;</span>
+        <span ng-switch-when="asc">&#9650;</span>
         <!-- We add a character here and use ng-visible above to prevent -->
         <!-- sort state from interfering with table header spacing -->
         <span ng-switch-default>&#9650;</span>

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -226,7 +226,9 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'wordcount.html',
     template: wordcountTemplate,
-    active: false
+    active: false,
+    isSortable: true,
+    sortField: 'wordCount'
 },{
     name: 'printwordcount',
     prettyName: 'Print wordcount',
@@ -236,7 +238,9 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'printwordcount.html',
     template: printWordcountTemplate,
     active: false,
-    isNew: true
+    isNew: true,
+    isSortable: true,
+    sortField: 'printWordCount'
 },{
     name: 'publicationlocation',
     prettyName: 'Publication location',
@@ -255,7 +259,8 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'commissionedLength.html',
     template: commissionedLengthTemplate,
-    active: false
+    active: false,
+    isSortable: true
 },{
     name: 'links',
     prettyName: 'Open in...',
@@ -292,7 +297,8 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'last-modified.html',
     template: lastModifiedTemplate,
     active: false,
-    isNew: true
+    isNew: true,
+    isSortable: true
 },{
     name: 'last-modified-by',
     prettyName: 'Last modified by',
@@ -302,7 +308,8 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'last-modified-by.html',
     template: lastModifiedByTemplate,
     active: false,
-    isNew: true
+    isNew: true,
+    isSortable: true
 }].map(col => {
   const _labelHTML = col.labelHTML === ''
     ? '&nbsp;'

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -280,7 +280,9 @@ var columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'published-state.html',
     template: publishedStateTemplate,
-    active: true
+    active: true,
+    isSortable: true,
+    sortField: 'lifecycleStateSortString'
 },{
     name: 'needsLegal',
     prettyName: 'Needs Legal',


### PR DESCRIPTION
## What does this change?

Adds more sortable columns to workflow. Numbers now behave themselves – dates should too (and always have, I thought they'd need more work but they're all ISO8601 AFAICS).

![sort-workflow-cols-2](https://user-images.githubusercontent.com/7767575/85323781-91bca000-b4c0-11ea-9a7e-172bdc35567d.gif)

This should include every column with heading text – we can add others, although it might be a bit of UX to figure out how to represent them.

## How can we measure success?

Click through each column heading in workflow. Things should sort correctly on a per-section basis, including numbers and dates.

There's one caveat – some columns conditionally hide values if the content type isn't `article`. There are a few examples on CODE but I wasn't sure how common this was in PROD – if this turns out to be an issue we can revisit how these values are modelled.
