### PR TITLE
Display Presence indicator for Chart atoms

### DIFF
--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -61,7 +61,7 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
                   this.editor = this.mediaAtomMaker;
               } else {
                 if (config.atomTypes.includes(item.contentType)) {
-                  this.atomWorkshop = `${config.atomWorkshopViewAtom}/${item.contentType.toUpperCase()}/${item.editorId}/edit`;
+                  this.atomWorkshop = `${config.atomWorkshopViewAtom}/${item.contentType}/${item.editorId}/edit`;
                   this.editor = this.atomWorkshop;
                 }
               }

--- a/public/components/content-list-item/templates/presence.html
+++ b/public/components/content-list-item/templates/presence.html
@@ -3,4 +3,6 @@
     </wf-presence-indicators>
     <wf-presence-indicators presence-id="'media-' + contentItem.item.editorId" ng-if="contentItem.contentType === 'media'">
     </wf-presence-indicators>
+    <wf-presence-indicators presence-id="'chart-' + contentItem.item.editorId" ng-if="contentItem.contentType === 'chart'">
+    </wf-presence-indicators>
 </td>


### PR DESCRIPTION
## What does this change?
Continues https://github.com/guardian/atom-workshop/pull/276 by displaying the Presence indicator in Workflow for Chart atoms.

See also: https://github.com/guardian/atom-workshop/pull/277

## How to test
Deploy the branch into CODE and open a Chart atom. You should see the Presence indicator in the 'In use by' column.

## How can we measure success?
The indicator appears and disappears as you open and close a Chart atom. Sub-editors workflows are improved, as they're able to see at a glance whether another user is already editting a Chart atom.

## Images
![Screenshot 2020-07-31 at 16 44 39](https://user-images.githubusercontent.com/12645938/89052137-2b436100-d34d-11ea-9260-934cea5f3783.png)

