### PR TITLE
Fix reauth for API endpoints

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -59,15 +59,15 @@ class Api(
     }
   }
 
-  def content = HMACAuthAction.async(getContentBlock)
+  def content = APIHMACAuthAction.async(getContentBlock)
 
   def getContentByComposerId(composerId: String) = {
-      HMACAuthAction.async { implicit request =>
-        ApiResponseFt[Option[Stub]](for {
-          item <- getResponse(stubsApi.getStubByComposerId(stubDecorator, composerId))
-        } yield item
-      )}
-    }
+    APIHMACAuthAction.async { implicit request =>
+      ApiResponseFt[Option[Stub]](for {
+        item <- getResponse(stubsApi.getStubByComposerId(stubDecorator, composerId))
+      } yield item
+    )}
+  }
 
   def getContentByEditorId(editorId: String) = {
     APIAuthAction.async { implicit request =>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,13 +14,15 @@ preamble() {
       exit 1
   fi
 
-  if ! test -e "$NVM_DIR/nvm.sh"; then
-      echo -e "NVM not found. NVM is required to run this project"
-      echo -e "Install it from https://github.com/creationix/nvm#installation"
-      exit 1
-  else
+  if test -e "$NVM_DIR/nvm.sh"; then
       source "$NVM_DIR/nvm.sh"
       nvm install
+  elif command -v fnm >/dev/null; then
+      fnm use
+  # TODO use asdf? add detection and enable here
+  else
+      echo -e "No node version manager found. Consider installing fnm <https://github.com/Schniz/fnm> or asdf <???>"
+      exit 1
   fi
 }
 


### PR DESCRIPTION
## What does this change?

- Use APIHMAC actions for API endpoints
  - The two types of auth actions ('standard' vs API) behave differently when the user is unauthed or the auth has expired. 'standard' actions will return a redirect to the Google OAuth endpoint (useful if you're navigating, you get immediately pushed through the authentication flow and can interact with Google if necessary). The API actions will instead return a 4xx, which the app's frontend can detect and run an 'invisible' reauthentication flow.
  - When migrating a couple of the API endpoints to optionally use panda-HMAC auth, we accidentally picked the 'standard' action, which means that when the user is unauthed the action will attempt to redirect the XHR directly to Google. This will not succeed as the Google OAuth endpoint does not set CORS headers.
  - So, replace the HMAC actions with APIHMAC actions.

- While I'm here and not using nvm, this PR adds support for setting up with different node managers


## How to test

Open workflow, wait for initial page and api requests to load. Delete you panda cookie, then wait for the JS to poll the API. Before this change, reauth will fail and you will get a red banner saying unexpected error occurred. After this change, reauth succeeds.

