### PR TITLE
Adjust presence display logic to hide idle and show furniture as semi-transparent

### DIFF
--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -33,6 +33,7 @@ $iconAnimationEasingFunction: ease-in-out;
 
     &--present,
     &--unknown,
+    &--furniture,
     &--idle {
         @extend .content-list-item__presence;
     }
@@ -50,12 +51,15 @@ $iconAnimationEasingFunction: ease-in-out;
 
 // Compact View modifiers ============================================================================
 
-.content-list--compact .content-list-item__presence-list .content-list-item__presence--present, .content-list-item__presence--idle {
+.content-list--compact .content-list-item__presence-list .content-list-item__presence--present, 
+.content-list-item__presence--furniture,
+.content-list-item__presence--idle {
     top: $topIconOffsetCompact;
     right: $rightIconOffsetCompact;
 }
 
 .content-list--compact .content-list-item__presence-list:hover .content-list-item__presence--present,
+.content-list--compact .content-list-item__presence-list:hover .content-list-item__presence--furniture,
 .content-list--compact .content-list-item__presence-list:hover .content-list-item__presence--idle {
     @for $i from 1 to $iconsToStack + 50 {
         &:nth-of-type(#{$i+1}) {
@@ -68,7 +72,7 @@ $iconAnimationEasingFunction: ease-in-out;
 
 .content-list-item__presence-list {
 
-    .content-list-item__presence--present, .content-list-item__presence--idle {
+    .content-list-item__presence--present, .content-list-item__presence--furniture, .content-list-item__presence--idle {
         position: absolute;
         top: $topIconOffset;
         right: $rightIconOffset;
@@ -86,7 +90,7 @@ $iconAnimationEasingFunction: ease-in-out;
         }
     }
 
-    .content-list-item__presence--idle  {
+    .content-list-item__presence--furniture, .content-list-item__presence--idle  {
         .content-list-item__icon--presence {
             background-color: $c-presence-light-purple;
         }
@@ -130,7 +134,7 @@ $iconAnimationEasingFunction: ease-in-out;
         }
     }
 
-    &:hover .content-list-item__presence--idle {
+    &:hover .content-list-item__presence--furniture, .content-list-item__presence--idle {
         @for $i from 1 to $iconsToStack + 50 {
             // ensure all icons shown when expanded
             &:nth-of-type(#{$i+1}) {
@@ -153,7 +157,7 @@ $iconAnimationEasingFunction: ease-in-out;
     padding: 0;
     position: relative;
 
-    .content-list-item__presence--present, .content-list-item__presence--idle {
+    .content-list-item__presence--present, .content-list-item__presence--furniture, .content-list-item__presence--idle {
         position: static;
         display: inline-block;
         .content-list-item__icon--presence {
@@ -175,7 +179,7 @@ $iconAnimationEasingFunction: ease-in-out;
             }
         }
     }
-    .content-list-item__presence--idle {
+    .content-list-item__presence--furniture, .content-list-item__presence--idle {
         .content-list-item__icon--presence {
             background-color: $c-presence-light-purple;
 

--- a/public/components/presence-indicator/presence-indicators.html
+++ b/public/components/presence-indicator/presence-indicators.html
@@ -3,7 +3,7 @@
     <span ng-show="(!presences.length || presences.length === 1 && presences[0].status === 'free') && inDrawer" class="drawer__section-data-row drawer__section-data-row--coming-soon">Nobody</span>
 
     <li ng-repeat="presence in presences track by presence.email"
-        ng-if="presence.status === 'present' || presence.status === 'idle'"
+        ng-if="presence.status === 'present' || presence.status === 'furniture'"
         ng-class="'content-list-item__presence--' + presence.status">
         <a class="content-list-item__icon--presence"
            href="mailto:{{ presence.email }}" title="{{ inDrawer ? presence.shortTitle : presence.longTitle }}">{{ inDrawer ? presence.longText : presence.indicatorText }}</a>

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -36,32 +36,29 @@ function wfPresenceIndicatorsDirective($rootScope, wfPresenceService,
 
                             if (editingBodyLocations.some((l) => currentLocations.includes(l)) || $scope.dontDisplayIdle) {
                                 return {
-                                    ...presenceObject, ...{
-                                        status: "present",
-                                        longTitle: [presenceObject.longText, "editing body"].join(" - "),
-                                        shortTitle: [presenceObject.email, "editing body"].join(" - "),
-                                        iconPrecedence: 1
-                                    }
+                                    ...presenceObject, 
+                                    status: "present",
+                                    longTitle: [presenceObject.longText, "editing body"].join(" - "),
+                                    shortTitle: [presenceObject.email, "editing body"].join(" - "),
+                                    iconPrecedence: 1
                                 };
                             } else if(editingFurnitureLocations.some((l) => currentLocations.includes(l))) {
                                 // the user is not editing the body, has clicked 'Save and close'
                                 return {
-                                    ...presenceObject, ...{
-                                        status: "furniture",
-                                        longTitle: [presenceObject.longText, "editing furniture"].join(" - "),
-                                        shortTitle: [presenceObject.email, "editing furniture"].join(" - "),
-                                        iconPrecedence: 2
-                                    }
+                                    ...presenceObject,
+                                    status: "furniture",
+                                    longTitle: [presenceObject.longText, "editing furniture"].join(" - "),
+                                    shortTitle: [presenceObject.email, "editing furniture"].join(" - "),
+                                    iconPrecedence: 2
                                 };
                             } else {
                                 // the user is not editing the body, has clicked 'Save and close'
                                 return {
-                                    ...presenceObject, ...{
-                                        status: "idle",
-                                        longTitle: presenceObject.longText,
-                                        shortTitle: presenceObject.email,
-                                        iconPrecedence: 3
-                                    }
+                                    ...presenceObject,
+                                    status: "idle",
+                                    longTitle: presenceObject.longText,
+                                    shortTitle: presenceObject.email,
+                                    iconPrecedence: 3
                                 };
                             }
                         }).sortBy(function (pr) { return pr.iconPrecedence });

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -29,20 +29,27 @@ function wfPresenceIndicatorsDirective($rootScope, wfPresenceService,
                                 longText: [person.firstName, person.lastName].join(" "),
                                 email: person.email
                             };
+                            const currentLocations = pr.location ? [...pr.locations, pr.location] : pr.locations
+                            const editingBodyLocations = ["body", "document"];
+                            const editingFurnitureLocations = ["furniture"];
 
-                            const location = currentState.find(p => p.clientId === pr.clientId).location;
-                            const locations = currentState.find(p => p.clientId === pr.clientId).locations || [];
-
-                            const currentLocations = location ? [...locations, location] : locations
-                            const activeEditingLocations = ["body", "document", "furniture"];
-
-                            if (activeEditingLocations.some((l) => currentLocations.includes(l)) || $scope.dontDisplayIdle) {
+                            if (editingBodyLocations.some((l) => currentLocations.includes(l)) || $scope.dontDisplayIdle) {
                                 return {
                                     ...presenceObject, ...{
                                         status: "present",
-                                        longTitle: [presenceObject.longText, "editing"].join(" - "),
-                                        shortTitle: [presenceObject.email, "editing"].join(" - "),
+                                        longTitle: [presenceObject.longText, "editing body"].join(" - "),
+                                        shortTitle: [presenceObject.email, "editing body"].join(" - "),
                                         iconPrecedence: 1
+                                    }
+                                };
+                            } else if(editingFurnitureLocations.some((l) => currentLocations.includes(l))) {
+                                // the user is not editing the body, has clicked 'Save and close'
+                                return {
+                                    ...presenceObject, ...{
+                                        status: "furniture",
+                                        longTitle: [presenceObject.longText, "editing furniture"].join(" - "),
+                                        shortTitle: [presenceObject.email, "editing furniture"].join(" - "),
+                                        iconPrecedence: 2
                                     }
                                 };
                             } else {
@@ -52,7 +59,7 @@ function wfPresenceIndicatorsDirective($rootScope, wfPresenceService,
                                         status: "idle",
                                         longTitle: presenceObject.longText,
                                         shortTitle: presenceObject.email,
-                                        iconPrecedence: 2
+                                        iconPrecedence: 3
                                     }
                                 };
                             }

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -29,7 +29,8 @@ function wfPresenceIndicatorsDirective($rootScope, wfPresenceService,
                                 longText: [person.firstName, person.lastName].join(" "),
                                 email: person.email
                             };
-                            const currentLocations = pr.location ? [...pr.locations, pr.location] : pr.locations
+                            const locations = pr.locations || [];
+                            const currentLocations = pr.location ? [...locations, pr.location] : locations;
                             const editingBodyLocations = ["body", "document"];
                             const editingFurnitureLocations = ["furniture"];
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR use the multiple location Presence work to display the icons differently depending on the users location.

The behaviour is now:

1. In body -> Opaque icon
2. In furniture -> Semi-transparent icon
3. In neither body or furniture -> no icon

Note: This behaviour is also featured in the content drawer, in the management pane. 

Note 2: Liveblogs are currently not supported but could be added. This would require a change to Composer to more clearly identify liveblog blocks in the locations field.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This is probably best tested on CODE in conjunction with https://github.com/guardian/flexible-content/pull/3764. However it is also possible to test locally but requires Presence, Workflow, Workflow-Frontend & Composer to all be running.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Workflow users are able to clearly identify who is working in a given piece of content, and what they're doing.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![WORKFLOW_PRESENCE](https://user-images.githubusercontent.com/4633246/107525312-a31cfe80-6bae-11eb-95ac-88f425bbd1b0.gif)
