### PR TITLE
Send notifications when rows appear in a view

### DIFF
--- a/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
@@ -15,9 +15,7 @@ import scala.util.control.NonFatal
 class Notifier(stage: Stage, override val secret: String, subsApi: SubscriptionsAPI) extends SharedSecretAuth with Logging {
 
   private val appUrl = stage match {
-    // TODO MRB: put this back to https://workflow.local.dev-gutools.co.uk
-    //           by convincing the JVM that our local dev cert is totes legit
-    case Dev => "http://localhost:9090"
+    case Dev => "https://workflow.local.dev-gutools.co.uk"
     case stage => s"https://workflow.${stage.appDomain}"
   }
 

--- a/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
@@ -70,6 +70,11 @@ class Notifier(stage: Stage, override val secret: String, subsApi: Subscriptions
 
       (before, after) match {
         case (Some(statusBefore), Some(statusAfter)) if statusAfter != statusBefore =>
+          // The row has changed status
+          stubs.find(_._2.id.contains(id))
+
+        case (None, Some(_)) =>
+          // A new row has appeared
           stubs.find(_._2.id.contains(id))
 
         case _ =>


### PR DESCRIPTION
**NB: depends on https://github.com/guardian/workflow-frontend/pull/304**

You can subscribe to the current view in Workflow and be sent notifications when rows (stubs) move from one status to another (see https://github.com/guardian/workflow-frontend/pull/153, https://github.com/guardian/workflow-frontend/pull/156).

We'd like to test these out with the new "Needs Picture Desk" flag (#286 #289) as it may be an easier way for them to be notified rather than having to regularly check a tab with Workflow open.

Unfortunately, the existing implementation would only send notifications when a row changed Status, for example Writers to Desk. This was a bug introduced in #156. To subscribe to "Needs Picture Desk" it must also send a notification the first time a new row is seen in the view.

## How to test

- Configure Workflow filters to include "Needs Picture Desk"
- Register a notification (click your name in the top right menu, then "Subscribe to this Page")
- Update a row to set the "Needs Picture Desk" flag, such that it appears in the view

You should receive a notification.

