### PR TITLE
Removes a check for no actual print information

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -396,7 +396,7 @@
                         </li>
                     </ul>
                     <!-- We allow overflow here for the datepicker, which will otherwise be occluded by its container -->
-                    <ul class="drawer__column  drawer__column--wide drawer__column--with-overflow" ng-if="!contentItem.longActualPrintLocationDescription">
+                    <ul class="drawer__column  drawer__column--wide drawer__column--with-overflow">
                         <li class="drawer__item">
                             <p class="drawer__item-title">Print Location</p>
                             <div class="drawer__item-printlocation">


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Removes a check for no actual print information when displaying the print location div. This was accidentally left in place in this [PR](https://github.com/guardian/workflow-frontend/pull/271) when merging the planned and actual HTML into one section. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Have planned and actual print information against some content, see that the data is displaying correctly.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Planned and actual print information should display in the management panel.

