### PR TITLE
Allow some endpoints to be authed using play-hmac

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.pandomainauth.action.UserRequest
 import com.gu.workflow.api.{ApiUtils, SectionsAPI, StubAPI}
@@ -30,7 +31,12 @@ class Api(
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
   override val panDomainSettings: PanDomainAuthSettingsRefresher
-) extends BaseController with PanDomainAuthActions with SharedSecretAuth with Logging with ApiUtils {
+) extends BaseController
+  with PanDomainAuthActions
+  with SharedSecretAuth
+  with HMACAuthActions
+  with Logging
+  with ApiUtils {
 
   val contentAPI = new ContentAPI(capiPreviewRole = config.capiPreviewRole, apiRoot = config.capiPreviewIamUrl, ws = wsClient)
   val stubDecorator = new StubDecorator(contentAPI)
@@ -53,10 +59,10 @@ class Api(
     }
   }
 
-  def content = APIAuthAction.async(getContentBlock)
+  def content = HMACAuthAction.async(getContentBlock)
 
   def getContentByComposerId(composerId: String) = {
-      APIAuthAction.async { implicit request =>
+      HMACAuthAction.async { implicit request =>
         ApiResponseFt[Option[Stub]](for {
           item <- getResponse(stubsApi.getStubByComposerId(stubDecorator, composerId))
         } yield item

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,8 @@ object Dependencies {
 
   val authDependencies = Seq(
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
-    "com.gu" %% "hmac-headers" % "1.1.2"
+    "com.gu" %% "hmac-headers" % "1.1.2",
+    "com.gu" %% "panda-hmac-play_2-8" % "2.0.1"
   )
 
   val testDependencies = Seq(


### PR DESCRIPTION
## What does this change?

This is starting to address the comment in SharedSecretAuth "NB: we should also migrate to panda-hmac and SHA-256".

It doesn't actually stop us using the old sharedsecretauth, but it does mean a new user of this api can go straight to the future.

## How to test

* Deploy to code
* Check in browser that requests to `/api/content` and `/api/content/:composerId` do not encounter auth errrors