### PR TITLE
Provide sensible defaults on column sort

### DIFF
--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -34,22 +34,27 @@ import publicationLocationTemplate from "components/content-list-item/templates/
  *      colspan: number, // colspan of this field
  *      title: string, // title attribute contents for the column heading
  *      templateUrl: string // URL for the content-list-item template for this field
- *      isSortable: boolean // Can the column be sorted by clicking its header?
- *      sortField: string // The field to sort on, if different from `name`. Can be an item path, e.g. `a.nested.field`
+ *      isSortable: boolean = false // Can the column be sorted by clicking its header?
+ *      sortField?: string // The field to sort on, if different from `name`. Can be an item path, e.g. `a.nested.field`
+ *      defaultSortOrder?: 'asc' | 'desc' // The default sort order for the column on first click. Defaults to 'asc'
+ *      flipSortIconDirection: boolean = false // Flip the direction of the sort chevron relative to the sort order. Defaults to 'desc' -> ▼
  * }
  */
 
 var templateRoot = '/assets/components/content-list-item/templates/';
 
-const createSortTemplate = (sortField, labelHTML) => `
+const chevronUp = '&#9660;'
+const chevronDown = '&#9650;'
+
+const createSortTemplate = (sortField, labelHTML, flipSortIconDirection = false) => `
     <div ng-click="toggleSortState('${sortField}')" class="content-list-head__heading-sort-by">
       ${labelHTML}
       <span
         class="content-list-head__heading-sort-indicator"
         ng-class="{invisible: !getSortDirection('${sortField}')}"
         ng-switch="getSortDirection('${sortField}')">
-        <span ng-switch-when="desc">&#9660;</span>
-        <span ng-switch-when="asc">&#9650;</span>
+        <span ng-switch-when="desc">${flipSortIconDirection ? chevronDown : chevronUp}</span>
+        <span ng-switch-when="asc">${flipSortIconDirection ? chevronUp : chevronDown}</span>
         <!-- We add a character here and use ng-visible above to prevent -->
         <!-- sort state from interfering with table header spacing -->
         <span ng-switch-default>&#9650;</span>
@@ -57,7 +62,11 @@ const createSortTemplate = (sortField, labelHTML) => `
     </div>
 `;
 
-var columnDefaults = [{
+export const getSortField = column => column
+  && column.isSortable
+  && (column.sortField || column.name);
+
+const columnDefaults = [{
     name: 'priority',
     prettyName: 'Priority',
     labelHTML: '<i class="content-list-item__icon--priority" wf-icon="priority-neutral" />',
@@ -67,7 +76,9 @@ var columnDefaults = [{
     template: priorityTemplate,
     active: true,
     alwaysShown: true,
-    isSortable: true
+    isSortable: true,
+    defaultSortOrder: 'desc',
+    flipSortIconDirection: true
 },{
     name: 'content-type',
     prettyName: 'Content Type',
@@ -193,7 +204,8 @@ var columnDefaults = [{
     templateUrl: templateRoot + 'deadline.html',
     template: deadlineTemplate,
     active: true,
-    isSortable: true
+    isSortable: true,
+    defaultSortOrder: 'desc'
 },{
     name: 'section',
     prettyName: 'Section',
@@ -299,7 +311,8 @@ var columnDefaults = [{
     active: true,
     isNew: true,
     isSortable: true,
-    sortField: 'lastModified'
+    sortField: 'lastModified',
+    defaultSortOrder: 'desc'
 },{
     name: 'last-modified-by',
     prettyName: 'Last modified by',
@@ -318,10 +331,10 @@ var columnDefaults = [{
     : col.labelHTML;
 
   const labelHTML = col.isSortable
-    ? createSortTemplate(col.sortField || col.name, _labelHTML)
+    ? createSortTemplate(getSortField(col), _labelHTML, col.flipSortIconDirection)
     : _labelHTML;
 
-  return {...col, labelHTML};
+  return {...col, active: true, labelHTML};
 });
 
 export { columnDefaults }

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -46,21 +46,28 @@ var templateRoot = '/assets/components/content-list-item/templates/';
 const chevronUp = '&#9660;'
 const chevronDown = '&#9650;'
 
-const createSortTemplate = (sortField, labelHTML, flipSortIconDirection = false) => `
+const createSortTemplate = (sortField, labelHTML, flipSortIconDirection = false) => {
+  // For some field types, the semantics of 'up' or 'down' differ; we use
+  // flipSortIconDirection to switch them when needed.
+  const descChevron = flipSortIconDirection ? chevronDown : chevronUp;
+  const ascChevron = flipSortIconDirection ? chevronUp : chevronDown;
+
+  return `
     <div ng-click="toggleSortState('${sortField}')" class="content-list-head__heading-sort-by">
       ${labelHTML}
       <span
         class="content-list-head__heading-sort-indicator"
         ng-class="{invisible: !getSortDirection('${sortField}')}"
         ng-switch="getSortDirection('${sortField}')">
-        <span ng-switch-when="desc">${flipSortIconDirection ? chevronDown : chevronUp}</span>
-        <span ng-switch-when="asc">${flipSortIconDirection ? chevronUp : chevronDown}</span>
+        <span ng-switch-when="desc">${descChevron}</span>
+        <span ng-switch-when="asc">${ascChevron}</span>
         <!-- We add a character here and use ng-visible above to prevent -->
         <!-- sort state from interfering with table header spacing -->
         <span ng-switch-default>&#9650;</span>
       </span>
     </div>
-`;
+  `;
+};
 
 export const getSortField = column => column
   && column.isSortable


### PR DESCRIPTION
## What does this change?

This applies the following defaults to the sortable workflow columns:

- Priority, first-click view ▲ (top priority on top, low bottom)
- Webtitle, first-click view ▲ (A at top, Z at bottom)
- Notes, first-click view ▲ (A at top, Z at bottom)
- Office, first-click view ▲ (A at top, Z at bottom)
- Deadline, first-click view ▼ (newest at top, oldest at bottom)
- Section, first-click view ▲ (A at top, Z at bottom)
- Webwords, first-click view ▲ (low nos. top, high nos. bottom) <--- for discussion?
- Printwords, first-click view ▲ (low nos. top, high nos. bottom) <--- for discussion?
- Publication location, first-click view ▲ (Booksection A–Z, then pubdate newest at top, then page no. low nos. top)
- Commission, first-click view ▲ (low nos. top, high nos. bottom)
- State, first-click view ▲ (State A–Z, then date newest top)
- Last modified, first-click view ▼ (newest at top, oldest at bottom)
- Last modified by, first-click view ▲ (A at top, Z at bottom)

There are two caveats –

- Sparsely populated fields like publication location, notes, state etc. treat no data as less-than some data, which leads to some emptier-than-expected first states. We can discuss how to deal with these – it might be better to treat empty fields according to the default sort order to push them downwards when we first click by default.
- With the current approach, 'Publication location' and 'State' might not quite reflect what's in the list (we can't break the data down into its parts and sort each part with different directions yet).

## How can we measure success?

Click on the column headings – they should behave as above, notes above notwithstanding.

