### PR TITLE
Removing testing code

### DIFF
--- a/public/components/presence-indicator/presence-indicators.html
+++ b/public/components/presence-indicator/presence-indicators.html
@@ -2,7 +2,7 @@
 
     <span ng-show="(!presences.length || presences.length === 1 && presences[0].status === 'free') && inDrawer" class="drawer__section-data-row drawer__section-data-row--coming-soon">Nobody</span>
 
-    <li ng-repeat="presence in presences"
+    <li ng-repeat="presence in presences track by presence.email"
         ng-if="presence.status === 'present' || presence.status === 'idle'"
         ng-class="'content-list-item__presence--' + presence.status">
         <a class="content-list-item__icon--presence"

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -19,7 +19,7 @@ function wfPresenceIndicatorsDirective($rootScope, wfPresenceService,
                     $scope.presences = [{ status: "free", indicatorText: "" }];
                 } else {
                     $scope.presences = _.map(
-                        _.uniqBy(currentState, (s) => { return s; }),
+                        _.uniqBy(currentState, (s) => { return s.clientId.person.email; }),
                         (pr) => {
                             const person = pr.clientId.person;
 


### PR DESCRIPTION
I'd been using these changes to test what multiple icons looked like locally for https://github.com/guardian/workflow-frontend/pull/301 and they slipped through on merge of that PR. Changing this back ensures that each person only has a single icon displayed for their presence in Workflow.