### PR TITLE
Allow users to change the Section an atom is assigned to

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -318,6 +318,10 @@
                                 </span>
                             </li>
                             <li class="drawer__item">
+                                <p class="drawer__item-title">Section</p>
+                                <select ng-click="$event.stopPropagation()" ng-model="contentItem.section" ng-options="section.name for section in contentList.sections" wf-content-item-update-action="section"></select>
+                            </li>
+                            <li class="drawer__item">
                                 <p class="drawer__item-title">Content type</p>
                                 <span class="drawer__item-content">
                                     {{ contentItem.contentTypeTitle || '-' }}


### PR DESCRIPTION
## What does this change?
We've had feedback that it would be useful to be able to adjust the 'Section' a Chart atom is assigned to after the atom is created. Currently, there's no element in the UI of either Workflow or Atom Workshop that will allow you to change this value. This can be problematic for users if they accidentally select the wrong Section during creation or just want to change it at a later date.

## How to test
Run this branch locally, with the ssh tunnel to CODE setup, or deploy the branch to CODE. Click on a Chart atom and observe that the 'Section' dropdown is present in the Furniture tab of the drawer. Use the dropdown to change the value. Open Atom Workshop in CODE and confirm that the value has also changed in the Workflow info panel there.

## How can we measure success?
It's possible to change the 'Section' an atom is assigned to.

## Have we considered potential risks?
This affects all atoms that aren't media atoms. I'm not sure if that's a problem?

## Images
![Screenshot 2020-08-19 at 16 42 09](https://user-images.githubusercontent.com/12645938/90657999-f4b98180-e23a-11ea-9ab7-30cd0c7c5379.png)
