### PR TITLE
Moved Xenial AMI to Bionic as it is no longer supported

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -11,7 +11,7 @@ deployments:
     parameters:
       amiTags:
         AmigoStage: PROD
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-bionic-java8
         BuiltBy: amigo
       cloudFormationStackName: Workflow-Frontend
       prependStackToCloudFormationStackName: false


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Moves AMI from Xenial to Bionic because Xenial is no longer supported.

Related card [here](https://trello.com/c/NLpikw2C/2330-update-xenial-amis-to-use-bionic).

## Has it been successfully deployed?

Yes, [here](https://riffraff.gutools.co.uk/deployment/view/94a440d5-d576-46e8-8820-0707937f89bc)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to [CODE](https://workflow.code.dev-gutools.co.uk/dashboard) via RiffRaff (it's under `Editorial Tools::Workflow::Workflow Frontend`), and ensure it deploys and runs correctly.