### PR TITLE
Change type of statusInPrint

### DIFF
--- a/common-lib/src/main/scala/models/OctopusStatus.scala
+++ b/common-lib/src/main/scala/models/OctopusStatus.scala
@@ -1,0 +1,20 @@
+package models
+
+import enumeratum.EnumEntry.CapitalWords
+import enumeratum._
+
+sealed trait OctopusStatus extends EnumEntry with CapitalWords
+
+case object OctopusStatus extends Enum[OctopusStatus] with CirceEnum[OctopusStatus] {
+
+  case object Writers extends OctopusStatus
+  case object Desk extends OctopusStatus
+  case object ChiefSub extends OctopusStatus
+  case object Subs extends OctopusStatus
+  case object ReviseSub extends OctopusStatus
+  case object Finalled extends OctopusStatus
+  case object Hold extends OctopusStatus
+  case object Killed extends OctopusStatus
+
+  override def values = findValues
+}

--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -46,7 +46,7 @@ case class ExternalData(
                          // Description enriched for use by WF front end client code.
                          shortActualPrintLocationDescription: Option[String] = None,
                          longActualPrintLocationDescription: Option[String] = None,
-                         statusInPrint: Option[Status] = None,
+                         statusInPrint: Option[OctopusStatus] = None,
                          lastModifiedInPrintBy: Option[String] = None) {
 }
 


### PR DESCRIPTION
## What does this change?
Rather than typing `statusInPrint` as a `Status`, it is represented as a `OctopusStatus`. 

## How to test
Test with https://github.com/guardian/workflow/pull/1070/. Push [example Octopus-shaped data](https://gist.github.com/jennygrahamjones/3df30de9d947eefc86f767c6f4566104) (for Composer content tracked in Workflow) onto the octopus-integration-CODE Kinesis stream. Observe that Workflow frontend displays the relevant values.

## How can we measure success?
All [flexible-octopus-model ](https://github.com/guardian/flexible-octopus-model/blob/eb999fcfdcec6c9e8ec0fb4346a04690a6e80f00/src/main/thrift/octopus.thrift#L52) `ArticleStatus` values can be displayed.

## Have we considered potential risks?
n/a

## Images
n/a
