### PR TITLE
Add print modified-by and status fields

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -11,7 +11,6 @@ import io.circe.parser.decode
 import io.circe.syntax._
 import org.joda.time.{DateTime, LocalDate}
 import DateFormat._ // Required for serialisation / deserialisation of DateTime
-
 import scala.collection.immutable
 
 case class ExternalData(
@@ -47,7 +46,7 @@ case class ExternalData(
                          // Description enriched for use by WF front end client code.
                          shortActualPrintLocationDescription: Option[String] = None,
                          longActualPrintLocationDescription: Option[String] = None,
-                         statusInPrint: Option[String] = None,
+                         statusInPrint: Option[Status] = None,
                          lastModifiedInPrintBy: Option[String] = None) {
 }
 

--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -46,7 +46,9 @@ case class ExternalData(
                          actualNewspaperPublicationDate: Option[LocalDate] = None,
                          // Description enriched for use by WF front end client code.
                          shortActualPrintLocationDescription: Option[String] = None,
-                         longActualPrintLocationDescription: Option[String] = None) {
+                         longActualPrintLocationDescription: Option[String] = None,
+                         statusInPrint: Option[String] = None,
+                         lastModifiedInPrintBy: Option[String] = None) {
 }
 
 object ExternalData {

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -469,6 +469,16 @@
                                 </form>
                             </div>
                         </li>
+                        <li class="drawer__item">
+                            <p class="drawer__item-title">Last modified in print</p>
+                            <span class="drawer__item-content">{{ (contentItem.lastModified | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime) || "-" }}</span>
+                            <span class="drawer__item-content" ng-show="contentItem.lastModifiedInPrintBy">by {{ contentItem.lastModifiedInPrintBy }}</span>
+                        </li>
+                        <li class="drawer__item">
+                            <p class="drawer__item-title">Status in print</p>
+                            <span class="drawer__item-content" ng-show="contentItem.statusInPrint">{{ contentItem.statusInPrint }}</span>
+                        </li>
+
                     </ul>
 
             

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -470,7 +470,7 @@
                             </div>
                         </li>
                         <li class="drawer__item">
-                            <p class="drawer__item-title">Last modified by (print)</p>
+                            <p class="drawer__item-title">Last modified By (print)</p>
                             <span class="drawer__item-content">{{ (contentItem.lastModified | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime) || "-" }}</span>
                             <span class="drawer__item-content" ng-show="contentItem.lastModifiedInPrintBy">by {{ contentItem.lastModifiedInPrintBy }}</span>
                         </li>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -470,7 +470,7 @@
                             </div>
                         </li>
                         <li class="drawer__item">
-                            <p class="drawer__item-title">Last modified in print</p>
+                            <p class="drawer__item-title">Last modified by (print)</p>
                             <span class="drawer__item-content">{{ (contentItem.lastModified | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime) || "-" }}</span>
                             <span class="drawer__item-content" ng-show="contentItem.lastModifiedInPrintBy">by {{ contentItem.lastModifiedInPrintBy }}</span>
                         </li>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -470,7 +470,7 @@
                             </div>
                         </li>
                         <li class="drawer__item">
-                            <p class="drawer__item-title">Last modified By (print)</p>
+                            <p class="drawer__item-title">Last modified by (print)</p>
                             <span class="drawer__item-content">{{ (contentItem.lastModified | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime) || "-" }}</span>
                             <span class="drawer__item-content" ng-show="contentItem.lastModifiedInPrintBy">by {{ contentItem.lastModifiedInPrintBy }}</span>
                         </li>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -470,7 +470,7 @@
                             </div>
                         </li>
                         <li class="drawer__item">
-                            <p class="drawer__item-title">Last modified by (print)</p>
+                            <p class="drawer__item-title">Last modified (print)</p>
                             <span class="drawer__item-content">{{ (contentItem.lastModified | wfLocaliseDateTime:$root.globalSettings.location | wfFormatDateTime) || "-" }}</span>
                             <span class="drawer__item-content" ng-show="contentItem.lastModifiedInPrintBy">by {{ contentItem.lastModifiedInPrintBy }}</span>
                         </li>

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -157,6 +157,7 @@
         &--office,
         &--legal,
         &--status,
+        &--status-in-print,
         &--composer,
         &--media,
         &--preview,
@@ -235,11 +236,13 @@
         &--created,
         &--legal,
         &--last-modified,
-        &--last-modified-by {
+        &--last-modified-by,
+        &--last-modified-in-print-by {
             width: 100px;
         }
 
-        &--status {
+        &--status,
+        &--status-in-print {
             @include smallScreen {
                 width: 80px;
                 &--select {
@@ -264,14 +267,16 @@
         &--section,
         &--deadline,
         &--last-modified,
-        &--last-modified-by {
+        &--last-modified-by,
+        &--last-modified-in-print-by {
             @extend %fs-data-1;
         }
 
         &--deadline,
         &--created,
         &--last-modified,
-        &--last-modified-by {
+        &--last-modified-by,
+        &--last-modified-in-print-by {
             white-space: nowrap;
         }
 
@@ -458,6 +463,7 @@
         &--office,
         &--legal,
         &--status,
+        &--status-in-print,
         &--composer,
         &--preview,
         &--live,
@@ -475,6 +481,7 @@
         &--printwordcount,
         &--last-modified,
         &--last-modified-by,
+        &--last-modified-in-print-by,
         &--printlocation {
             @extend %fs-data-1;
         }
@@ -492,7 +499,8 @@
             display: inline;
         }
 
-        &--status {
+        &--status,
+        &--status-in-print {
             width: 125px;
 
             &--select {

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -180,6 +180,9 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
             this.plannedNewspaperPageNumber = item.plannedNewspaperPageNumber;
             this.plannedNewspaperPublicationDate = item.plannedNewspaperPublicationDate;
 
+            this.statusInPrint = item.statusInPrint;
+            this.lastModifiedInPrintBy = item.lastModifiedInPrintBy;
+
             // These are derived values used for display purposes.
             const {
               shortPrintLocationDescription,

--- a/public/components/content-list-item/templates/lastModifiedInPrintBy.html
+++ b/public/components/content-list-item/templates/lastModifiedInPrintBy.html
@@ -1,0 +1,3 @@
+<td class="content-list-item__field--last-modified-in-print-by" title="Last Modified in Print By">
+    <span ng-show="contentItem.contentType == 'article'">{{ contentItem.lastModifiedInPrintBy }}</span>
+</td>

--- a/public/components/content-list-item/templates/lastModifiedInPrintBy.html
+++ b/public/components/content-list-item/templates/lastModifiedInPrintBy.html
@@ -1,3 +1,3 @@
-<td class="content-list-item__field--last-modified-in-print-by" title="Last Modified By (print)">
+<td class="content-list-item__field--last-modified-in-print-by" title="Last modified by (print)">
     <span ng-show="contentItem.contentType == 'article'">{{ contentItem.lastModifiedInPrintBy }}</span>
 </td>

--- a/public/components/content-list-item/templates/lastModifiedInPrintBy.html
+++ b/public/components/content-list-item/templates/lastModifiedInPrintBy.html
@@ -1,3 +1,3 @@
-<td class="content-list-item__field--last-modified-in-print-by" title="Last Modified in Print By">
+<td class="content-list-item__field--last-modified-in-print-by" title="Last Modified By (print)">
     <span ng-show="contentItem.contentType == 'article'">{{ contentItem.lastModifiedInPrintBy }}</span>
 </td>

--- a/public/components/content-list-item/templates/statusInPrint.html
+++ b/public/components/content-list-item/templates/statusInPrint.html
@@ -1,0 +1,3 @@
+<td class="content-list-item__field--status-in-print" title="Status in Print">
+    <span ng-show="contentItem.contentType == 'article'">{{ contentItem.statusInPrint }}</span>
+</td>

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -90,6 +90,7 @@ google-auth-banner .alert {
             &--section,
             &--legal,
             &--status,
+            &--status-in-print,
             &--notes,
             &--links,
             &--published-state,
@@ -99,6 +100,7 @@ google-auth-banner .alert {
             &--needsLegal,
             &--last-modified,
             &--last-modified-by,
+            &--last-modified-in-print-by,
             &--printlocation {
                 padding: 15px 10px 5px 5px;
                 @extend %fs-data-2;
@@ -181,10 +183,8 @@ google-auth-banner .alert {
                 min-width: 200px;
             }
 
-            &--last-modified {
-                min-width: 100px;
-            }
-
+            &--last-modified,
+            &--last-modified-in-print-by,
             &--last-modified-by {
                 min-width: 110px;
             }

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -1,28 +1,30 @@
-import priorityTemplate            from "components/content-list-item/templates/priority.html";
-import contentTypeTemplate         from "components/content-list-item/templates/content-type.html";
-import titleTemplate               from "components/content-list-item/templates/title.html";
-import commentsTemplate            from "components/content-list-item/templates/comments.html";
-import mainImageTemplate           from "components/content-list-item/templates/main-image.html";
-import incopyTemplate              from "components/content-list-item/templates/incopy.html";
-import optimisedForWebTemplate     from "components/content-list-item/templates/optimisedForWeb.html";
-import sensitiveTemplate           from "components/content-list-item/templates/sensitive.html";
-import legallySensitiveTemplate    from "components/content-list-item/templates/legallySensitive.html";
-import presenceTemplate            from "components/content-list-item/templates/presence.html";
-import assigneeTemplate            from "components/content-list-item/templates/assignee.html";
-import officeTemplate              from "components/content-list-item/templates/office.html";
-import deadlineTemplate            from "components/content-list-item/templates/deadline.html";
-import sectionTemplate             from "components/content-list-item/templates/section.html";
-import statusTemplate              from "components/content-list-item/templates/status.html";
-import notesTemplate               from "components/content-list-item/templates/notes.html";
-import linksTemplate               from "components/content-list-item/templates/links.html";
-import publishedStateTemplate      from "components/content-list-item/templates/published-state.html";
-import wordcountTemplate           from "components/content-list-item/templates/wordcount.html";
-import printWordcountTemplate      from "components/content-list-item/templates/printwordcount.html";
-import commissionedLengthTemplate  from "components/content-list-item/templates/commissionedLength.html";
-import needsLegalTemplate          from "components/content-list-item/templates/needsLegal.html";
-import lastModifiedTemplate        from "components/content-list-item/templates/last-modified.html";
-import lastModifiedByTemplate      from "components/content-list-item/templates/last-modified-by.html";
-import printLocationTemplate       from "components/content-list-item/templates/printLocation.html";
+import priorityTemplate              from "components/content-list-item/templates/priority.html";
+import contentTypeTemplate           from "components/content-list-item/templates/content-type.html";
+import titleTemplate                 from "components/content-list-item/templates/title.html";
+import commentsTemplate              from "components/content-list-item/templates/comments.html";
+import mainImageTemplate             from "components/content-list-item/templates/main-image.html";
+import incopyTemplate                from "components/content-list-item/templates/incopy.html";
+import optimisedForWebTemplate       from "components/content-list-item/templates/optimisedForWeb.html";
+import sensitiveTemplate             from "components/content-list-item/templates/sensitive.html";
+import legallySensitiveTemplate      from "components/content-list-item/templates/legallySensitive.html";
+import presenceTemplate              from "components/content-list-item/templates/presence.html";
+import assigneeTemplate              from "components/content-list-item/templates/assignee.html";
+import officeTemplate                from "components/content-list-item/templates/office.html";
+import deadlineTemplate              from "components/content-list-item/templates/deadline.html";
+import sectionTemplate               from "components/content-list-item/templates/section.html";
+import statusTemplate                from "components/content-list-item/templates/status.html";
+import notesTemplate                 from "components/content-list-item/templates/notes.html";
+import linksTemplate                 from "components/content-list-item/templates/links.html";
+import publishedStateTemplate        from "components/content-list-item/templates/published-state.html";
+import wordcountTemplate             from "components/content-list-item/templates/wordcount.html";
+import printWordcountTemplate        from "components/content-list-item/templates/printwordcount.html";
+import commissionedLengthTemplate    from "components/content-list-item/templates/commissionedLength.html";
+import needsLegalTemplate            from "components/content-list-item/templates/needsLegal.html";
+import lastModifiedTemplate          from "components/content-list-item/templates/last-modified.html";
+import lastModifiedByTemplate        from "components/content-list-item/templates/last-modified-by.html";
+import printLocationTemplate         from "components/content-list-item/templates/printLocation.html";
+import statusInPrintTemplate         from "components/content-list-item/templates/statusInPrint.html";
+import lastModifiedInPrintByTemplate from "components/content-list-item/templates/lastModifiedInPrintBy.html";
 
 /**
  * This array represents the default ordering and display of the content-list-item columns for workflow.
@@ -335,6 +337,30 @@ const columnDefaults = [{
     isNew: true,
     isSortable: true,
     sortField: ['lastModifiedBy']
+},{
+    name: 'last-modified-in-print-by',
+    prettyName: 'Last Modified in Print By',
+    labelHTML: 'Last Modified in Print By',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'lastModifiedInPrintBy.html',
+    template: lastModifiedInPrintByTemplate,
+    active: true,
+    isNew: true,
+    isSortable: true,
+    sortField: ['lastModifiedInPrintBy']
+},{
+    name: 'status-in-print',
+    prettyName: 'Status in Print',
+    labelHTML: 'Status in Print',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'statusInPrint.html',
+    template: statusInPrintTemplate,
+    active: true,
+    isNew: true,
+    isSortable: true,
+    sortField: ['statusInPrint']
 }].map(col => {
   const _labelHTML = col.labelHTML === ''
     ? '&nbsp;'

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -339,8 +339,8 @@ const columnDefaults = [{
     sortField: ['lastModifiedBy']
 },{
     name: 'last-modified-in-print-by',
-    prettyName: 'Last Modified in Print By',
-    labelHTML: 'Last Modified in Print By',
+    prettyName: 'Last Modified By (print)',
+    labelHTML: 'Last Modified By (print)',
     colspan: 1,
     title: '',
     templateUrl: templateRoot + 'lastModifiedInPrintBy.html',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -339,8 +339,8 @@ const columnDefaults = [{
     sortField: ['lastModifiedBy']
 },{
     name: 'last-modified-in-print-by',
-    prettyName: 'Last Modified By (print)',
-    labelHTML: 'Last Modified By (print)',
+    prettyName: 'Last modified by (print)',
+    labelHTML: 'Last modified by (print)',
     colspan: 1,
     title: '',
     templateUrl: templateRoot + 'lastModifiedInPrintBy.html',


### PR DESCRIPTION
## What does this change?
Adds two new elements to the workflow dash: "last modified in print by", and "status in print".

## How to test

Deploy this branch into CODE, along with https://github.com/guardian/workflow/pull/1070. Push [example Octopus-shaped data](https://gist.github.com/jennygrahamjones/3df30de9d947eefc86f767c6f4566104) (for Composer content tracked in Workflow) onto the octopus-integration-CODE Kinesis stream. Observe that Workflow frontend displays the relevant values.

## How can we measure success?
Fields are present, correctly populated, and look nice.

## Have we considered potential risks?
N/A

## Images
N/A
