### PR TITLE
Adjust presence opacity depending on user location

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -503,7 +503,7 @@
                         </li>
                         <li class="drawer__item">
                             <p class="drawer__item-title">In use by</p>
-                            <wf-presence-indicators presence-id="contentItem.composerId" in-drawer="true" ng-if="contentItem.composerId"></wf-presence-indicators>
+                            <wf-presence-indicators presence-id="contentItem.composerId" dont-display-idle="contentItem.contentType == 'liveblog'" in-drawer="true" ng-if="contentItem.composerId"></wf-presence-indicators>
                             <wf-presence-indicators presence-id="'media-' + contentItem.item.editorId" in-drawer="true" ng-if="contentItem.contentType === 'media'"></wf-presence-indicators>
                         </li>
                         <li class="drawer__item">

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -94,7 +94,6 @@
         }
 
         &--presence {
-            background-color: $c-presence-purple;
             border: 1px solid $c-white;
             color: #fff;
 

--- a/public/components/content-list-item/templates/presence.html
+++ b/public/components/content-list-item/templates/presence.html
@@ -1,8 +1,11 @@
 <td class="content-list-item__field--presence">
-    <wf-presence-indicators presence-id="contentItem.composerId" ng-if="contentItem.composerId">
+    <wf-presence-indicators presence-id="contentItem.composerId"
+        dont-display-idle="contentItem.contentType == 'liveblog'" ng-if="contentItem.composerId">
     </wf-presence-indicators>
-    <wf-presence-indicators presence-id="'media-' + contentItem.item.editorId" ng-if="contentItem.contentType === 'media'">
+    <wf-presence-indicators presence-id="'media-' + contentItem.item.editorId"
+        ng-if="contentItem.contentType === 'media'">
     </wf-presence-indicators>
-    <wf-presence-indicators presence-id="'chart-' + contentItem.item.editorId" ng-if="contentItem.contentType === 'chart'">
+    <wf-presence-indicators presence-id="'chart-' + contentItem.item.editorId"
+        ng-if="contentItem.contentType === 'chart'">
     </wf-presence-indicators>
 </td>

--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -32,12 +32,12 @@ $iconAnimationEasingFunction: ease-in-out;
 
 
     &--present,
-    &--unknown {
+    &--unknown,
+    &--idle {
         @extend .content-list-item__presence;
     }
 
     &--idle {
-        @extend .content-list-item__presence;
         opacity: 50%;
     }
 
@@ -59,7 +59,8 @@ $iconAnimationEasingFunction: ease-in-out;
     right: $rightIconOffsetCompact;
 }
 
-.content-list--compact .content-list-item__presence-list:hover .content-list-item__presence--present, .content-list-item__presence--idle {
+.content-list--compact .content-list-item__presence-list:hover .content-list-item__presence--present,
+.content-list--compact .content-list-item__presence-list:hover .content-list-item__presence--idle {
     @for $i from 1 to $iconsToStack + 50 {
         &:nth-of-type(#{$i+1}) {
             right: ($i * $iconExpandIntervalDistanceCompact) + $rightIconOffsetCompact;
@@ -99,7 +100,7 @@ $iconAnimationEasingFunction: ease-in-out;
         }
     }
 
-    &:hover .content-list-item__presence--present, .content-list-item__presence--idle {
+    &:hover .content-list-item__presence--present, &:hover .content-list-item__presence--idle {
         @for $i from 1 to $iconsToStack + 50 {
             // ensure all icons shown when expanded
             &:nth-of-type(#{$i+1}) {

--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -36,6 +36,11 @@ $iconAnimationEasingFunction: ease-in-out;
         @extend .content-list-item__presence;
     }
 
+    &--idle {
+        @extend .content-list-item__presence;
+        opacity: 50%;
+    }
+
     &--unknown {
         background-color: lightgrey;
         color: white;
@@ -49,12 +54,12 @@ $iconAnimationEasingFunction: ease-in-out;
 
 // Compact View modifiers ============================================================================
 
-.content-list--compact .content-list-item__presence-list .content-list-item__presence--present {
+.content-list--compact .content-list-item__presence-list .content-list-item__presence--present, .content-list-item__presence--idle {
     top: $topIconOffsetCompact;
     right: $rightIconOffsetCompact;
 }
 
-.content-list--compact .content-list-item__presence-list:hover .content-list-item__presence--present {
+.content-list--compact .content-list-item__presence-list:hover .content-list-item__presence--present, .content-list-item__presence--idle {
     @for $i from 1 to $iconsToStack + 50 {
         &:nth-of-type(#{$i+1}) {
             right: ($i * $iconExpandIntervalDistanceCompact) + $rightIconOffsetCompact;
@@ -66,14 +71,14 @@ $iconAnimationEasingFunction: ease-in-out;
 
 .content-list-item__presence-list {
 
-    .content-list-item__presence--present {
+    .content-list-item__presence--present, .content-list-item__presence--idle {
         position: absolute;
         top: $topIconOffset;
         right: $rightIconOffset;
 
         @include transition(right $iconAnimationTransTime $iconAnimationEasingFunction);
 
-        .content-list-item__icon--presence {
+        .content-list-item__icon--presence, .content-list-item__icon--idle {
             @include transition(color $iconAnimationTransTime, background-color $iconAnimationTransTime $iconAnimationEasingFunction);
         }
 

--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -37,10 +37,6 @@ $iconAnimationEasingFunction: ease-in-out;
         @extend .content-list-item__presence;
     }
 
-    &--idle {
-        opacity: 50%;
-    }
-
     &--unknown {
         background-color: lightgrey;
         color: white;
@@ -88,6 +84,26 @@ $iconAnimationEasingFunction: ease-in-out;
                 z-index: $i*-1;
             }
         }
+    }
+
+    .content-list-item__presence--idle  {
+        .content-list-item__icon--presence {
+            background-color: $c-presence-light-purple;
+        }
+        @for $i from 1 to 3 {
+            &:nth-of-type(#{$i+1}) {
+                right: ($i * -$stackOffset) + $rightIconOffset;
+                .content-list-item__icon--presence {
+                    background-color: lighten($c-presence-light-purple, $i*$stackColorLightenIncrement);
+                    color: rgba(255, 255, 255, 0);
+                }
+            }
+        }
+    }
+    .content-list-item__presence--present  {
+        .content-list-item__icon--presence {
+            background-color: $c-presence-purple;
+        }
 
         @for $i from 1 to 3 {
             &:nth-of-type(#{$i+1}) {
@@ -100,13 +116,27 @@ $iconAnimationEasingFunction: ease-in-out;
         }
     }
 
-    &:hover .content-list-item__presence--present, &:hover .content-list-item__presence--idle {
+    &:hover .content-list-item__presence--present {
         @for $i from 1 to $iconsToStack + 50 {
             // ensure all icons shown when expanded
             &:nth-of-type(#{$i+1}) {
                 right: ($i * $iconExpandIntervalDistance) + $rightIconOffset;
                 .content-list-item__icon--presence {
                     background-color: $c-presence-purple;
+                    color: rgba(255, 255, 255, 1);
+                    @include box-shadow(0px 0px 4px 1px #ffffff);
+                }
+            }
+        }
+    }
+
+    &:hover .content-list-item__presence--idle {
+        @for $i from 1 to $iconsToStack + 50 {
+            // ensure all icons shown when expanded
+            &:nth-of-type(#{$i+1}) {
+                right: ($i * $iconExpandIntervalDistance) + $rightIconOffset;
+                .content-list-item__icon--presence {
+                    background-color: $c-presence-light-purple;
                     color: rgba(255, 255, 255, 1);
                     @include box-shadow(0px 0px 4px 1px #ffffff);
                 }
@@ -127,6 +157,7 @@ $iconAnimationEasingFunction: ease-in-out;
         position: static;
         display: inline-block;
         .content-list-item__icon--presence {
+            background-color: $c-presence-purple;
             width: auto;
             height: auto;
             text-transform: none;
@@ -144,4 +175,16 @@ $iconAnimationEasingFunction: ease-in-out;
             }
         }
     }
+    .content-list-item__presence--idle {
+        .content-list-item__icon--presence {
+            background-color: $c-presence-light-purple;
+
+            &:hover {
+                background-color: #ffffff;
+                border: 1px solid $c-presence-light-purple;
+                color: $c-presence-light-purple;
+            }
+        }
+    }
+
 }

--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -78,7 +78,7 @@ $iconAnimationEasingFunction: ease-in-out;
 
         @include transition(right $iconAnimationTransTime $iconAnimationEasingFunction);
 
-        .content-list-item__icon--presence, .content-list-item__icon--idle {
+        .content-list-item__icon--presence {
             @include transition(color $iconAnimationTransTime, background-color $iconAnimationTransTime $iconAnimationEasingFunction);
         }
 

--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -99,7 +99,7 @@ $iconAnimationEasingFunction: ease-in-out;
         }
     }
 
-    &:hover .content-list-item__presence--present {
+    &:hover .content-list-item__presence--present, .content-list-item__presence--idle {
         @for $i from 1 to $iconsToStack + 50 {
             // ensure all icons shown when expanded
             &:nth-of-type(#{$i+1}) {
@@ -122,7 +122,7 @@ $iconAnimationEasingFunction: ease-in-out;
     padding: 0;
     position: relative;
 
-    .content-list-item__presence--present {
+    .content-list-item__presence--present, .content-list-item__presence--idle {
         position: static;
         display: inline-block;
         .content-list-item__icon--presence {

--- a/public/components/presence-indicator/presence-indicators.html
+++ b/public/components/presence-indicator/presence-indicators.html
@@ -6,6 +6,6 @@
         ng-if="presence.status === 'present' || presence.status === 'idle'"
         ng-class="'content-list-item__presence--' + presence.status">
         <a class="content-list-item__icon--presence"
-           href="mailto:{{ presence.email }}" title="{{ inDrawer ? presence.email : presence.longText }}">{{ inDrawer ? presence.longText : presence.indicatorText }}</a>
+           href="mailto:{{ presence.email }}" title="{{ inDrawer ? presence.shorTtitle : presence.longTitle }}">{{ inDrawer ? presence.longText : presence.indicatorText }}</a>
     </li>
 </ul>

--- a/public/components/presence-indicator/presence-indicators.html
+++ b/public/components/presence-indicator/presence-indicators.html
@@ -3,7 +3,7 @@
     <span ng-show="(!presences.length || presences.length === 1 && presences[0].status === 'free') && inDrawer" class="drawer__section-data-row drawer__section-data-row--coming-soon">Nobody</span>
 
     <li ng-repeat="presence in presences track by presence.email"
-        ng-if="presence.status === 'present'"
+        ng-if="presence.status === 'present' || presence.status === 'idle'"
         ng-class="'content-list-item__presence--' + presence.status">
         <a class="content-list-item__icon--presence"
            href="mailto:{{ presence.email }}" title="{{ inDrawer ? presence.email : presence.longText }}">{{ inDrawer ? presence.longText : presence.indicatorText }}</a>

--- a/public/components/presence-indicator/presence-indicators.html
+++ b/public/components/presence-indicator/presence-indicators.html
@@ -6,6 +6,6 @@
         ng-if="presence.status === 'present' || presence.status === 'idle'"
         ng-class="'content-list-item__presence--' + presence.status">
         <a class="content-list-item__icon--presence"
-           href="mailto:{{ presence.email }}" title="{{ inDrawer ? presence.shorTtitle : presence.longTitle }}">{{ inDrawer ? presence.longText : presence.indicatorText }}</a>
+           href="mailto:{{ presence.email }}" title="{{ inDrawer ? presence.shortTitle : presence.longTitle }}">{{ inDrawer ? presence.longText : presence.indicatorText }}</a>
     </li>
 </ul>

--- a/public/components/presence-indicator/presence-indicators.html
+++ b/public/components/presence-indicator/presence-indicators.html
@@ -2,7 +2,7 @@
 
     <span ng-show="(!presences.length || presences.length === 1 && presences[0].status === 'free') && inDrawer" class="drawer__section-data-row drawer__section-data-row--coming-soon">Nobody</span>
 
-    <li ng-repeat="presence in presences track by presence.email"
+    <li ng-repeat="presence in presences"
         ng-if="presence.status === 'present' || presence.status === 'idle'"
         ng-class="'content-list-item__presence--' + presence.status">
         <a class="content-list-item__icon--presence"

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -29,8 +29,11 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                                 email: person.email
                             };
 
-                            if(currentState[0].location === "body") {
-                                // the user is actively editing the body
+                            const currentLocation = currentState[0].location;
+
+                            const activeEditingLocations = ["body", "document"];
+
+                            if(activeEditingLocations.includes(currentLocation)) {
                                 return {...presenceObject, ...{status: "present"}};
                             } else {
                                 // the user is not editing the body, has clicked 'Save and close'

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -34,10 +34,16 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                             const activeEditingLocations = ["body", "document"];
 
                             if(activeEditingLocations.includes(currentLocation)) {
-                                return {...presenceObject, ...{status: "present"}};
+                                return {...presenceObject, ...{ status: "present",
+                                        longTitle: [presenceObject.longText, "editing body"].join(" - "),
+                                        shortTitle: [presenceObject.email, "editing body"].join(" - "),
+                                    }};
                             } else {
                                 // the user is not editing the body, has clicked 'Save and close'
-                                return {...presenceObject, ...{status: "idle"}};
+                                return {...presenceObject, ...{status: "idle",
+                                        longTitle: [presenceObject.longText, "editing furniture"].join(" - "),
+                                        shortTitle: [presenceObject.email, "editing furniture"].join(" - ")
+                                    }};
                             }
                         });
                 }

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -41,8 +41,8 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                             } else {
                                 // the user is not editing the body, has clicked 'Save and close'
                                 return {...presenceObject, ...{status: "idle",
-                                        longTitle: [presenceObject.longText, "editing furniture"].join(" - "),
-                                        shortTitle: [presenceObject.email, "editing furniture"].join(" - ")
+                                        longTitle: presenceObject.longText,
+                                        shortTitle: presenceObject.email
                                     }};
                             }
                         });

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -37,15 +37,17 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                                 return {...presenceObject, ...{ status: "present",
                                         longTitle: [presenceObject.longText, "editing body"].join(" - "),
                                         shortTitle: [presenceObject.email, "editing body"].join(" - "),
+                                        iconPrecedence: 1
                                     }};
                             } else {
                                 // the user is not editing the body, has clicked 'Save and close'
                                 return {...presenceObject, ...{status: "idle",
                                         longTitle: presenceObject.longText,
-                                        shortTitle: presenceObject.email
+                                        shortTitle: presenceObject.email,
+                                        iconPrecedence: 2
                                     }};
                             }
-                        });
+                        }).sortBy(function(pr){return pr.iconPrecedence});
                 }
             }
 

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -29,7 +29,7 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                                 email: person.email
                             };
 
-                            const currentLocation = currentState[0].location;
+                            const currentLocation = currentState.find(p => p.clientId === pr.clientId).location;
 
                             const activeEditingLocations = ["body", "document"];
 

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -20,12 +20,22 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
                     $scope.presences = _.map(
                         _.uniqBy(currentState, (s) => { return s.clientId.person.email; }),
                         (pr) => {
-                            var person = pr.clientId.person;
-                            return { indicatorText:
-                                (person.firstName.charAt(0) + person.lastName.charAt(0)).toUpperCase(),
+                            const person = pr.clientId.person;
+
+                            const presenceObject = {
+                                indicatorText:
+                                    (person.firstName.charAt(0) + person.lastName.charAt(0)).toUpperCase(),
                                 longText: [person.firstName, person.lastName].join(" "),
-                                email: person.email,
-                                status: "present" };
+                                email: person.email
+                            };
+
+                            if(currentState[0].location === "body") {
+                                // the user is actively editing the body
+                                return {...presenceObject, ...{status: "present"}};
+                            } else {
+                                // the user is not editing the body, has clicked 'Save and close'
+                                return {...presenceObject, ...{status: "idle"}};
+                            }
                         });
                 }
             }

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -1,24 +1,25 @@
 import presenceIndicatorsTemplate from './presence-indicators.html';
 import _ from 'lodash';
 
-function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
-                                        wfPresenceInitialData) {
+function wfPresenceIndicatorsDirective($rootScope, wfPresenceService,
+    wfPresenceInitialData) {
 
     return {
         restrict: 'E',
         template: presenceIndicatorsTemplate,
         scope: {
             id: "=presenceId",
+            dontDisplayIdle: "=dontDisplayIdle",
             inDrawer: "=inDrawer"
         },
         link: ($scope) => {
 
             function applyCurrentState(currentState) {
-                if(currentState.length === 0) {
-                    $scope.presences = [{ status: "free", indicatorText: ""}];
+                if (currentState.length === 0) {
+                    $scope.presences = [{ status: "free", indicatorText: "" }];
                 } else {
                     $scope.presences = _.map(
-                        _.uniqBy(currentState, (s) => { return s.clientId.person.email; }),
+                        _.uniqBy(currentState, (s) => { return s; }),
                         (pr) => {
                             const person = pr.clientId.person;
 
@@ -33,21 +34,27 @@ function wfPresenceIndicatorsDirective ($rootScope, wfPresenceService,
 
                             const activeEditingLocations = ["body", "document"];
 
-                            if(activeEditingLocations.includes(currentLocation)) {
-                                return {...presenceObject, ...{ status: "present",
+                            if (activeEditingLocations.includes(currentLocation) || $scope.dontDisplayIdle) {
+                                return {
+                                    ...presenceObject, ...{
+                                        status: "present",
                                         longTitle: [presenceObject.longText, "editing body"].join(" - "),
                                         shortTitle: [presenceObject.email, "editing body"].join(" - "),
                                         iconPrecedence: 1
-                                    }};
+                                    }
+                                };
                             } else {
                                 // the user is not editing the body, has clicked 'Save and close'
-                                return {...presenceObject, ...{status: "idle",
+                                return {
+                                    ...presenceObject, ...{
+                                        status: "idle",
                                         longTitle: presenceObject.longText,
                                         shortTitle: presenceObject.email,
                                         iconPrecedence: 2
-                                    }};
+                                    }
+                                };
                             }
-                        }).sortBy(function(pr){return pr.iconPrecedence});
+                        }).sortBy(function (pr) { return pr.iconPrecedence });
                 }
             }
 

--- a/public/layouts/global/_colours.scss
+++ b/public/layouts/global/_colours.scss
@@ -21,6 +21,7 @@ $c-red: #ed5935;
 $c-bluegrey: #dee2e3;
 $c-highlight-blue: #00adee;
 $c-presence-purple: #474D80;
+$c-presence-light-purple: #9094b2;
 
 // Secondary accent colours
 $c-light-green: #f3faf2;


### PR DESCRIPTION
## What does this change?
> "Articles are often not subbed, because ppl see them as being edited in Workflow, even though someone has just left a tab opened and went to lunch."

This PR introduces a small change to the way that Presence is handled in Workflow. We can use the `location` value provided by the Presence service to determine whether or not the user is actively editing the body copy. If the `location` is 'body', the Presence indicator will display as normal. Otherwise, the indicators opacity will be reduced.

## How to test
Run Workflow, Composer (using https://github.com/guardian/flexible-content/pull/3595), and the Presence services locally. Open a piece of Composer content. Observe the Presence indicator in Workflow and that it changes opacity depending on whether you are actively editing the body copy, or have clicked the 'Save and close' button and are no longer editing the body.

Alternatively, deploy this branch of Workflow to CODE and repeat steps above.

## How can we measure success?
Users of Workflow have a better idea of when their colleagues are actively working on some content and when they have just left a browser tab open.

## Have we considered potential risks?
n/a?

## Images
![Screen Recording 2020-09-02 at 15 51 15](https://user-images.githubusercontent.com/12645938/92000823-df158300-ed35-11ea-92fe-61f0dbf0f614.gif)

Tooltips:

![Screen Recording 2020-09-04 at 15 39 47](https://user-images.githubusercontent.com/12645938/92251618-00f14000-eec5-11ea-94db-1b2730ae4589.gif)
