### PR TITLE
Add pinboard column to dashboard

### DIFF
--- a/app/views/app.scala.html
+++ b/app/views/app.scala.html
@@ -25,4 +25,5 @@
     </script>
   }
   <script async src="https://apis.google.com/js/client.js?onload=init"></script>
+    <script async src="https://pinboard.local.dev-gutools.co.uk/pinboard.loader.js"></script>
 }

--- a/public/components/content-list-item/templates/pinboard.html
+++ b/public/components/content-list-item/templates/pinboard.html
@@ -1,0 +1,1 @@
+<td class="content-list-item__field--notes" title="Pinboard"><pinboard-info id="pinboard-{{contentItem.id}}" data-stub-id="{{contentItem.id}}"></td>

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -26,6 +26,7 @@ import printLocationTemplate         from "components/content-list-item/template
 import needsPictureDeskTemplate      from "components/content-list-item/templates/needsPictureDesk.html";
 import statusInPrintTemplate         from "components/content-list-item/templates/statusInPrint.html";
 import lastModifiedInPrintByTemplate from "components/content-list-item/templates/lastModifiedInPrintBy.html";
+import pinboardTemplate              from "components/content-list-item/templates/pinboard.html";
 
 /**
  * This array represents the default ordering and display of the content-list-item columns for workflow.
@@ -122,6 +123,16 @@ const columnDefaults = [{
     active: true,
     isSortable: true,
     sortField: ['note']
+},{
+    name: 'pinboard',
+    prettyName: 'Pinboard',
+    labelHTML: 'Pinboard',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'pinboard.html',
+    template: pinboardTemplate,
+    active: true,
+    isSortable: true,
 },{
     name: 'comments',
     prettyName: 'Comments: On/Off',


### PR DESCRIPTION
## What does this change?
Provides example integration with pinboard by adding a new column that shows the number of pinboard messages, and can be clicked to open the pinboard itself. Some food for thought for how it might look/work.

## Images
![pinboard-workflow(1)](https://user-images.githubusercontent.com/12645938/103528322-bd4a1b00-4e51-11eb-94f0-8d421558feb5.gif)

