### PR TITLE
Revert "Disable debug info to improve performances"

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -88,8 +88,6 @@ angular.module('workflow',
         $compileProvider.aHrefSanitizationWhitelist(
             sanitizeUrl(_wfConfig.indesignExportUrl)
         );
-        
-        $compileProvider.debugInfoEnabled(false);
 
         $provide.decorator('$log', ["$delegate", 'logger', function ($delegate, logger) {
 


### PR DESCRIPTION
Reverts guardian/workflow-frontend#257.

I didn't spot this on CODE on review, but we require this debug info in [dashboard-toolbar.js](https://github.com/guardian/workflow-frontend/blob/master/public/layouts/dashboard/dashboard-toolbar.js), and removing it disables this functionality and throws an error that's picked up by the console and the workflow notifications at the top of the page. We'll need to find a workaround before we can merge it again.