### PR TITLE
Adds a displayed idle state

### DIFF
--- a/public/components/presence-indicator/_presence-indicators.scss
+++ b/public/components/presence-indicator/_presence-indicators.scss
@@ -90,7 +90,7 @@ $iconAnimationEasingFunction: ease-in-out;
         }
     }
 
-    .content-list-item__presence--furniture, .content-list-item__presence--idle  {
+    .content-list-item__presence--furniture {
         .content-list-item__icon--presence {
             background-color: $c-presence-light-purple;
         }
@@ -104,6 +104,22 @@ $iconAnimationEasingFunction: ease-in-out;
             }
         }
     }
+
+    .content-list-item__presence--idle {
+        .content-list-item__icon--presence {
+            background-color: $c-presence-lightest-purple;
+        }
+        @for $i from 1 to 3 {
+            &:nth-of-type(#{$i+1}) {
+                right: ($i * -$stackOffset) + $rightIconOffset;
+                .content-list-item__icon--presence {
+                    background-color: lighten($c-presence-lightest-purple, $i*$stackColorLightenIncrement);
+                    color: rgba(255, 255, 255, 0);
+                }
+            }
+        }
+    }
+
     .content-list-item__presence--present  {
         .content-list-item__icon--presence {
             background-color: $c-presence-purple;
@@ -134,13 +150,27 @@ $iconAnimationEasingFunction: ease-in-out;
         }
     }
 
-    &:hover .content-list-item__presence--furniture, .content-list-item__presence--idle {
+    &:hover .content-list-item__presence--furniture {
         @for $i from 1 to $iconsToStack + 50 {
             // ensure all icons shown when expanded
             &:nth-of-type(#{$i+1}) {
                 right: ($i * $iconExpandIntervalDistance) + $rightIconOffset;
                 .content-list-item__icon--presence {
                     background-color: $c-presence-light-purple;
+                    color: rgba(255, 255, 255, 1);
+                    @include box-shadow(0px 0px 4px 1px #ffffff);
+                }
+            }
+        }
+    }
+
+    &:hover .content-list-item__presence--idle {
+        @for $i from 1 to $iconsToStack + 50 {
+            // ensure all icons shown when expanded
+            &:nth-of-type(#{$i+1}) {
+                right: ($i * $iconExpandIntervalDistance) + $rightIconOffset;
+                .content-list-item__icon--presence {
+                    background-color: $c-presence-lightest-purple;
                     color: rgba(255, 255, 255, 1);
                     @include box-shadow(0px 0px 4px 1px #ffffff);
                 }

--- a/public/components/presence-indicator/presence-indicators.html
+++ b/public/components/presence-indicator/presence-indicators.html
@@ -3,7 +3,6 @@
     <span ng-show="(!presences.length || presences.length === 1 && presences[0].status === 'free') && inDrawer" class="drawer__section-data-row drawer__section-data-row--coming-soon">Nobody</span>
 
     <li ng-repeat="presence in presences track by presence.email"
-        ng-if="presence.status === 'present' || presence.status === 'furniture'"
         ng-class="'content-list-item__presence--' + presence.status">
         <a class="content-list-item__icon--presence"
            href="mailto:{{ presence.email }}" title="{{ inDrawer ? presence.shortTitle : presence.longTitle }}">{{ inDrawer ? presence.longText : presence.indicatorText }}</a>

--- a/public/components/presence-indicator/presence-indicators.js
+++ b/public/components/presence-indicator/presence-indicators.js
@@ -56,8 +56,8 @@ function wfPresenceIndicatorsDirective($rootScope, wfPresenceService,
                                 return {
                                     ...presenceObject,
                                     status: "idle",
-                                    longTitle: presenceObject.longText,
-                                    shortTitle: presenceObject.email,
+                                    longTitle: [presenceObject.longText, "idle"].join(" - "),
+                                    shortTitle: [presenceObject.email, "idle"].join(" - "),
                                     iconPrecedence: 3
                                 };
                             }

--- a/public/layouts/global/_colours.scss
+++ b/public/layouts/global/_colours.scss
@@ -20,8 +20,9 @@ $c-orange: #ffb100;
 $c-red: #ed5935;
 $c-bluegrey: #dee2e3;
 $c-highlight-blue: #00adee;
-$c-presence-purple: #474D80;
-$c-presence-light-purple: #9094b2;
+$c-presence-purple: #42487e;
+$c-presence-light-purple: #696d94;
+$c-presence-lightest-purple: #9495a7;
 
 // Secondary accent colours
 $c-light-green: #f3faf2;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR reintroduces displaying the idle state Presence icon when a user is in a document but not editing. The difference between idle and furniture is **subtly** displayed with different colours but can primarily be identifier by the tooltips which are commonly used.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to CODE, view a stub with a user idle, editing furniture and editing the body.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
![THREE_STATES_PRESENCE_II](https://user-images.githubusercontent.com/4633246/107776460-7fd28a80-6d39-11eb-97a8-5e0ce0c994d1.gif)

