### PR TITLE
Clear plans in drawer on content change

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -91,12 +91,21 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
                     $scope.$apply(() => {
 
                         $contentListItemElement.after($element);
+                        delete $scope.bookSectionQuery;
+                        delete $scope.plannedBookId;
+                        delete $scope.plannedBookSectionId;
+                        $scope.showBookTagPicker = false;
+                        delete $scope.editedLongPlannedPrintLocationDescription;
+                        delete $scope.candidateBookSections;
+                        delete $scope.bookSectionQuery;  
 
                         $scope.contentItem = contentItem;
+                        $scope.plannedPublicationId
                         $scope.contentList.selectedItem = contentItem;
                         $scope.capiData = capiData;
 
                         $scope.currentDatePickerValue = $scope.contentItem.item.due ? $scope.contentItem.item.due : undefined;
+                        $scope.currentPublicationDatePickerValue = $scope.contentItem.plannedNewspaperPublicationDate ? $scope.contentItem.plannedNewspaperPublicationDate : undefined;
 
                         self.updateAssigneeUserImage();
                     });

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -97,7 +97,6 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
                         $scope.showBookTagPicker = false;
                         delete $scope.editedLongPlannedPrintLocationDescription;
                         delete $scope.candidateBookSections;
-                        delete $scope.bookSectionQuery;  
 
                         $scope.contentItem = contentItem;
                         $scope.plannedPublicationId


### PR DESCRIPTION
## What does this change?
This clears plans in drawer on content change

## How can we measure success?
That the plans in the drawer are cleared on content change

https://trello.com/c/8nsRU0rl/287-planned-print-information-values-linger
This passes the test in the ticket.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
