### PR TITLE
Hide the 'View versions' button for content that isn't in Composer

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -619,7 +619,8 @@
             <div class="drawer__toolbar-item drawer__toolbar-item--spacer">
                 &nbsp;
             </div>
-            <span class="drawer__toolbar-item drawer__toolbar-item--action">
+            <!-- if the content doesn't have a Composer page, it won't be accessible in Restorer -->
+            <span ng:if="!composerRestorerUrl.includes('null')" class="drawer__toolbar-item drawer__toolbar-item--action">
                 <a href="{{ composerRestorerUrl }}" target="_blank" class="drawer__item-content" title="View versions">
                     <i class="drawer__icon drawer__toolbar-icon" wf-icon="view-versions"></i>
                     View versions


### PR DESCRIPTION
## What does this change?
A small change based on observing a user interact with Workflow this morning. The user wanted to see who had worked on a piece of Video content, so clicked the 'View versions' button in the management panel. This button passes the Composer ID on to Restorer, to display a version/snapshot history. If there is no Composer ID, the value `null` is passed in it's place. This PR hides the 'View versions' button if `null` is present in the Restorer URL.

## How to test
In Workflow, find some content of the following types (Content Type of Video or Atom Type of Media).

<img width="146" alt="Screenshot 2020-11-27 at 09 26 58" src="https://user-images.githubusercontent.com/12645938/100459015-bbdb4500-3092-11eb-899b-ccef34a2d7b0.png">

Check whether the content has an associated Composer page. If it doesn't, there will be a 'Create Video Page' button visible in Media Atom Maker.

<img width="273" alt="Screenshot 2020-11-27 at 09 41 23" src="https://user-images.githubusercontent.com/12645938/100460183-c4cd1600-3094-11eb-88e1-c9ac426e5f03.png">

Running this branch locally or in CODE, observe that the 'View versions' button should not be visible in the management panel for any content that does not have a Composer page.

## Have we considered potential risks?
1. Will this be confusing to users who are used to seeing this button here? Arguably it is better UX, because they won't click it only to discover that it doesn't work.

1. The conditional check for `null` in the Restorer URL is quite basic. Is there a better attribute, on the `contentItem` model perhaps, that could give us an indication about whether the content will be found in Restorer? I'd originally thought to use the content type, but given a video may start off without an ID and then later acquire one, we can't rely on the content type.
