### PR TITLE
Increase file descriptor limit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val root = playProject(application)
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffPackageName := s"editorial-tools:workflow:$application",
     riffRaffManifestProjectName := riffRaffPackageName.value,
+    fileDescriptorLimit := Option("32768"),
     riffRaffArtifactResources := Seq(
       riffRaffPackageType.value -> s"$application/${riffRaffPackageType.value.getName}",
       (notificationLambda / Universal / packageBin).value -> s"${(notificationLambda / name).value}/${(notificationLambda / Universal / packageBin).value.getName}",


### PR DESCRIPTION
## What does this change?

Increases the limit on the number of open files.  The default in sbt-native-packager is 1024, which is a lot lower that the limit set in https://github.com/guardian/amigo/blob/main/roles/ubuntu-init/tasks/main.yml.  This new limit is quite arbitrary.

## How to test

Deploy workflow, check that nothing obvious is broken.

## How can we measure success?

We stop seeing errors like this about too many open files:

![image](https://user-images.githubusercontent.com/2619836/193248504-0e354c59-19a5-4d58-8b44-af4ef9d85d01.png)

## Have we considered potential risks?

Seems fairly low risk?