### PR TITLE
new `GET` endpoint `/redirect/:stubId` which attempts to redirect to the composer page

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -43,7 +43,7 @@ class AppComponents(context: Context)
   val adminController = new Admin(sectionsApi, desksApi, sectionsDeskMappingsApi, config, controllerComponents, wsClient, panDomainRefresher)
   val editorialSupportTeamsController = new EditorialSupportTeamsController(config, controllerComponents, wsClient, panDomainRefresher)
   val apiController = new Api(stubsApi, sectionsApi, editorialSupportTeamsController, config, controllerComponents, wsClient, panDomainRefresher)
-  val applicationController = new Application(editorialSupportTeamsController, sectionsApi, tagService, desksApi, sectionsDeskMappingsApi, config, controllerComponents, wsClient, panDomainRefresher)
+  val applicationController = new Application(editorialSupportTeamsController, sectionsApi, tagService, desksApi, sectionsDeskMappingsApi, config, controllerComponents, wsClient, panDomainRefresher, stubsApi)
 
   val notificationsController = new Notifications(config, controllerComponents, wsClient, panDomainRefresher)
 

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,8 @@ GET            /                                           controllers.Applicati
 
 GET            /dashboard                                  controllers.Application.dashboard
 
+GET            /redirect/:stubId                           controllers.Application.redirect(stubId: Long)
+
 #static user pages
 GET            /editorialSupport                           controllers.Application.editorialSupport
 POST           /editorialSupport                           controllers.Application.updateEditorialSupport


### PR DESCRIPTION
Co-authored-by: @aracho1 
Co-authored-by: @phillipbarron 

Primarily for the benefit of [guardian/pinboard](https://github.com/guardian/pinboard) we need a way to go from workflow stub ID (the ID used in pinboard) to the composer article URL.

See https://github.com/guardian/pinboard/blob/38e95d9de68a44061309487f1808acb9abbbc650/client/src/push-notifications/serviceWorker.ts#L114-L117 ...for why this is useful.