### PR TITLE
hasPrintInfo to mean page no

### DIFF
--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -184,8 +184,8 @@ var filterDefaults = function (statuses, wfFiltersService) {
             listIsOpen: false,
             multi: false,
             filterOptions: [
-                { caption: 'Has print info', value: 'true' },
-                { caption: 'No print info', value: 'false' }
+                { caption: 'Has book info', value: 'true' },
+                { caption: 'No book info', value: 'false' }
             ]
         }
     ].filter(notEmpty);

--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -175,8 +175,8 @@ var filterDefaults = function (statuses, wfFiltersService) {
             listIsOpen: false,
             multi: false,
             filterOptions: [
-                { caption: 'Has book info', value: 'true' },
-                { caption: 'No book info', value: 'false' }
+                { caption: 'Has page number', value: 'true' },
+                { caption: 'No page number', value: 'false' }
             ]
         },
         {


### PR DESCRIPTION
Depends on (and explained in): https://github.com/guardian/workflow/pull/1075

<img width="161" alt="image" src="https://user-images.githubusercontent.com/6032869/91293953-b5d28100-e790-11ea-8bdb-03876d06fcc1.png">
