### PR TITLE
set `publicReadAcl: false` for the `workflow-frontend-fluentbit` deployment step

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -28,3 +28,4 @@ deployments:
     parameters:
       bucket: workflow-dist
       cacheControl: private
+      publicReadAcl: false


### PR DESCRIPTION
## What does this change?
as per https://github.com/guardian/riff-raff/pull/665 `publicReadAcl` needs to be set explicitly

## How to test
deploy to CODE and check that logs still work
