### PR TITLE
use `pinboardId` query param with workflow ID on the 'needs picture desk' flag link to pinboard

### DIFF
--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -293,10 +293,7 @@ var wfContentListItem = function ($rootScope, statuses, legalValues, pictureDesk
             const gridHost = window && window.location && window.location.host &&
               window.location.host.toLowerCase().replace("workflow", "media").replace("code", "test");
 
-            $scope.pinboardInGridLink = `https://${gridHost}/search?pinboardComposerID=${
-              $scope.contentItem.links.composer &&
-              $scope.contentItem.links.composer.substring($scope.contentItem.links.composer.lastIndexOf('/') + 1)
-            }`
+            $scope.pinboardInGridLink = `https://${gridHost}/search?pinboardId=${$scope.contentItem.id || $scope.contentItem.stubId}`
         },
         link: function ($scope, elem) {
 


### PR DESCRIPTION
Tweak to https://github.com/guardian/workflow-frontend/pull/332 to use the workflow ID rather than composer ID on the 'needs picture desk' flag link to pinboard, as this is simpler and can be reused for other features in pinboard (e.g. https://github.com/guardian/pinboard/pull/163).

✅  tested on `CODE` (in conjunction with https://github.com/guardian/pinboard/pull/163)

_Note that has been broken for a while (and not used tbh) but re-visited due to https://github.com/guardian/pinboard/pull/163_