### PR TITLE
Set timestamp in output jars from SBT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,16 @@
 import play.sbt.PlayImport.PlayKeys._
+import sbt.Package.FixedTimestamp
 import Dependencies._
 import com.gu.riffraff.artifact.BuildInfo
 
 Test / parallelExecution := false
+
+// We need to keep the timestamps to allow caching headers to work as expected on assets.
+// The below should work, but some problem in one of the plugins (possibly the play plugin? or sbt-web?) causes
+// the option not to be passed correctly
+//   ThisBuild / packageTimestamp := Package.keepTimestamps
+// Setting as a packageOption seems to bypass that problem, wherever it lies
+ThisBuild / packageOptions += FixedTimestamp(Package.keepTimestamps)
 
 val scalaVersionNumber = "2.12.15"
 


### PR DESCRIPTION
Since SBT 1.4.0, SBT has edited the last modified dates in packaged
JARs, which include web assets (css, js, etc.); Grid's current version
sets the date to 1 Jan 2010. Play framework uses these dates to
calculate the ETag and Last-Modified headers. Since the headers are now
based upon a static date, caching (especially via Cloudfront) is broken,
returning outdated assets.

This commit restores the previous behaviour, so cloudfront should now
notice and pick up new assets upon deployment.

See also <playframework/playframework#10572>
See also <sbt/sbt#6237>

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
