### PR TITLE
Rename Publication location to Print location

### DIFF
--- a/public/components/content-list-item/templates/printLocation.html
+++ b/public/components/content-list-item/templates/printLocation.html
@@ -1,4 +1,4 @@
-<td class="content-list-item__field--publicationlocation" title="Print location">
+<td class="content-list-item__field--printlocation" title="Print location">
     <span ng-show="contentItem.contentType == 'article'">
         <div ng-if="!!contentItem.printLocationDisplayString"
           class="{{contentItem.printLocationType}}-print-location"

--- a/public/components/content-list-item/templates/publicationLocation.html
+++ b/public/components/content-list-item/templates/publicationLocation.html
@@ -1,4 +1,4 @@
-<td class="content-list-item__field--publicationlocation" title="Publication location">
+<td class="content-list-item__field--publicationlocation" title="Print location">
     <span ng-show="contentItem.contentType == 'article'">
         <div ng-if="!!contentItem.printLocationDisplayString"
           class="{{contentItem.printLocationType}}-print-location"

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -22,7 +22,7 @@ import commissionedLengthTemplate  from "components/content-list-item/templates/
 import needsLegalTemplate          from "components/content-list-item/templates/needsLegal.html";
 import lastModifiedTemplate        from "components/content-list-item/templates/last-modified.html";
 import lastModifiedByTemplate      from "components/content-list-item/templates/last-modified-by.html";
-import publicationLocationTemplate from "components/content-list-item/templates/publicationLocation.html";
+import printLocationTemplate       from "components/content-list-item/templates/printLocation.html";
 
 /**
  * This array represents the default ordering and display of the content-list-item columns for workflow.
@@ -257,13 +257,13 @@ const columnDefaults = [{
     isSortable: true,
     sortField: 'printWordCount'
 },{
-    name: 'publicationlocation',
+    name: 'printlocation',
     prettyName: 'Print location',
     labelHTML: 'Print location',
     colspan: 1,
     title: '',
-    templateUrl: templateRoot + 'publicationLocation.html',
-    template: publicationLocationTemplate,
+    templateUrl: templateRoot + 'printLocation.html',
+    template: printLocationTemplate,
     active: true,
     isNew: true,
     isSortable: true,

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -258,8 +258,8 @@ const columnDefaults = [{
     sortField: 'printWordCount'
 },{
     name: 'publicationlocation',
-    prettyName: 'Publication location',
-    labelHTML: 'Publication location',
+    prettyName: 'Print location',
+    labelHTML: 'Print location',
     colspan: 1,
     title: '',
     templateUrl: templateRoot + 'publicationLocation.html',


### PR DESCRIPTION
Ronseal. We are renaming this to be more inline with what Composer called it for years. Why column different from Management panel where it’s gonna be Print information? Cos in other places this may/will contain other print-related information in the future, while the column just holds info about location. And should, maybe, be three columns anyway…

- [x] tested on CODE
