### PR TITLE
Add a description to notifications

### DIFF
--- a/app/controllers/Notifications.scala
+++ b/app/controllers/Notifications.scala
@@ -5,7 +5,7 @@ import com.gu.pandomainauth.model.User
 import com.gu.workflow.api.{ApiUtils, SubscriptionsAPI}
 import config.Config
 import models.api.ApiResponseFt
-import models.{CreateSubscriptionRequest, Subscription, SubscriptionEndpoint, SubscriptionSchedule}
+import models.{Subscription, SubscriptionEndpoint, SubscriptionSchedule}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{BaseController, ControllerComponents}
 
@@ -49,9 +49,10 @@ class Notifications(
 
     ApiResponseFt[String](for {
       json <- readJsonFromRequestResponse(request.body)
-      requestBody <- extractResponse[CreateSubscriptionRequest](json)(Subscription.createSubscriptionRequestDecoder)
+      browserDetails <- extractResponse[SubscriptionEndpoint](json)(Subscription.endpointDecoder)
 
-      sub = Subscription(request.user.email, userAgent, qs, Some(requestBody.description), requestBody.browserDetails,
+      description = Subscription.humanReadable(qs)
+      sub = Subscription(request.user.email, userAgent, qs, Some(description), browserDetails,
         schedule = SubscriptionSchedule(enabled = true), runtime = None)
 
       _ <- ApiResponseFt.Right(subsApi.put(sub))

--- a/common-lib/src/main/scala/models/Subscription.scala
+++ b/common-lib/src/main/scala/models/Subscription.scala
@@ -33,8 +33,6 @@ case class Subscription(
 case class SubscriptionRuntime(seenIds: Map[Long, Status])
 case class SubscriptionSchedule(enabled: Boolean)
 
-case class CreateSubscriptionRequest(browserDetails: SubscriptionEndpoint, description: String)
-
 // The actual contents of a notification fired and sent to the service worker to actually display on the users machine
 case class SubscriptionUpdate(title: String, body: String, url: Option[String])
 
@@ -52,8 +50,6 @@ object Subscription {
 
   implicit val scheduleEncoder: Encoder[SubscriptionSchedule] = deriveConfiguredEncoder
   implicit val scheduleDecoder: Decoder[SubscriptionSchedule] = deriveConfiguredDecoder
-
-  implicit val createSubscriptionRequestDecoder: Decoder[CreateSubscriptionRequest] = deriveConfiguredDecoder
 
   implicit val updateEncoder: Encoder[SubscriptionUpdate] = deriveConfiguredEncoder
   implicit val updateDecoder: Decoder[SubscriptionUpdate] = deriveConfiguredDecoder

--- a/common-lib/src/main/scala/models/Subscription.scala
+++ b/common-lib/src/main/scala/models/Subscription.scala
@@ -34,7 +34,7 @@ case class SubscriptionRuntime(seenIds: Map[Long, Status])
 case class SubscriptionSchedule(enabled: Boolean)
 
 // The actual contents of a notification fired and sent to the service worker to actually display on the users machine
-case class SubscriptionUpdate(title: String, body: String, url: Option[String])
+case class SubscriptionUpdate(title: String, body: String, url: String)
 
 object Subscription {
   implicit val customConfig: Configuration = Configuration.default.withDefaults

--- a/common-lib/src/main/scala/models/Subscription.scala
+++ b/common-lib/src/main/scala/models/Subscription.scala
@@ -20,11 +20,20 @@ case class SubscriptionEndpoint(endpoint: String, keys: SubscriptionKeys)
 //   None            -> we have not seen any content under the given query yet so don't fire notifications
 //   Some(Map.empty) -> we last saw no content matching the query
 //   Some(content)   -> the content we saw last and the status it was in (ie do a diff and fire notifications)
-case class Subscription(email: String, userAgent: String, query: Subscription.Query, endpoint: SubscriptionEndpoint,
-                        schedule: SubscriptionSchedule, runtime: Option[SubscriptionRuntime])
+case class Subscription(
+  email: String,
+  userAgent: String,
+  query: Subscription.Query,
+  description: Option[String],
+  endpoint: SubscriptionEndpoint,
+  schedule: SubscriptionSchedule,
+  runtime: Option[SubscriptionRuntime]
+)
 
 case class SubscriptionRuntime(seenIds: Map[Long, Status])
 case class SubscriptionSchedule(enabled: Boolean)
+
+case class CreateSubscriptionRequest(browserDetails: SubscriptionEndpoint, description: String)
 
 // The actual contents of a notification fired and sent to the service worker to actually display on the users machine
 case class SubscriptionUpdate(title: String, body: String, url: Option[String])
@@ -43,6 +52,8 @@ object Subscription {
 
   implicit val scheduleEncoder: Encoder[SubscriptionSchedule] = deriveConfiguredEncoder
   implicit val scheduleDecoder: Decoder[SubscriptionSchedule] = deriveConfiguredDecoder
+
+  implicit val createSubscriptionRequestDecoder: Decoder[CreateSubscriptionRequest] = deriveConfiguredDecoder
 
   implicit val updateEncoder: Encoder[SubscriptionUpdate] = deriveConfiguredEncoder
   implicit val updateDecoder: Decoder[SubscriptionUpdate] = deriveConfiguredDecoder

--- a/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
@@ -108,10 +108,11 @@ class Notifier(stage: Stage, override val secret: String, subsApi: Subscriptions
       stubs.foreach { case (status, stub) =>
         // TODO MRB: atom edit URLs?
         val url = stub.composerId.map { id => s"$composerUrl/content/$id"}
-        val body = stub.note.getOrElse("")
 
-        val message = sub.description.map(_ + s": ${stub.title}").getOrElse(s"${stub.title} now in $status")
-        val update = SubscriptionUpdate(message, body, url)
+        val title = sub.description.getOrElse(status.toString)
+        val body = stub.title
+
+        val update = SubscriptionUpdate(title, body, url)
 
         subsApi.sendNotification(update, sub.endpoint)
       }

--- a/public/layouts/dashboard/dashboard-create.js
+++ b/public/layouts/dashboard/dashboard-create.js
@@ -25,8 +25,8 @@ angular
         $scope.registerSubscription = () => {
             $scope.subscriptionStatus = "Subscribing...";
 
-            registerSubscription().then(() => {
-                $scope.subscriptionStatus = "Subscribed!";
+            registerSubscription().then((result) => {
+                $scope.subscriptionStatus = result ? "Subscribed!" : null;
             }).catch((err) => {
                 $scope.subscriptionStatus = null;
             });

--- a/public/lib/notifications.js
+++ b/public/lib/notifications.js
@@ -19,19 +19,13 @@ export function registerServiceWorker() {
 
 export function registerSubscription() {
     // TODO MRB: handle service worker not being registered yet (disable button?)
-    const description = window.prompt("Enter a description. This will appear in the body of the notification");
-
-    if(description !== null) {
-        return navigator.serviceWorker.getRegistration(serviceWorkerURL).then(({ pushManager }) => {
-            return getBrowserSubscription(pushManager).then((sub) => {
-                return saveSubscription(sub, window.location.search, description).then(() => true);
-            });
-        }).catch(err => {
-            console.error("Unable to register subscription", err);
+    return navigator.serviceWorker.getRegistration(serviceWorkerURL).then(({ pushManager }) => {
+        return getBrowserSubscription(pushManager).then((sub) => {
+            return saveSubscription(sub, window.location.search).then(() => true);
         });
-    }
-
-    return Promise.resolve(false);
+    }).catch(err => {
+        console.error("Unable to register subscription", err);
+    });
 }
 
 function getBrowserSubscription(pushManager) {
@@ -51,13 +45,10 @@ function getBrowserSubscription(pushManager) {
     });
 }
 
-function saveSubscription(sub, query, description) {
+function saveSubscription(sub, query) {
     return fetch("/api/notifications" + query, {
         method: "POST",
-        body: JSON.stringify({
-            browserDetails: sub,
-            description
-        }),
+        body: JSON.stringify(sub),
         headers: { "Content-Type": "application/json" },
         credentials: "include"
     }).then(( { status }) => {


### PR DESCRIPTION
When you subscribe to be notified on a page, it repeats the query you subscribed to in the title of the notification:

<img width="361" alt="Screen Shot 2020-10-13 at 11 06 21" src="https://user-images.githubusercontent.com/395805/95847291-706c1200-0d44-11eb-8977-21093f7dbdaf.png">

The current use case for notifications is to monitor a flag like "Needs Picture Desk". The previous implementation used to simply say "XYZ is in Writers" which made it difficult to know what the user was supposed to do based on the notification.

As the call to action is in the description this PR now only sends notifications when something appears in the view. You can recreate the old behaviour of notifying on every stage by creating multiple subscriptions (for Desk, Subs, Revise etc). I've retained enough information in the database to switch back if we want.

Clicking the notification also opens Workflow itself (with the filters you subscribed to) rather than Composer directly.
