### PR TITLE
Print location styling tweaks

### DIFF
--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -180,10 +180,6 @@
         &-printlocation {
             padding-bottom: 5px;
           }
-
-        &-bold {
-            font-weight: bold;
-        }
     }
 
     &__mainmedia {

--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -177,10 +177,13 @@
             display: inline-block;
           }
 
-
         &-printlocation {
             padding-bottom: 5px;
           }
+
+        &-bold {
+            font-weight: bold;
+        }
     }
 
     &__mainmedia {

--- a/public/components/content-list-drawer/_content-list-drawer.scss
+++ b/public/components/content-list-drawer/_content-list-drawer.scss
@@ -176,6 +176,11 @@
             padding: 0 2px;
             display: inline-block;
           }
+
+
+        &-printlocation {
+            padding-bottom: 5px;
+          }
     }
 
     &__mainmedia {

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -433,9 +433,11 @@
                             <div class="drawer__item-printlocation">
                                 <span>Page number:</span>
                                 <span ng-if="contentItem.actualNewspaperPageNumber">{{contentItem.actualNewspaperPageNumber}}</span>
-                                <wf-editable class="planned-print-location editable__view-value" ng-if="!contentItem.actualNewspaperPageNumber" class="editable--inline" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
-                                    <span>{{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}</span>
-                                    <span class="planned-print-location__brackets" ng:show="contentItem.plannedNewspaperPageNumber" class="editable__printlocation">(planned)</span>
+                                <wf-editable class="editable--inline" ng-if="!contentItem.actualNewspaperPageNumber" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
+                                    <div class="planned-print-location editable__view-value">
+                                        <span>{{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}</span>
+                                        <span class="planned-print-location__brackets" ng:show="contentItem.plannedNewspaperPageNumber" class="editable__printlocation">(planned)</span>
+                                    </div>
                                 </wf-editable>
                             </div>
                             <div class="drawer__item-printlocation">

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -422,63 +422,64 @@
                     <ul class="drawer__column  drawer__column--wide drawer__column--with-overflow" ng-if="!contentItem.longActualPrintLocationDescription">
                        
                         <li class="drawer__item">
-                            <p class="drawer__item-title">Planned Print Location</p>
-                            <button class="drawer__item-content editable__edit-button editable__view-value" ng-hide="showBookTagPicker" ng-click="toggleBookTagPicker(true)">
-                                {{ (editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription) || 'Add planned print location' }}</button>
-                            <div class="editable--edit autocomplete" ng-show="showBookTagPicker">
-                                <input class="text-input fullwidth"
-                                       ng-model="$parent.bookSectionQuery"
-                                       placeholder="Enter a book section…"
-                                       name="bookSection"
-                                       autocomplete="off"
-                                       ui-filter-list="candidateBookSections"
-                                       ui-filter-list-on-filter="setBookSections()"
-                                       ui-filter-list-on-select="pickBookSection(selectedItem)"
-                                       >
-                                <ul class="autocomplete__results" ng:show="candidateBookSections">
-                                    <li ng-repeat="tag in candidateBookSections" ng:class="{'is-selected': tag.selected}">
-                                        <button ng-click="pickBookSection(tag.item)" >{{tag.item.internalName}}</button>
-                                    </li>
-                                </ul>
-                                <span class="editable__controls">
-                                    <button class="editable__control editable__control--cancel" ng-click="toggleBookTagPicker(false)" title="Cancel changes">
-                                        <i class="editable__control-icon editable__control-icon--cancel" wf-icon="cross"></i>
-                                    </button>
-                                </span>
-                            </div>
-                        </li>
-                        <li class="drawer__item">
-                            <span class="drawer__item-title">Planned Newspaper Page Number</span>
-                            <wf-editable class="drawer__item-content" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
-                                {{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}
-                            </wf-editable>
-                        </li>
-                        <li class="drawer__item">
-                            <p class="drawer__item-title">Planned Publication Date</p>
-
-                            <button 
-                                ng-hide="publicationDateTimeEdit" 
-                                ng-click="publicationDateTimeEdit = true" 
-                                ng-class="{ 'drawer__section-data-row--editable': contentItem.plannedNewspaperPublicationDate, 'drawer__section-data-row--editable-empty': !contentItem.plannedNewspaperPublicationDate, 'editable__view-value': true, 'editable__edit-button': true }"
-                                title="{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || '' }}"
-                                >
-                                {{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || 'Add planned publication date' }}
-                            </button>
-                            <form ng-show="publicationDateTimeEdit" ng-submit="publicationDateTimeEdit = false">
-                                <div class="form-group">
-                                    <div 
-                                      wf-date-time-picker 
-                                      wf-update-on="enter" 
-                                      ng-model="$parent.currentPublicationDatePickerValue" 
-                                      wf-on-cancel="publicationDateTimeEdit = false; revertPlannedPublicationDate()" 
-                                      wf-cancel-on="blur" 
-                                      wf-on-submit="updatePlannedPublicationDate(); publicationDateTimeEdit = false;" 
-                                      wf-date-only="true"
-                                    ></div>
+                            <p class="drawer__item-title">Print Location</p>
+                            <div class="drawer__item-printlocation">
+                                <span>Book section:</span>
+                                <button class="editable__edit-button" ng-hide="showBookTagPicker" ng-click="toggleBookTagPicker(true)">
+                                    <span class="editable__view-value">{{ (editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
+                                </button>
+                                <div class="editable--edit editable--inline autocomplete" ng-show="showBookTagPicker">
+                                    <input class="text-input fullwidth"
+                                        ng-model="$parent.bookSectionQuery"
+                                        placeholder="Enter a book section…"
+                                        name="bookSection"
+                                        autocomplete="off"
+                                        ui-filter-list="candidateBookSections"
+                                        ui-filter-list-on-filter="setBookSections()"
+                                        ui-filter-list-on-select="pickBookSection(selectedItem)"
+                                        >
+                                    <ul class="autocomplete__results" ng:show="candidateBookSections">
+                                        <li ng-repeat="tag in candidateBookSections" ng:class="{'is-selected': tag.selected}">
+                                            <button ng-click="pickBookSection(tag.item)" >{{tag.item.internalName}}</button>
+                                        </li>
+                                    </ul>
+                                    <span class="editable__controls">
+                                        <button class="editable__control editable__control--cancel" ng-click="toggleBookTagPicker(false)" title="Cancel changes">
+                                            <i class="editable__control-icon editable__control-icon--cancel" wf-icon="cross"></i>
+                                        </button>
+                                    </span>
                                 </div>
-                            </form>
-                            
-
+                            </div>
+                            <div class="drawer__item-printlocation">
+                                <span>Page number:</span>
+                                <wf-editable class="editable--inline" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
+                                    {{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}
+                                </wf-editable>
+                            </div>
+                            <div class="drawer__item-printlocation">
+                                <span>Publication date:</span>
+                                <button 
+                                    ng-hide="publicationDateTimeEdit" 
+                                    ng-click="publicationDateTimeEdit = true" 
+                                    ng-class="{ 'drawer__section-data-row--editable': contentItem.plannedNewspaperPublicationDate, 'drawer__section-data-row--editable-empty': !contentItem.plannedNewspaperPublicationDate, 'editable__edit-button': true }"
+                                    title="{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || '' }}"
+                                    >
+                                    <span class="editable__view-value">{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || 'Add planned publication date' }}</span>
+                                </button>
+                                <form ng-show="publicationDateTimeEdit" ng-submit="publicationDateTimeEdit = false">
+                                    <div class="form-group editable--inline">
+                                        <div 
+                                        wf-date-time-picker 
+                                        wf-update-on="enter" 
+                                        ng-model="$parent.currentPublicationDatePickerValue" 
+                                        wf-on-cancel="publicationDateTimeEdit = false; revertPlannedPublicationDate()" 
+                                        wf-cancel-on="blur" 
+                                        wf-on-submit="updatePlannedPublicationDate(); publicationDateTimeEdit = false;" 
+                                        wf-date-only="true"
+                                        ></div>
+                                    </div>
+                                </form>
+                            </div>
                         </li>
                     </ul>
 

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -395,37 +395,14 @@
                             <select ng-model="contentItem.status" ng-options="status.value as status.label for status in contentItem.statusValues" wf-content-item-update-action="status"></select>
                         </li>
                     </ul>
-                    <!-- Actual Print Info -->
-                    <ul class="drawer__column" ng-if="contentItem.shortActualPrintLocationDescription">
-             
-                        <li class="drawer__item">
-                            <p class="drawer__item-title">Print Location</p>
-                            <p class="drawer__item-content">{{ contentItem.shortActualPrintLocationDescription }}</p>
-                        </li>
-                        <li class="drawer__item">
-                            <p class="drawer__item-title">Newspaper Page Number</p>
-                            <p class="drawer__item-content">{{ contentItem.actualNewspaperPageNumber || 'None' }}</p>                            
-                        </li>
-                        <li class="drawer__item">
-                            <p class="drawer__item-title">Publication Date</p>
-                            <p class="drawer__item-content">{{ (contentItem.actualNewspaperPublicationDate | wfFormatDateTime:'date') || 'None'}}</p>
-                        </li>
-                        <li class="drawer__item">
-                            <p class="drawer__item-content"><em>Publication data has been filled from inDesign or Composer and can no longer be edited in Workflow.</em></p>
-                        </li>
-
-                    </ul>
-
-                    <!-- Planned Print Info -->
                     <!-- We allow overflow here for the datepicker, which will otherwise be occluded by its container -->
-
                     <ul class="drawer__column  drawer__column--wide drawer__column--with-overflow" ng-if="!contentItem.longActualPrintLocationDescription">
-                       
                         <li class="drawer__item">
                             <p class="drawer__item-title">Print Location</p>
                             <div class="drawer__item-printlocation">
                                 <span>Book section:</span>
-                                <button class="editable__edit-button" ng-hide="showBookTagPicker" ng-click="toggleBookTagPicker(true)">
+                                <span ng-if="contentItem.shortActualPrintLocationDescription">{{contentItem.shortActualPrintLocationDescription}}</span>
+                                <button ng-if="!contentItem.shortActualPrintLocationDescription" class="editable__edit-button" ng-hide="showBookTagPicker" ng-click="toggleBookTagPicker(true)">
                                     <div class="editable__printlocation">
                                         <span>{{ (editedShortPlannedPrintLocationDescription || contentItem.shortPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
                                         <span class="drawer__item-bold" ng:show="editedShortPlannedPrintLocationDescription || contentItem.shortPlannedPrintLocationDescription" class="editable__printlocation">(planned)</span>
@@ -455,15 +432,17 @@
                             </div>
                             <div class="drawer__item-printlocation">
                                 <span>Page number:</span>
-                                <wf-editable class="editable--inline" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
+                                <span ng-if="contentItem.actualNewspaperPageNumber">{{contentItem.actualNewspaperPageNumber}}</span>
+                                <wf-editable ng-if="!contentItem.actualNewspaperPageNumber" class="editable--inline" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
                                     <span class="editable__printlocation">{{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}</span>
                                     <span class="drawer__item-bold" ng:show="contentItem.plannedNewspaperPageNumber" class="editable__printlocation">(planned)</span>
                                 </wf-editable>
                             </div>
                             <div class="drawer__item-printlocation">
                                 <span>Publication date:</span>
+                                <span ng-if="contentItem.actualNewspaperPublicationDate">{{contentItem.actualNewspaperPublicationDate | wfFormatDateTime:'date'}}</span>
                                 <button 
-                                    ng-hide="publicationDateTimeEdit" 
+                                    ng-hide="publicationDateTimeEdit || contentItem.actualNewspaperPublicationDate" 
                                     ng-click="publicationDateTimeEdit = true" 
                                     ng-class="{ 'drawer__section-data-row--editable': contentItem.plannedNewspaperPublicationDate, 'drawer__section-data-row--editable-empty': !contentItem.plannedNewspaperPublicationDate, 'editable__edit-button': true }"
                                     title="{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || '' }}"

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -427,8 +427,8 @@
                                 <span>Book section:</span>
                                 <button class="editable__edit-button" ng-hide="showBookTagPicker" ng-click="toggleBookTagPicker(true)">
                                     <div class="editable__printlocation">
-                                        <span>{{ (editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
-                                        <span class="drawer__item-bold" ng:show="editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription" class="editable__printlocation">(planned)</span>
+                                        <span>{{ (editedShortPlannedPrintLocationDescription || contentItem.shortPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
+                                        <span class="drawer__item-bold" ng:show="editedShortPlannedPrintLocationDescription || contentItem.shortPlannedPrintLocationDescription" class="editable__printlocation">(planned)</span>
                                     </div>
                                 </button>
                                 <div class="editable--edit editable--inline autocomplete" ng-show="showBookTagPicker">

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -396,11 +396,11 @@
                         </li>
                     </ul>
                     <!-- Actual Print Info -->
-                    <ul class="drawer__column" ng-if="contentItem.longActualPrintLocationDescription">
+                    <ul class="drawer__column" ng-if="contentItem.shortActualPrintLocationDescription">
              
                         <li class="drawer__item">
                             <p class="drawer__item-title">Print Location</p>
-                            <p class="drawer__item-content">{{ contentItem.longActualPrintLocationDescription }}</p>
+                            <p class="drawer__item-content">{{ contentItem.shortActualPrintLocationDescription }}</p>
                         </li>
                         <li class="drawer__item">
                             <p class="drawer__item-title">Newspaper Page Number</p>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -426,7 +426,10 @@
                             <div class="drawer__item-printlocation">
                                 <span>Book section:</span>
                                 <button class="editable__edit-button" ng-hide="showBookTagPicker" ng-click="toggleBookTagPicker(true)">
-                                    <span class="editable__printlocation">{{ (editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
+                                    <div class="editable__printlocation">
+                                        <span>{{ (editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
+                                        <span class="drawer__item-bold" ng:show="editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription" class="editable__printlocation">(planned)</span>
+                                    </div>
                                 </button>
                                 <div class="editable--edit editable--inline autocomplete" ng-show="showBookTagPicker">
                                     <input class="text-input fullwidth"
@@ -454,6 +457,7 @@
                                 <span>Page number:</span>
                                 <wf-editable class="editable--inline" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
                                     <span class="editable__printlocation">{{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}</span>
+                                    <span class="drawer__item-bold" ng:show="contentItem.plannedNewspaperPageNumber" class="editable__printlocation">(planned)</span>
                                 </wf-editable>
                             </div>
                             <div class="drawer__item-printlocation">
@@ -464,7 +468,10 @@
                                     ng-class="{ 'drawer__section-data-row--editable': contentItem.plannedNewspaperPublicationDate, 'drawer__section-data-row--editable-empty': !contentItem.plannedNewspaperPublicationDate, 'editable__edit-button': true }"
                                     title="{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || '' }}"
                                     >
-                                    <span class="editable__printlocation">{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || 'Add planned publication date' }}</span>
+                                    <div class="editable__printlocation">
+                                        <span>{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || 'Add planned publication date' }}</span>
+                                        <span class="drawer__item-bold" ng:show="contentItem.plannedNewspaperPublicationDate" class="editable__printlocation">(planned)</span>
+                                    </div>
                                 </button>
                                 <form ng-show="publicationDateTimeEdit" ng-submit="publicationDateTimeEdit = false">
                                     <div class="form-group editable--inline">

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -426,7 +426,7 @@
                             <div class="drawer__item-printlocation">
                                 <span>Book section:</span>
                                 <button class="editable__edit-button" ng-hide="showBookTagPicker" ng-click="toggleBookTagPicker(true)">
-                                    <span class="editable__view-value">{{ (editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
+                                    <span class="editable__printlocation">{{ (editedLongPlannedPrintLocationDescription || contentItem.longPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
                                 </button>
                                 <div class="editable--edit editable--inline autocomplete" ng-show="showBookTagPicker">
                                     <input class="text-input fullwidth"
@@ -453,7 +453,7 @@
                             <div class="drawer__item-printlocation">
                                 <span>Page number:</span>
                                 <wf-editable class="editable--inline" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
-                                    {{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}
+                                    <span class="editable__printlocation">{{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}</span>
                                 </wf-editable>
                             </div>
                             <div class="drawer__item-printlocation">
@@ -464,7 +464,7 @@
                                     ng-class="{ 'drawer__section-data-row--editable': contentItem.plannedNewspaperPublicationDate, 'drawer__section-data-row--editable-empty': !contentItem.plannedNewspaperPublicationDate, 'editable__edit-button': true }"
                                     title="{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || '' }}"
                                     >
-                                    <span class="editable__view-value">{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || 'Add planned publication date' }}</span>
+                                    <span class="editable__printlocation">{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || 'Add planned publication date' }}</span>
                                 </button>
                                 <form ng-show="publicationDateTimeEdit" ng-submit="publicationDateTimeEdit = false">
                                     <div class="form-group editable--inline">

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -403,9 +403,9 @@
                                 <span>Book section:</span>
                                 <span ng-if="contentItem.shortActualPrintLocationDescription">{{contentItem.shortActualPrintLocationDescription}}</span>
                                 <button ng-if="!contentItem.shortActualPrintLocationDescription" class="editable__edit-button" ng-hide="showBookTagPicker" ng-click="toggleBookTagPicker(true)">
-                                    <div class="editable__printlocation">
+                                    <div class="planned-print-location editable__view-value">
                                         <span>{{ (editedShortPlannedPrintLocationDescription || contentItem.shortPlannedPrintLocationDescription) || 'Add planned print location' }}</span>
-                                        <span class="drawer__item-bold" ng:show="editedShortPlannedPrintLocationDescription || contentItem.shortPlannedPrintLocationDescription" class="editable__printlocation">(planned)</span>
+                                        <span class="planned-print-location__brackets" ng:show="editedShortPlannedPrintLocationDescription || contentItem.shortPlannedPrintLocationDescription" class="editable__printlocation">(planned)</span>
                                     </div>
                                 </button>
                                 <div class="editable--edit editable--inline autocomplete" ng-show="showBookTagPicker">
@@ -433,9 +433,9 @@
                             <div class="drawer__item-printlocation">
                                 <span>Page number:</span>
                                 <span ng-if="contentItem.actualNewspaperPageNumber">{{contentItem.actualNewspaperPageNumber}}</span>
-                                <wf-editable ng-if="!contentItem.actualNewspaperPageNumber" class="editable--inline" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
-                                    <span class="editable__printlocation">{{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}</span>
-                                    <span class="drawer__item-bold" ng:show="contentItem.plannedNewspaperPageNumber" class="editable__printlocation">(planned)</span>
+                                <wf-editable class="planned-print-location editable__view-value" ng-if="!contentItem.actualNewspaperPageNumber" class="editable--inline" ng-model="contentItem.plannedNewspaperPageNumber" wf-editable-on-update="onBeforeSavePlannedPageNumber(newValue)" wf-editable-input-type="number">
+                                    <span>{{ contentItem.plannedNewspaperPageNumber || 'Add planned page number.' }}</span>
+                                    <span class="planned-print-location__brackets" ng:show="contentItem.plannedNewspaperPageNumber" class="editable__printlocation">(planned)</span>
                                 </wf-editable>
                             </div>
                             <div class="drawer__item-printlocation">
@@ -447,9 +447,9 @@
                                     ng-class="{ 'drawer__section-data-row--editable': contentItem.plannedNewspaperPublicationDate, 'drawer__section-data-row--editable-empty': !contentItem.plannedNewspaperPublicationDate, 'editable__edit-button': true }"
                                     title="{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || '' }}"
                                     >
-                                    <div class="editable__printlocation">
+                                    <div class="planned-print-location editable__view-value">
                                         <span>{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || 'Add planned publication date' }}</span>
-                                        <span class="drawer__item-bold" ng:show="contentItem.plannedNewspaperPublicationDate" class="editable__printlocation">(planned)</span>
+                                        <span class="planned-print-location__brackets" ng:show="contentItem.plannedNewspaperPublicationDate" class="editable__printlocation">(planned)</span>
                                     </div>
                                 </button>
                                 <form ng-show="publicationDateTimeEdit" ng-submit="publicationDateTimeEdit = false">

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -36,7 +36,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
         priority: 1001,
         scope: {
             showBookTagPicker: '<',
-            editedLongPlannedPrintLocationDescription: '<',
+            editedShortPlannedPrintLocationDescription: '<',
             contentList: '=',
             legalValues: '=',
             statusValues: '='
@@ -433,7 +433,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
                         updateField("plannedBookSectionId", bookSectionTag.id, $scope.plannedBookSectionId)
                         updateField("plannedPublicationId", publication.data.id, $scope.plannedPublicationId)
                         $scope.showBookTagPicker = false;
-                        $scope.editedLongPlannedPrintLocationDescription = `${book.data.internalName} >> ${bookSectionTag.internalName}`
+                        $scope.editedShortPlannedPrintLocationDescription = `${bookSectionTag.internalName}`
                     });
                 });
                 

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -544,6 +544,11 @@
 
 .planned-print-location {
     color: $c-grey-600;
+    font-style: italic;
+
+    &__brackets {
+        color: black;
+    }
 }
 .actual-print-location {
     color: black;

--- a/public/components/editable-field/_editable-field.scss
+++ b/public/components/editable-field/_editable-field.scss
@@ -97,6 +97,15 @@
         white-space: nowrap;
     }
 
+    &__printlocation {
+        border-bottom: dashed 1px #333;
+        font-style: italic;
+
+        &--preserve-whitespace {
+            white-space: pre-line;
+        }
+    }
+
     &--inline {
         display: inline-block;
     }

--- a/public/components/editable-field/_editable-field.scss
+++ b/public/components/editable-field/_editable-field.scss
@@ -97,15 +97,6 @@
         white-space: nowrap;
     }
 
-    &__printlocation {
-        border-bottom: dashed 1px #333;
-        font-style: italic;
-
-        &--preserve-whitespace {
-            white-space: pre-line;
-        }
-    }
-
     &--inline {
         display: inline-block;
     }

--- a/public/components/editable-field/_editable-field.scss
+++ b/public/components/editable-field/_editable-field.scss
@@ -96,4 +96,8 @@
         margin-right: -55px;
         white-space: nowrap;
     }
+
+    &--inline {
+        display: inline-block;
+    }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR makes the various styling changes requested in the [trello card](https://trello.com/c/9HHUsPLG/275-print-information-ui-tweaks). These include: 
1. Having a single title for all fields
1. Planned values being italicised
1. When planned values are displayed, "(planned)" is shown.
1. Ability to edit values as long as they are planned. Before being editable was based on the book section being available.

I haven't been able to test with actual print location values locally so this is worth taking care with.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The UX has improved, making the print location display more intuitive and readable. 

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

Before:
![image](https://user-images.githubusercontent.com/4633246/87679730-6d2cae80-c774-11ea-9859-1d90a2d93c57.png)

After:
![image](https://user-images.githubusercontent.com/4633246/87679697-64d47380-c774-11ea-9e6e-5ba29233e56d.png)

