### PR TITLE
Add data-cy selector for content list tables

### DIFF
--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -17,7 +17,7 @@
         </tr>
     </thead>
 
-    <tbody class="content-list__item-container" ng-repeat="group in content track by group.name" content-list-item-container>
+    <tbody data-cy="content-list-{{group.name}}" class="content-list__item-container" ng-repeat="group in content track by group.name" content-list-item-container>
         <!-- Find my content in content-list.js:45 -->
     </tbody>
 


### PR DESCRIPTION
## What does this change?

This adds another selector for content list tables, so that Cypress can assert that an article has moved from one table to another after changing the status
