### PR TITLE
Add filtering for hasMainMedia

### DIFF
--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -187,6 +187,16 @@ var filterDefaults = function (statuses, wfFiltersService) {
                 { caption: 'Has print info', value: 'true' },
                 { caption: 'No print info', value: 'false' }
             ]
+        },
+        {
+            title: 'MainMedia',
+            namespace: 'hasMainMedia',
+            listIsOpen: false,
+            multi: false,
+            filterOptions: [
+                { caption: 'Has Main Media', value: 'true' },
+                { caption: 'No Main Media', value: 'false' }
+            ]
         }
     ].filter(notEmpty);
 };


### PR DESCRIPTION
## What does this change?
Currently Stubs are marked as 'hasMainMedia' true or false, but the datum is not filterable.

This front end change optionally passes a hasMainMedia=true/false flag to the back end for searching.

See also: 

## How to test
Deploy both PRs to code.
View front end; there will be a new entry in the left side tool bar.
Execute searches with has main media true, false, or absent, and confirm that the results reflect the setting.

## How can we measure success?
Searches return correctly, respecting the setting.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
