### PR TITLE
Sort by multiple fields

### DIFF
--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -143,7 +143,6 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
             this.lifecycleStateKey  = lifecycleState.key;
             this.lifecycleStateSupl = lifecycleState.supl;
             this.lifecycleStateSuplDate = lifecycleState.suplDate;
-            this.lifecycleStateSortString = `${lifecycleState.display}-${lifecycleState.suplDate}`;
 
             this.links = new ContentItemLinks(item);
             this.path = item.path;
@@ -195,7 +194,9 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
                 : '';
               this.printLocationDisplayString = `${shortPrintLocationDescription}<br />${newspaperPageNumberStr} ${wfFormatDateTime(newspaperPublicationDate, 'DD MMMM')}`;
               // We use 8601 dates to make the date sortable.
-              this.printLocationSortString = `${shortPrintLocationDescription}-${newspaperPageNumberStr}-${wfFormatDateTime(newspaperPublicationDate, 'ISO8601')}`
+              this.printLocationBookSection = shortPrintLocationDescription;
+              this.printLocationPublicationDate =wfFormatDateTime(newspaperPublicationDate, 'ISO8601');
+              this.printLocationPageNumber = newspaperPageNumberStr;
               this.longPrintLocationDescription = longPrintLocationDescription;
               this.printLocationType = printLocationType;
             }

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -96,6 +96,7 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
             this.workingTitle = item.workingTitle || item.title;
 
             this.priority = item.priority;
+            this.prioritySortValue = item.priority !== undefined ? item.priority : 0;
 
             this.hasComments = !!(item.commentable);
             this.commentsTitle = this.hasComments ? 'on' : 'off';
@@ -196,7 +197,7 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
               // We use 8601 dates to make the date sortable.
               this.printLocationBookSection = shortPrintLocationDescription;
               this.printLocationPublicationDate =wfFormatDateTime(newspaperPublicationDate, 'ISO8601');
-              this.printLocationPageNumber = newspaperPageNumberStr;
+              this.printLocationPageNumber = newspaperPageNumber !== undefined ? newspaperPageNumber : Number.MAX_VALUE;
               this.longPrintLocationDescription = longPrintLocationDescription;
               this.printLocationType = printLocationType;
             }

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -111,7 +111,7 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
     };
 
     $scope.getSortDirection = columnName => {
-      return columnName === $scope.sortColumn ? $scope.sortDirection : undefined
+      return columnName === $scope.sortColumn ? $scope.sortDirection[0] : undefined
     }
 
     $scope.sortColumn = undefined;
@@ -128,13 +128,21 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
       if (!column) {
         return;
       }
+      
+      function invertSort(sortDirection){
+        return sortStates[(sortStates.indexOf(sortDirection) + 1) % sortStates.length];
+      }
 
-      // Reset the sort order if we're toggling a new field
-      const sortDirectionIndex = colName === $scope.sortColumn
-        ? (sortStates.indexOf($scope.sortDirection) + 1) % sortStates.length
-        : Math.max(sortStates.indexOf(column.defaultSortOrder), 0);
+      if(colName === $scope.sortColumn){
+        $scope.sortDirection = $scope.sortDirection.map(invertSort);
+      }
+      else if(column.defaultSortOrder && column.defaultSortOrder.length === sortFields.length){
+        $scope.sortDirection = column.defaultSortOrder;
+      }
+      else {
+        $scope.sortDirection = sortFields.map(() => sortStates[0])
+      }
 
-      $scope.sortDirection = sortStates[sortDirectionIndex];
       $scope.sortColumn = $scope.sortDirection ? colName : undefined;
       $scope.sortFields = $scope.sortDirection ? sortFields : undefined;
 
@@ -418,7 +426,7 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
        function createIteratee(sortColumn) {
             return item => {
                 const val = _.get(item, sortColumn) || undefined;
-                return typeof val === 'string' ? val.toLowerCase() : undefined;
+                return typeof val === 'string' ? val.toLowerCase() : val;
             }
         }
 

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -426,7 +426,7 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
 
        function createIteratee(sortColumn) {
             return item => {
-                const val = _.get(item, sortColumn) || undefined;
+                const val = _.get(item, sortColumn);
                 return typeof val === 'string' ? val.toLowerCase() : val;
             }
         }

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -128,17 +128,18 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
       if (!column) {
         return;
       }
-      
-      function invertSort(sortDirection){
-        return sortStates[(sortStates.indexOf(sortDirection) + 1) % sortStates.length];
-      }
 
+      //If same column invert score
       if(colName === $scope.sortColumn){
-        $scope.sortDirection = $scope.sortDirection.map(invertSort);
+        $scope.sortDirection = $scope.sortDirection.map(sortDirection => {
+            return sortStates[(sortStates.indexOf(sortDirection) + 1) % sortStates.length];
+        });
       }
+      //If new column and default sort order array matches length of sort fields
       else if(column.defaultSortOrder && column.defaultSortOrder.length === sortFields.length){
         $scope.sortDirection = column.defaultSortOrder;
       }
+      //Else create default sort
       else {
         $scope.sortDirection = sortFields.map(() => sortStates[0])
       }

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -115,26 +115,29 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
     }
 
     $scope.sortColumn = undefined;
+    $scope.sortFields = [];
     $scope.sortDirection = undefined;
     const defaultSortColName = 'priority';
     // If we'd prefer to allow people to remove the sort state entirely,
     // this list can be changed to ['desc', 'asc', undefined]
     const sortStates = ['asc', 'desc'];
 
-    $scope.toggleSortState = sortField => {
-      const column = $scope.columns.find(col => getSortField(col) === sortField);
+    $scope.toggleSortState = (colName, sortFields) => {
+      const column = $scope.columns.find(col => col.name === colName);
 
       if (!column) {
         return;
       }
 
       // Reset the sort order if we're toggling a new field
-      const sortDirectionIndex = sortField === $scope.sortColumn
+      const sortDirectionIndex = colName === $scope.sortColumn
         ? (sortStates.indexOf($scope.sortDirection) + 1) % sortStates.length
         : Math.max(sortStates.indexOf(column.defaultSortOrder), 0);
 
       $scope.sortDirection = sortStates[sortDirectionIndex];
-      $scope.sortColumn = $scope.sortDirection ? sortField : undefined;
+      $scope.sortColumn = $scope.sortDirection ? colName : undefined;
+      $scope.sortFields = $scope.sortDirection ? sortFields : undefined;
+
 
       applyNewContentState();
     };
@@ -287,7 +290,7 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
         }
 
         const hydratedItems = (group.items || []).map(wfContentItemParser.parse);
-        const sortedGroupItems = this.sortGroupItems(hydratedItems || [], $scope.sortColumn, $scope.sortDirection);
+        const sortedGroupItems = this.sortGroupItems(hydratedItems || [], $scope.sortFields, $scope.sortDirection);
         const newItemsRemaining = sortedGroupItems.length < itemsRemaining
           ? itemsRemaining - sortedGroupItems.length
           : 0;
@@ -407,23 +410,19 @@ function wfContentListController($rootScope, $scope, $anchorScroll, statuses, le
 
     };
 
-    this.sortGroupItems = (items, sortColumn, sortDirection) => {
-      if (!$scope.sortColumn) {
+    this.sortGroupItems = (items, sortColumns, sortDirection) => {
+      if (!$scope.sortFields || $scope.sortFields.length < 1) {
         return items;
       }
 
-      const iteratee = item => {
-        const val = _.get(item, sortColumn) || '';
-        return typeof val === 'string' ? val.toLowerCase() : val;
-      }
+       function createIteratee(sortColumn) {
+            return item => {
+                const val = _.get(item, sortColumn) || undefined;
+                return typeof val === 'string' ? val.toLowerCase() : undefined;
+            }
+        }
 
-      // Priority is a special case – on the server, we sort by priority -> title
-      // by default, so we add this secondary sort to reflect that behaviour.
-      if (sortColumn === 'priority') {
-        return _.orderBy(items, [iteratee, 'title'], [sortDirection, 'desc']);
-      }
-
-      return _.orderBy(items, iteratee, sortDirection);
+      return _.orderBy(items, sortColumns.map(column => createIteratee(column)), sortDirection);
     }
 
     $scope.$on('contentItem.update', ($event, msg) => {

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -86,7 +86,7 @@ const columnDefaults = [{
     isSortable: true,
     defaultSortOrder: ['desc', 'asc'],
     flipSortIconDirection: true,
-    sortField: ['priority', 'workingTitle']
+    sortField: ['prioritySortValue', 'workingTitle']
 },{
     name: 'content-type',
     prettyName: 'Content Type',
@@ -268,7 +268,7 @@ const columnDefaults = [{
     active: true,
     isNew: true,
     isSortable: true,
-    defaultSortOrder: ['desc', 'desc', 'asc'],
+    defaultSortOrder: ['asc', 'desc', 'asc'],
     sortField: ['printLocationBookSection', 'printLocationPublicationDate', 'printLocationPageNumber']
 },{
     name: 'commissionedLength',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -35,7 +35,7 @@ import printLocationTemplate       from "components/content-list-item/templates/
  *      title: string, // title attribute contents for the column heading
  *      templateUrl: string // URL for the content-list-item template for this field
  *      isSortable: boolean = false // Can the column be sorted by clicking its header?
- *      sortField?: string // The field to sort on, if different from `name`. Can be an item path, e.g. `a.nested.field`
+ *      sortField?: string[] // The field(s) to sort on, if different from `name`. Can be an item path, e.g. `a.nested.field`
  *      defaultSortOrder?: 'asc' | 'desc' // The default sort order for the column on first click. Defaults to 'asc'
  *      flipSortIconDirection: boolean = false // Flip the direction of the sort chevron relative to the sort order. Defaults to 'desc' -> ▼
  * }
@@ -46,19 +46,19 @@ var templateRoot = '/assets/components/content-list-item/templates/';
 const chevronUp = '&#9660;'
 const chevronDown = '&#9650;'
 
-const createSortTemplate = (sortField, labelHTML, flipSortIconDirection = false) => {
+const createSortTemplate = (colName, sortField, labelHTML, flipSortIconDirection = false) => {
   // For some field types, the semantics of 'up' or 'down' differ; we use
   // flipSortIconDirection to switch them when needed.
   const descChevron = flipSortIconDirection ? chevronDown : chevronUp;
   const ascChevron = flipSortIconDirection ? chevronUp : chevronDown;
 
   return `
-    <div ng-click="toggleSortState('${sortField}')" class="content-list-head__heading-sort-by">
+    <div ng-click="toggleSortState('${colName}', [${sortField.map(field => `'${field}'`).join()}])" class="content-list-head__heading-sort-by">
       ${labelHTML}
       <span
         class="content-list-head__heading-sort-indicator"
-        ng-class="{invisible: !getSortDirection('${sortField}')}"
-        ng-switch="getSortDirection('${sortField}')">
+        ng-class="{invisible: !getSortDirection('${colName}')}"
+        ng-switch="getSortDirection('${colName}')">
         <span ng-switch-when="desc">${descChevron}</span>
         <span ng-switch-when="asc">${ascChevron}</span>
         <!-- We add a character here and use ng-visible above to prevent -->
@@ -71,7 +71,7 @@ const createSortTemplate = (sortField, labelHTML, flipSortIconDirection = false)
 
 export const getSortField = column => column
   && column.isSortable
-  && (column.sortField || column.name);
+  && (column.sortField || [column.name]);
 
 const columnDefaults = [{
     name: 'priority',
@@ -85,7 +85,8 @@ const columnDefaults = [{
     alwaysShown: true,
     isSortable: true,
     defaultSortOrder: 'desc',
-    flipSortIconDirection: true
+    flipSortIconDirection: true,
+    sortField: ['priority', 'title']
 },{
     name: 'content-type',
     prettyName: 'Content Type',
@@ -106,7 +107,7 @@ const columnDefaults = [{
     active: true,
     alwaysShown: true,
     isSortable: true,
-    sortField: 'workingTitle'
+    sortField: ['workingTitle']
 },{
     name: 'notes',
     prettyName: 'Notes',
@@ -117,7 +118,7 @@ const columnDefaults = [{
     template: notesTemplate,
     active: true,
     isSortable: true,
-    sortField: 'note'
+    sortField: ['note']
 },{
     name: 'comments',
     prettyName: 'Comments: On/Off',
@@ -223,7 +224,7 @@ const columnDefaults = [{
     template: sectionTemplate,
     active: true,
     isSortable: true,
-    sortField: 'item.section',
+    sortField: ['item.section'],
 },{
     name: 'status',
     prettyName: 'Status',
@@ -243,7 +244,7 @@ const columnDefaults = [{
     template: wordcountTemplate,
     active: true,
     isSortable: true,
-    sortField: 'wordCount'
+    sortField: ['wordCount']
 },{
     name: 'printwordcount',
     prettyName: 'Print wordcount',
@@ -255,7 +256,7 @@ const columnDefaults = [{
     active: true,
     isNew: true,
     isSortable: true,
-    sortField: 'printWordCount'
+    sortField: ['printWordCount']
 },{
     name: 'printlocation',
     prettyName: 'Print location',
@@ -267,7 +268,7 @@ const columnDefaults = [{
     active: true,
     isNew: true,
     isSortable: true,
-    sortField: 'printLocationSortString'
+    sortField: ['printLocationBookSection', 'printLocationPublicationDate', 'printLocationPageNumber']
 },{
     name: 'commissionedLength',
     prettyName: 'Commissioned Length',
@@ -297,7 +298,7 @@ const columnDefaults = [{
     template: publishedStateTemplate,
     active: true,
     isSortable: true,
-    sortField: 'lifecycleStateSortString'
+    sortField: ['lifecycleState', 'lifecycleStateSuplDate']
 },{
     name: 'needsLegal',
     prettyName: 'Needs Legal',
@@ -318,7 +319,7 @@ const columnDefaults = [{
     active: true,
     isNew: true,
     isSortable: true,
-    sortField: 'lastModified',
+    sortField: ['lastModified'],
     defaultSortOrder: 'desc'
 },{
     name: 'last-modified-by',
@@ -331,14 +332,14 @@ const columnDefaults = [{
     active: true,
     isNew: true,
     isSortable: true,
-    sortField: 'lastModifiedBy'
+    sortField: ['lastModifiedBy']
 }].map(col => {
   const _labelHTML = col.labelHTML === ''
     ? '&nbsp;'
     : col.labelHTML;
 
   const labelHTML = col.isSortable
-    ? createSortTemplate(getSortField(col), _labelHTML, col.flipSortIconDirection)
+    ? createSortTemplate(col.name, getSortField(col), _labelHTML, col.flipSortIconDirection)
     : _labelHTML;
 
   return {...col, active: true, labelHTML};

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -36,7 +36,7 @@ import printLocationTemplate       from "components/content-list-item/templates/
  *      templateUrl: string // URL for the content-list-item template for this field
  *      isSortable: boolean = false // Can the column be sorted by clicking its header?
  *      sortField?: string[] // The field(s) to sort on, if different from `name`. Can be an item path, e.g. `a.nested.field`
- *      defaultSortOrder?: 'asc' | 'desc' // The default sort order for the column on first click. Defaults to 'asc'
+ *      defaultSortOrder?: ['asc' | 'desc'] // The default sort order for the column on first click. Defaults to 'asc'
  *      flipSortIconDirection: boolean = false // Flip the direction of the sort chevron relative to the sort order. Defaults to 'desc' -> ▼
  * }
  */
@@ -84,9 +84,9 @@ const columnDefaults = [{
     active: true,
     alwaysShown: true,
     isSortable: true,
-    defaultSortOrder: 'desc',
+    defaultSortOrder: ['desc', 'asc'],
     flipSortIconDirection: true,
-    sortField: ['priority', 'title']
+    sortField: ['priority', 'workingTitle']
 },{
     name: 'content-type',
     prettyName: 'Content Type',
@@ -213,7 +213,7 @@ const columnDefaults = [{
     template: deadlineTemplate,
     active: true,
     isSortable: true,
-    defaultSortOrder: 'desc'
+    defaultSortOrder: ['desc']
 },{
     name: 'section',
     prettyName: 'Section',
@@ -268,6 +268,7 @@ const columnDefaults = [{
     active: true,
     isNew: true,
     isSortable: true,
+    defaultSortOrder: ['desc', 'desc', 'asc'],
     sortField: ['printLocationBookSection', 'printLocationPublicationDate', 'printLocationPageNumber']
 },{
     name: 'commissionedLength',
@@ -320,7 +321,7 @@ const columnDefaults = [{
     isNew: true,
     isSortable: true,
     sortField: ['lastModified'],
-    defaultSortOrder: 'desc'
+    defaultSortOrder: ['desc']
 },{
     name: 'last-modified-by',
     prettyName: 'Last modified by',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -299,6 +299,7 @@ const columnDefaults = [{
     template: publishedStateTemplate,
     active: true,
     isSortable: true,
+    defaultSortOrder: ['asc', 'desc'],
     sortField: ['lifecycleState', 'lifecycleStateSuplDate']
 },{
     name: 'needsLegal',


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR provides the ability to sort workflow fields by multiple fields specified in the column-default.js files. A dev can specify the order of fields to sort by and a direction for each of those fields. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
This additional functionality allows us to sort by the more complicated sort specified in the [trello card](https://trello.com/c/HjpEVCmx/270-correct-sorting-for-multi-value-fields). See the print location column in the column-default.js to see how it has been setup. 