### PR TITLE
use `bucketSsmLookup` in riff-raff.yaml 

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -4,7 +4,6 @@ deployments:
   workflow-frontend:
     type: autoscaling
     parameters:
-      bucket: workflow-dist
     dependencies: [workflow-frontend-ami-update, workflow-frontend-fluentbit]
   workflow-frontend-ami-update:
     type: ami-cloudformation-parameter
@@ -19,7 +18,6 @@ deployments:
   workflow-notification:
     type: aws-lambda
     parameters:
-      bucket: workflow-dist
       prefixStack: false
       functionNames: [workflow-notification-]
       fileName: workflow-notification.zip


### PR DESCRIPTION
remove `bucket` property from riff-raff.yaml - so it uses `bucketSsmLookup: true` by default (as per https://github.com/guardian/riff-raff/pull/884 and https://github.com/guardian/riff-raff/pull/885)