### PR TITLE
Change Typesafe resolver from http to https

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val commonSettings = Seq(
   version      := "0.1",
   fork in Test := false,
   resolvers ++= Seq(
-    "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
+    "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/",
     "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
   ),
   scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings")


### PR DESCRIPTION
## What does this change?
Recent builds on TeamCity have failed due to being unable to resolve dependencies from Typesafe's repository. By switching protocol to https, this error no longer occurs.

## How to test
Check that this branch builds in TeamCity.

## How can we measure success?
The project is able to build on TeamCity.

## Have we considered potential risks?
n/a

## Images
n/a
