### PR TITLE
Changes to Create Article modal

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -66,16 +66,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-
-    </div>
-    <div class="modal-body modal-body__header" ng-click="expanded = !expanded">
-        <a href="" class="modal-body__header-expander" ng-class="{'modal-body modal-body__header-expander--open': expanded}">
-            Advanced
-        </a>
-    </div>
-    <div class="modal-body modal-body__advanced" ng-class="{'modal-body__advanced--open' : expanded}">
-        <div class="form-group">
             <div wf-date-time-picker label="Production deadline" help-text="true" ng-model="stub.due"></div>
             <div class="form-horizontal clearfix">
                 <div class="form-group col-xs-8">
@@ -93,6 +83,12 @@
                     <label for="stub_legal">Legal</label>
                     <div>
                         <select id="stub_legal" name="needsLegal" ng-model="stub.needsLegal" ng-options="ls.value as ls.name for ls in legalStates"></select>
+                    </div>
+                </div>
+                <div class="form-group col-xs-5 pull-right">
+                    <label for="stub_picture_desk">Picture Desk</label>
+                    <div>
+                        <select id="stub_picture_desk" name="needsPictureDesk" ng-model="stub.needsPictureDesk" ng-options="pds.value as pds.name for pds in pictureDeskStates"></select>
                     </div>
                 </div>
             </div>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -10,16 +10,17 @@ import 'components/date-time-picker/date-time-picker';
 import 'lib/composer-service';
 import 'lib/content-service';
 import 'lib/legal-states-service';
+import 'lib/picture-desk-states-service';
 import 'lib/filters-service';
 import 'lib/prodoffice-service';
 import { punters } from 'components/punters/punters';
 
 const wfStubModal = angular.module('wfStubModal', [
-    'ui.bootstrap', 'legalStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService'])
+    'ui.bootstrap', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService'])
     .directive('punters', ['$rootScope', 'wfGoogleApiService', punters]);
 
 function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, config, stub, mode,
-     sections, statusLabels, legalStatesService, wfComposerService, wfProdOfficeService, wfContentService,
+     sections, statusLabels, legalStatesService, pictureDeskStatesService, wfComposerService, wfProdOfficeService, wfContentService,
      wfPreferencesService, wfFiltersService, sectionsInDesks, wfCapiAtomService) {
 
     wfContentService.getTypes().then( (types) => {
@@ -117,6 +118,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     }
 
     $scope.legalStates = legalStatesService.getLegalStates();
+    $scope.pictureDeskStates = pictureDeskStatesService.getpictureDeskStates();
     $scope.prodOffices = wfProdOfficeService.getProdOffices();
 
     $scope.$watch('stub.section', (newValue) => {

--- a/public/lib/picture-desk-states-service.js
+++ b/public/lib/picture-desk-states-service.js
@@ -1,0 +1,24 @@
+define(['angular'], function (angular) {
+    'use strict';
+
+    var pictureDeskStatesService = angular.module('pictureDeskStatesService', []);
+
+    pictureDeskStatesService.factory('pictureDeskStatesService',
+        [function () {
+
+            function getPictureDeskStatus() {
+                return [
+                    {name: 'Not required', value: 'NA'},
+                    {name: 'Needs checking', value: 'REQUIRED'},
+                    {name: 'Approved', value: 'COMPLETE'}
+                ]
+            };
+
+            return {
+                getpictureDeskStates: getPictureDeskStatus
+            };
+
+        }]);
+
+    return pictureDeskStatesService;
+});

--- a/public/lib/picture-desk-states-service.js
+++ b/public/lib/picture-desk-states-service.js
@@ -10,7 +10,7 @@ define(['angular'], function (angular) {
                 return [
                     {name: 'Not required', value: 'NA'},
                     {name: 'Needs checking', value: 'REQUIRED'},
-                    {name: 'Approved', value: 'COMPLETE'}
+                    {name: 'Checked', value: 'COMPLETE'}
                 ]
             };
 


### PR DESCRIPTION
## What does this change?
1. The collapsible 'Advanced' section of the Create Article modal is now removed, with all elements of the modal visible.
2. The 'Picture Desk' menu is visible under the 'Legal' menu.

## How to test
Run the branch locally with the SSH tunnel to CODE set up. Create a new Article and observe the modal appears as in the 'After' image below, with all options available. Pick some options from the Legal and Picture Desk menus. Create your Article. Observe the correct info is displayed on the dashboard.

## How can we measure success?
More usage of the options that were previously hidden in the Advanced section. 

## Have we considered potential risks?
n/a

## Images
Before:
<img width="626" alt="Screenshot 2020-08-20 at 12 00 04" src="https://user-images.githubusercontent.com/12645938/90762301-b83e6200-e2dc-11ea-9219-638d19376c4f.png">

After (screenshot taken on local rather than CODE, so some menus are not populated/local errors displayed):
<img width="626" alt="Screenshot 2020-08-20 at 11 52 47" src="https://user-images.githubusercontent.com/12645938/90761694-b32ce300-e2db-11ea-9ae6-95833e170dfd.png">

