### PR TITLE
Fallback to the default credentials provider

### DIFF
--- a/common-lib/src/main/scala/com/gu/workflow/util/AWS.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/util/AWS.scala
@@ -1,7 +1,7 @@
 package com.gu.workflow.util
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
+import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.dynamodbv2.document.DynamoDB
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
@@ -15,7 +15,7 @@ import scala.collection.JavaConverters._
 object AWS {
   lazy val credentialsProvider = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider("workflow"),
-    InstanceProfileCredentialsProvider.getInstance()
+    new DefaultAWSCredentialsProviderChain()
   )
 
   lazy val region: Region = Region getRegion Regions.EU_WEST_1


### PR DESCRIPTION
broke the credentials chain needed for the lambda powering Workflow notifications (https://github.com/guardian/workflow-frontend/pull/153, https://github.com/guardian/workflow-frontend/pull/156).

We need at least the env vars provider for use in the notifications lambda but I figured if we fallback to the default then it's more resilient to other changes in the future.

## How to test

Register a notification (click your name in the top right menu, then "Subscribe to this Page"). Make a change so something new appears on the page. You should get a notification, even if you close the page.

