### PR TITLE
Upgrade Panda

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   )
 
   val authDependencies = Seq(
-    "com.gu" %% "pan-domain-auth-play_2-6" % "0.9.1",
+    "com.gu" %% "pan-domain-auth-play_2-7" % "0.9.2",
     "com.gu" %% "hmac-headers" % "1.1.2"
   )
 


### PR DESCRIPTION
Test the new 0.9.2 release of Panda with upgraded dependencies.

Use the correct version for Play, although 2.6 and 2.7 must be binary compatible anyway as it was working before.