### PR TITLE
Adds a close button to the date-time-picker input directive

### DIFF
--- a/public/components/date-time-picker/_date-time-picker.scss
+++ b/public/components/date-time-picker/_date-time-picker.scss
@@ -7,6 +7,11 @@
     color: #666;
 }
 
+.date-time-picker__dropdown {
+  border-radius: 0;
+}
+
+
 // Error message should be exposed properly from date-time-picker via form.field.$error
 .date-time-picker {
 

--- a/public/components/date-time-picker/date-time-picker.html
+++ b/public/components/date-time-picker/date-time-picker.html
@@ -4,18 +4,17 @@
 </label>
 <span class="date-time-picker__help-text" ng-if="!label && helpText">{{ helpText == 'true' && 'e.g. today 3pm, tomorrow 15:00, tuesday next week 18:00, 2014-08-14' || helpText }}</span>
 <div class="date-time-picker__group input-group">
-
     <input class="date-time-picker__text-input form-control" type="text" placeholder="{{ placeholderText }}" wf-date-time-field id="{{dateTimePicker.textInputId}}" name="due" wf-on-cancel="onCancel()" wf-on-update="onUpdate()" wf-on-submit="onSubmit()" wf-update-on="{{updateOn}}" wf-cancel-on="{{cancelOn}}" ng-class="{'input-sm': small}">
-
     <div dropdown id="{{dateTimePicker.dropDownId}}" class="input-group-btn">
-
         <button type="button" id="{{dateTimePicker.dropDownButtonId}}" class="btn btn-default dropdown-toggle date-time-picker__dropdown" ng-class="{'btn-sm': small}">
-            <i class="glyphicon glyphicon-calendar"></i></button>
-
+            <i class="glyphicon glyphicon-calendar"></i>
+        </button>
         <ul class="dropdown-menu pull-right" role="menu">
             <datetimepicker class="date-time-picker__dropdown-picker" ng-model="datePickerValue" on-set-time="dateTimePicker.onDatePicked(newDate)" data-datetimepicker-config="_config"></datetimepicker>
         </ul>
-        </ul>
+        <button type="button" ng-click="onCancel()" class="btn btn-default" ng-class="{'btn-sm': small}">
+            <i class="glyphicon glyphicon-remove"></i>
+        </button>
     </div>
 </div>
 <span class="help-block" ng-class="{'small': small}">{{ dateValue | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime:'ddd D MMM YYYY HH:mm z' }}</span>


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds a close button to the date-time-picker directive. This will allow users to close the input if they change their minds. Previously the only way to do this was click into the input and press the escape key.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

This can be tested in any of the places where the date-time-picker is available, this includes the deadline and publication date pickers.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A user is able to dismiss the date picker easily.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![DateTimePicker](https://user-images.githubusercontent.com/4633246/87917754-58e6fb00-ca6d-11ea-9ff4-e952ab0e219b.gif)

