### PR TITLE
Log when users are successfully reauthenticated

### DIFF
--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -4,6 +4,7 @@ import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.Config
 import play.api.libs.ws.WSClient
 import play.api.mvc._
+import play.api.{ Logging }
 import play.filters.headers.SecurityHeadersFilter
 
 import scala.concurrent.Future
@@ -14,7 +15,7 @@ class Login(
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
   override val panDomainSettings: PanDomainAuthSettingsRefresher
-) extends BaseController with PanDomainAuthActions {
+) extends BaseController with PanDomainAuthActions with Logging {
 
   def oauthCallback = Action.async { implicit request =>
     processOAuthCallback()
@@ -22,6 +23,7 @@ class Login(
 
   def status = AuthAction { request =>
     val user = request.user
+    logger.info(s"User ${user.email} successfully restablished session via login/status")
     Ok(views.html.loginStatus(user.toJson)).withHeaders(SecurityHeadersFilter.X_FRAME_OPTIONS_HEADER -> "SAMEORIGIN")
   }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Since the play upgrade, users' workflow sessions seem to be expiring unexpectedly. Here's the [trello card](https://trello.com/c/I1PNekWy/1974-since-the-play-upgrade-users-workflow-sessions-seem-to-be-expiring-unexpectedly).

This PR adds logging to indicate when users are successfully reauthenticated.

It should help us understand whether this is successfully occurring for users that are having trouble remaining authenticated in workflow.

## How can we measure success?

Launch workflow running this code, authenticate as usual, and remove the `.gutools` cookies. Workflow should reauthenticate, and a log line should appear indicating that this has happened with your email address.
