### PR TITLE
show all sections if no sections

### DIFF
--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -109,7 +109,11 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
      * @returns Filtered list of sections
      */
     function getSectionsList (sections) {
-        return sections.filter(({selected})=>selected);
+        const filtered = sections.filter(({ selected }) => selected);
+        if (filtered.length === 0) {
+            return sections
+        }
+        return filtered
     }
 
     $scope.legalStates = legalStatesService.getLegalStates();


### PR DESCRIPTION
## What does this change?
show all sections if no sections in the create modal. Fixes [this](https://trello.com/c/btltPDU1/283-populate-sections-dropdown-when-no-desk-section-chosen).

## How can we measure success?
all sections shown instead of none

## What is the cost of failure?
<!-- Is this a critical path? Does failure costs money, violates law, ruins reputation? Do we need to alarm on failure? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
