### PR TITLE
make the needsPictureDesk flag link to grid and open the correct pinboard

### DIFF
--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -289,6 +289,14 @@ var wfContentListItem = function ($rootScope, statuses, legalValues, pictureDesk
             $scope.pictureDeskValues = pictureDeskValues;
             $scope.sections = sections;
             $scope.isSupportedAtomType = config.atomTypes.includes($scope.contentItem.contentType);
+
+            const gridHost = window && window.location && window.location.host &&
+              window.location.host.toLowerCase().replace("workflow", "media").replace("code", "test");
+
+            $scope.pinboardInGridLink = `https://${gridHost}/search?pinboardComposerID=${
+              $scope.contentItem.links.composer &&
+              $scope.contentItem.links.composer.substring($scope.contentItem.links.composer.lastIndexOf('/') + 1)
+            }`
         },
         link: function ($scope, elem) {
 

--- a/public/components/content-list-item/templates/needsPictureDesk.html
+++ b/public/components/content-list-item/templates/needsPictureDesk.html
@@ -1,6 +1,17 @@
 <td class="content-list-item__field--needs-picture-desk" title="Needs Picture Desk: {{ contentItem.needsPictureDesk.toLowerCase() }}">
 
-    <i ng-if="contentItem.needsPictureDesk == 'REQUIRED'" class="content-list-item__icon--needs-picture-desk content-list-item__icon--inline" wf-icon="needs-picture-desk"></i>
-    <i ng-if="contentItem.needsPictureDesk == 'COMPLETE'" class="content-list-item__icon--needs-picture-desk content-list-item__icon--inline" wf-icon="needs-picture-desk-ticked"></i>
+    <a target="_blank"
+       href="{{pinboardInGridLink}}"
+       ng-click="$event.stopPropagation()"
+    >
+        <i ng-if="contentItem.needsPictureDesk == 'REQUIRED'"
+           class="content-list-item__icon--needs-picture-desk content-list-item__icon--inline"
+           wf-icon="needs-picture-desk"
+        ></i>
+        <i ng-if="contentItem.needsPictureDesk == 'COMPLETE'"
+           class="content-list-item__icon--needs-picture-desk content-list-item__icon--inline"
+           wf-icon="needs-picture-desk-ticked"
+        ></i>
+    </a>
 
 </td>


### PR DESCRIPTION
https://github.com/guardian/editorial-tools-pinboard/pull/40

As a tactical measure whilst we wait for mentions to be completed and in case we want to put pinboard in front of real users, we decided to make the 'needs picture desk' flag in Workflow clickable to open grid with pinboard expanded to the correct pinboard.

## What does this change?
This makes the `needsPictureDesk` flag (introduced in #286) clickable and opens grid in a new tab, with the `pinboardComposerID` query param enabling pinboard to open automatically to the pinboard associated with that workflow entry (as per https://github.com/guardian/editorial-tools-pinboard/pull/40).

## How to test
For a comprehensive test I recommend deploying https://github.com/guardian/editorial-tools-pinboard/pull/40 to `pinboard` `CODE` and this branch to `workflow-frontend` `CODE` then visit https://workflow.code.dev-gutools.co.uk/dashboard and click the needsPictureDesk flag on a row which has it turned on (assuming you have the column turned on) and you should see grid opened with the corresponding pinboard automatically opened.

## How can we measure success?
As stated this is a tactical measure (although we're unlikely to remove it as it will likely prove useful in various ways), but this enables us to get this in front of real users sooner 🎉

## Images
![workflow-needsPictureDesk-pinboard](https://user-images.githubusercontent.com/19289579/111385044-221bc000-86a2-11eb-82ea-4534e1d07c76.gif)
