### PR TITLE
Flip sort icon for legal and picdesk

### DIFF
--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -187,6 +187,7 @@ const columnDefaults = [{
     template: needsLegalTemplate,
     active: true,
     isSortable: true,
+    flipSortIconDirection: true,
     defaultSortOrder: ['desc']
 },{
     name: 'needs-picture-desk',
@@ -200,6 +201,7 @@ const columnDefaults = [{
     isNew: true,
     isSortable: true,
     defaultSortOrder: ['desc'],
+    flipSortIconDirection: true,
     sortField: ['needsPictureDesk']
 },{
     name: 'presence',


### PR DESCRIPTION
## What does this change?
Flips the sort icon for legal and picture desk columns.

## How to test
Deploy to code and open dashboard.  Make sure legal and pic desk fields are displayed.

## How can we measure success?
Check the icons are the right way up!

## Have we considered potential risks?

## Images
