### PR TITLE
Add integration test app to allowed origins

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -63,7 +63,7 @@ class AppComponents(context: Context)
   )
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(
-    allowedOrigins = Origins.Matching(Set(config.host) ++ config.corsAllowedDomains)
+    allowedOrigins = Origins.Matching(Set(config.host) ++ config.corsAllowedDomains ++ config.corsAllowedOrigins)
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = {

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -52,13 +52,19 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
     case _ => Set(atomWorkshopUrl)
   }
 
+  def baseUri(host: String) = s"https://$host"
+
   final def getStringSetFromConf(key: String): Set[String] = Try(
-    playConfig.get[String](key).split(",").map(_.trim).toSet
+    playConfig.get[String](key)
+      .split(",")
+      .map(_.trim)
+      .map(baseUri)
+      .toSet
   ).getOrElse(Set.empty)
 
   lazy val corsAllowedOrigins: Set[String] = getStringSetFromConf("security.cors.allowedOrigins")
 
-  lazy val corsAllowedDomains: Set[String] = composerUrls ++ mediaAtomMakerUrls ++ atomWorkshopUrls + corsAllowedOrigins
+  lazy val corsAllowedDomains: Set[String] = composerUrls ++ mediaAtomMakerUrls ++ atomWorkshopUrls
 
   lazy val presenceUrl: String = s"wss://presence.$domain/socket"
   lazy val presenceClientLib: String = s"https://presence.$domain/client/1/lib.js"

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -55,14 +55,14 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
   def baseUri(host: String) = s"https://$host"
 
   final def getStringSetFromConf(key: String): Set[String] = Try(
-    playConfig.get[String](key)
+    playConfig
+      .get[String](key)
       .split(",")
       .map(_.trim)
-      .map(baseUri)
       .toSet
   ).getOrElse(Set.empty)
 
-  lazy val corsAllowedOrigins: Set[String] = getStringSetFromConf("security.cors.allowedOrigins")
+  lazy val corsAllowedOrigins: Set[String] = getStringSetFromConf("security.cors.allowedOrigins").map(baseUri)
 
   lazy val corsAllowedDomains: Set[String] = composerUrls ++ mediaAtomMakerUrls ++ atomWorkshopUrls
 

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -52,7 +52,13 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
     case _ => Set(atomWorkshopUrl)
   }
 
-  lazy val corsAllowedDomains: Set[String] = composerUrls ++ mediaAtomMakerUrls ++ atomWorkshopUrls
+  final def getStringSetFromConf(key: String): Set[String] = Try(
+    playConfig.get[String](key).split(",").map(_.trim).toSet
+  ).getOrElse(Set.empty)
+
+  lazy val corsAllowedOrigins: Set[String] = getStringSetFromConf("security.cors.allowedOrigins")
+
+  lazy val corsAllowedDomains: Set[String] = composerUrls ++ mediaAtomMakerUrls ++ atomWorkshopUrls + corsAllowedOrigins
 
   lazy val presenceUrl: String = s"wss://presence.$domain/socket"
   lazy val presenceClientLib: String = s"https://presence.$domain/client/1/lib.js"


### PR DESCRIPTION
## What does this change?

This adds the ability to add allowed origins (namely the integration test origins) as a Cors allowed origin, mirroring the implementation in the Grid.

This change allows us to programmatically clean up after ourselves in the integration tests by deleting test content via the API.

## How can we measure success?

We can cleanly delete content via the API from within our integration tests (PR to be merged once this one is).
