### PR TITLE
Disable debug info to improve performances

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -88,6 +88,8 @@ angular.module('workflow',
         $compileProvider.aHrefSanitizationWhitelist(
             sanitizeUrl(_wfConfig.indesignExportUrl)
         );
+        
+        $compileProvider.debugInfoEnabled(false);
 
         $provide.decorator('$log', ["$delegate", 'logger', function ($delegate, logger) {
 


### PR DESCRIPTION
## What does this change?

The associated changes disable  debug data as by default AngularJS attaches information about binding and scopes to DOM nodes, and adds CSS classes to data-bound elements.

According to [angular documentation](https://code.angularjs.org/1.8.0/docs/guide/production):

>  you can disable this in production for a significant performance boost  

💥 ⚡ 

See similar changes:
 - [grid](https://github.com/guardian/grid/pull/1882)
 - [composer](https://github.com/guardian/flexible-content/pull/2545)


## How to review and test
- check that nothing break

## How can we measure success?

From  @akash1810  `There is an argument that perf isn't down to angular, but rather our implementation`, so the test case in the discussion thread can be used to test if performance is better.

