### PR TITLE
change log-level to `INFO` 

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -34,7 +34,7 @@
     <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="ASYNCSTDOUT"/>
         <appender-ref ref="FILE" />
     </root>


### PR DESCRIPTION
Wanted visibility on requests to `workflow-frontend` as per https://github.com/guardian/workflow-frontend/blob/e2caac417aadd03267a4210de4c67486f5a38888/app/lib/LoggingFilter.scala#L29-L32

...but @andrew-nowak noticed the log level was configured to ERROR only - so I've changed it to INFO for consistency with other apps.