### PR TITLE
Upgrade sbt to 1.5.7 and Play to 2.8.11

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -50,7 +50,7 @@ class Application(
   }
 
   def index = AuthAction { request =>
-    Redirect(routes.Application.dashboard())
+    Redirect(routes.Application.dashboard)
   }
 
   def dashboard = app("Workflow")
@@ -80,7 +80,7 @@ class Application(
   def updateEditorialSupport = AuthAction(parse.form(EditorialSupportStaff.form)) { implicit request =>
     editorialSupportTeams.updateStaff(request.body)
     // Get the browser to reload the page once we've sucessfully updated
-    Redirect(routes.Application.editorialSupport())
+    Redirect(routes.Application.editorialSupport)
   }
 
   // limited tag fields we want output into the DOM

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import com.gu.riffraff.artifact.BuildInfo
 
 Test / parallelExecution := false
 
-val scalaVersionNumber = "2.12.11"
+val scalaVersionNumber = "2.12.15"
 
 val buildInfo = Seq(
   buildInfoPackage := "build",
@@ -35,7 +35,10 @@ def project(path: String): Project = Project(path, file(path)).settings(commonSe
 def playProject(path: String): Project =
   Project(path, file("."))
     .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
-    .settings(libraryDependencies += ws)
+    .settings(
+      libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % "2.8.9", 
+      dependencyOverrides ++= jacksonDependencyOverrides
+    )
     .settings(commonSettings ++ buildInfo)
     .dependsOn(commonLib)
     .dependsOn(commonLib % "test->test")
@@ -43,7 +46,7 @@ def playProject(path: String): Project =
 lazy val commonLib = project("common-lib")
   .settings(
     libraryDependencies
-      ++= Seq("com.typesafe.play" %% "play" % "2.7.4", ws)
+      ++= Seq("com.typesafe.play" %% "play" % "2.8.11", "com.typesafe.play" %% "play-ahc-ws" % "2.8.9")
       ++ logbackDependencies
       ++ testDependencies
       ++ awsDependencies

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ def playProject(path: String): Project =
     .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
     .settings(
       libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % "2.8.9", 
+      //Necessary to override jackson-databind versions due to AWS and Play incompatibility
       dependencyOverrides ++= jacksonDependencyOverrides
     )
     .settings(commonSettings ++ buildInfo)
@@ -46,6 +47,7 @@ def playProject(path: String): Project =
 lazy val commonLib = project("common-lib")
   .settings(
     libraryDependencies
+      //Necessary to have a mix of play library versions due to scala-java8-compat incompatibility
       ++= Seq("com.typesafe.play" %% "play" % "2.8.11", "com.typesafe.play" %% "play-ahc-ws" % "2.8.9")
       ++ logbackDependencies
       ++ testDependencies

--- a/common-lib/src/main/scala/com/gu/workflow/lib/ClientMessageLoggable.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/ClientMessageLoggable.scala
@@ -23,11 +23,11 @@ object ClientMessageLoggable {
     val fieldsMap = scalaMap.asJava
     val output = log.message
     log.level match {
-      case "ERROR" => Logger.logger.error(appendEntries(fieldsMap),output)
-      case "WARN" => Logger.logger.warn(appendEntries(fieldsMap),output)
-      case "INFO" => Logger.logger.info(appendEntries(fieldsMap),output)
-      case "DEBUG" =>  Logger.logger.debug(appendEntries(fieldsMap),output)
-      case _ =>  Logger.logger.info(appendEntries(fieldsMap),output)
+      case "ERROR" => Logger("application").logger.error(appendEntries(fieldsMap),output)
+      case "WARN" => Logger("application").logger.warn(appendEntries(fieldsMap),output)
+      case "INFO" => Logger("application").logger.info(appendEntries(fieldsMap),output)
+      case "DEBUG" =>  Logger("application").logger.debug(appendEntries(fieldsMap),output)
+      case _ =>  Logger("application").logger.info(appendEntries(fieldsMap),output)
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val awsVersion: String = "1.11.784"
+  val awsVersion: String = "1.12.129"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1" % "test"
 
   val notificationDependencies = Seq(
@@ -17,8 +17,17 @@ object Dependencies {
     "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
-    "com.gu" %% "content-api-client-aws" % "0.5"
+    "com.gu" %% "content-api-client-aws" % "0.7"
   )
+
+  val jacksonDependencyOverrides: Seq[ModuleID] = {
+    val version = "2.11.4"
+    Seq(
+        "com.fasterxml.jackson.core" % "jackson-core" % version,
+        "com.fasterxml.jackson.core" % "jackson-databind" % version,
+        "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % version
+    )
+  }
 
   val akkaDependencies = Seq(
     // akka-agent 2.5.X has deprecated Agents,
@@ -29,7 +38,7 @@ object Dependencies {
   )
 
   val authDependencies = Seq(
-    "com.gu" %% "pan-domain-auth-play_2-6" % "0.9.1",
+    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
     "com.gu" %% "hmac-headers" % "1.1.2"
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts (Artifact("jdeb", 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 


### PR DESCRIPTION
## What does this change?

This PR upgrades the Workflow SBT and Scala Play versions to the latest. This is necessary to mitigate [security issues identified in log4j2](https://github.com/sbt/sbt/releases/tag/v1.5.6).

This PR makes several changes:

- Upgrades SBT to v1.5.7
- Upgrades Scala Play to v2.8.11
- Upgrades AWS libraries to v1.12.129
- Performs necessary migration steps for these upgrade to work

[Editorial tools working document](https://docs.google.com/document/d/1nVKsXiEXLviHOMY1iQEoyacvN93_SYCQwsOFfaP-dxo/edit#heading=h.67pgv1awhai).

Complexity:
A few libraries had dependency conflicts which required resolution. I believe this may have been improved by upgrades to Scala 2.13.x but there were dependencies which don't support it yet.

The conflicts were:

- `scala-java8-compat` -> Play used 0.9.1 and Play WS was using 1.x resulting in dependency incompatibility compile error. This was overcome by using an older version of Play WS (2.8.9) which was still using 0.9.1.
- `jackson-databind` -> AWS libraries and Play were using different version of `jackson-databind`. This was resulting in a runtime error which was overcome via [dependencyOverrides](https://www.scala-sbt.org/1.x/docs/Library-Management.html#Overriding+a+version) SBT feature.


## How to test

We should be able to test this works be deploying the changes to CODE or running locally. This should be a no-op from a user perspective. We would also expect areas such as logging to continue as before.

## How can we measure success?

`workflow-frontend` is on the latest security patched versions of core dependencies.