### PR TITLE
Adds support for the new presence locations field

### DIFF
--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -30,16 +30,18 @@ function wfPresenceIndicatorsDirective($rootScope, wfPresenceService,
                                 email: person.email
                             };
 
-                            const currentLocation = currentState.find(p => p.clientId === pr.clientId).location;
+                            const location = currentState.find(p => p.clientId === pr.clientId).location;
+                            const locations = currentState.find(p => p.clientId === pr.clientId).locations || [];
 
-                            const activeEditingLocations = ["body", "document"];
+                            const currentLocations = location ? [...locations, location] : locations
+                            const activeEditingLocations = ["body", "document", "furniture"];
 
-                            if (activeEditingLocations.includes(currentLocation) || $scope.dontDisplayIdle) {
+                            if (activeEditingLocations.some((l) => currentLocations.includes(l)) || $scope.dontDisplayIdle) {
                                 return {
                                     ...presenceObject, ...{
                                         status: "present",
-                                        longTitle: [presenceObject.longText, "editing body"].join(" - "),
-                                        shortTitle: [presenceObject.email, "editing body"].join(" - "),
+                                        longTitle: [presenceObject.longText, "editing"].join(" - "),
+                                        shortTitle: [presenceObject.email, "editing"].join(" - "),
                                         iconPrecedence: 1
                                     }
                                 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds support for the new [Presence locations](https://github.com/guardian/presence-indicator/pull/114) in the icons which appears against stubs.

This change should facilitate backwards compatibility with the existing functionality whilst supporting the new field.

it is also a slight change as editing the furniture will now count as actively editing a document. Previously, this only applied to editing the document.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This change would ideally be tested against the Presence updates with no `locations` and then with some `locations` to ensure it works before and after the changes. Currently no `locations` will be stored in Presence until Presence clients start adding them i.e. in [this PR](https://github.com/guardian/flexible-content/pull/3764).

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The Presence behaviour continues to work as before and also understands users editing multiple locations.

