### PR TITLE
Render error notice above unrecoverable error overlay

### DIFF
--- a/public/components/user-message/_user-message.scss
+++ b/public/components/user-message/_user-message.scss
@@ -1,5 +1,10 @@
 .user-message__container {
     flex: 0 0 auto;
+    /**
+    * It's important that this is above .irrecoverable-error-overlay,
+    * which can be displayed alongside this container.
+    */
+    z-index: 10000;
 }
 
 .user-message {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

At the moment, when workflow suffers from an unrecoverable error, it triggers an overlay that covers the entire page. This obscures the error message at the top of the screen, informing the user why the application is in this state:

<img width="847" alt="Screenshot 2020-07-15 at 13 55 58" src="https://user-images.githubusercontent.com/7767575/87548529-8534fd00-c6a4-11ea-800f-6d833ff045f0.png">

This PR hoists that error message above the overlay, so users are better informed:

<img width="847" alt="Screenshot 2020-07-15 at 13 55 48" src="https://user-images.githubusercontent.com/7767575/87548540-87975700-c6a4-11ea-91e8-c435af7df881.png">

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Trigger the above error in CODE by removing the gutools and google auth cookies whilst in workflow. You should see the error message as above.
