### PR TITLE
Don't use the CAPI key as Panda system

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -105,7 +105,7 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
 
   lazy val capiKey: String = playConfig.get[String]("capi.key")
 
-  lazy val pandaSystem: String = playConfig.getOptional[String]("capi.key").getOrElse("workflow")
+  lazy val pandaSystem: String = "workflow"
   lazy val pandaBucketName: String = "pan-domain-auth-settings"
   lazy val pandaSettingsFile: String = s"$domain.settings"
 


### PR DESCRIPTION
## What does this change?
An error during a Play upgrade has meant that workflow's panda ID is the CAPI key that workflow uses. This is, umm, a mistake. This should be a static meaningful ID. Fortunately it is static so it is still working, but this makes it meaningful again.

## How to test
This should be a no-op, although some users might need to refresh panda.

## How can we measure success?
`workflow` is the panda ID rather than a seemingly random UUID.

## Have we considered potential risks?
Some users might need to refresh panda but when testing in CODE I saw no impact.
