### PR TITLE
`Pinboard 📌` column

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,4 +1,5 @@
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
 import com.gu.workflow.api.{DesksAPI, SectionDeskMappingsAPI, SectionsAPI, StubAPI}
 import com.gu.workflow.lib.TagService
 import com.gu.workflow.util.AWS
@@ -40,10 +41,13 @@ class AppComponents(context: Context)
   val stubsApi = new StubAPI(config.apiRoot, wsClient)
   val tagService = new TagService(config.tagManagerUrl, wsClient)
 
-  val adminController = new Admin(sectionsApi, desksApi, sectionsDeskMappingsApi, config, controllerComponents, wsClient, panDomainRefresher)
+  val permissions: PermissionsProvider =
+    PermissionsProvider(PermissionsConfig(stage =  if (config.isProd) "PROD" else "CODE", AWS.region.getName, AWS.credentialsProvider))
+
+  val adminController = new Admin(sectionsApi, desksApi, sectionsDeskMappingsApi, permissions, config, controllerComponents, wsClient, panDomainRefresher)
   val editorialSupportTeamsController = new EditorialSupportTeamsController(config, controllerComponents, wsClient, panDomainRefresher)
   val apiController = new Api(stubsApi, sectionsApi, editorialSupportTeamsController, config, controllerComponents, wsClient, panDomainRefresher)
-  val applicationController = new Application(editorialSupportTeamsController, sectionsApi, tagService, desksApi, sectionsDeskMappingsApi, config, controllerComponents, wsClient, panDomainRefresher, stubsApi)
+  val applicationController = new Application(editorialSupportTeamsController, sectionsApi, tagService, desksApi, sectionsDeskMappingsApi, permissions, config, controllerComponents, wsClient, panDomainRefresher, stubsApi)
 
   val notificationsController = new Notifications(config, controllerComponents, wsClient, panDomainRefresher)
 

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -71,6 +71,8 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
 
   lazy val preferencesUrl: String = s"https://preferences.${stage.appDomain}/preferences"
 
+  lazy val pinboardLoaderUrl: String = s"https://pinboard.${stage.appDomain}/pinboard.loader.js"
+
   lazy val tagManagerUrl: String = s"https://tagmanager.${stage.appDomain}"
 
   lazy val capiPreviewIamUrl: String = playConfig.get[String]("capi.preview.iamUrl")

--- a/app/controllers/Admin.scala
+++ b/app/controllers/Admin.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import com.gu.workflow.api.{DesksAPI, SectionDeskMappingsAPI, SectionsAPI}
 import config.Config
 import io.circe.{Json, parser}
@@ -21,13 +22,14 @@ class Admin(
   sectionsAPI: SectionsAPI,
   desksAPI: DesksAPI,
   sectionDeskMappingsAPI: SectionDeskMappingsAPI,
+  permissions: PermissionsProvider,
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
   override val panDomainSettings: PanDomainAuthSettingsRefresher
 ) extends BaseController with PanDomainAuthActions with I18nSupport with Logging {
 
-  private val PermissionFilter = new AdminPermissionFilter(config)
+  private val PermissionFilter = new AdminPermissionFilter(config, permissions)
 
   import play.api.data.Forms._
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.{PermissionDefinition, PermissionsProvider}
 import com.gu.workflow.api.{DesksAPI, SectionDeskMappingsAPI, SectionsAPI, StubAPI}
 import com.gu.workflow.lib.{Priorities, StatusDatabase, TagService}
 import config.Config
@@ -23,6 +24,7 @@ class Application(
   val tagService: TagService,
   val desksAPI: DesksAPI,
   val sectionDeskMappingsAPI: SectionDeskMappingsAPI,
+  val permissions: PermissionsProvider,
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
@@ -92,6 +94,8 @@ class Application(
     implicit val decoder: Decoder[LimitedTag] = deriveDecoder
   }
 
+  private val pinboardPermission = PermissionDefinition("pinboard", "pinboard")
+
   def app(title: String) = AuthAction.async { request =>
     for {
       statuses <- StatusDatabase.statuses
@@ -135,6 +139,8 @@ class Application(
         ("storyPackagesUrl", Json.fromString(config.storyPackagesUrl)),
         ("presenceUrl", Json.fromString(config.presenceUrl)),
         ("preferencesUrl", Json.fromString(config.preferencesUrl)),
+        ("pinboardLoaderUrl", Json.fromString(config.pinboardLoaderUrl)),
+        ("hasPinboardPermission", Json.fromBoolean(permissions.hasPermission(pinboardPermission, request.user.email))),
         ("user", parser.parse(user.toJson).getOrElse(Json.Null)),
         ("incopyOpenUrl", Json.fromString(config.incopyOpenUrl)),
         ("incopyExportUrl", Json.fromString(config.incopyExportUrl)),

--- a/app/lib/AdminPermissionFilter.scala
+++ b/app/lib/AdminPermissionFilter.scala
@@ -10,15 +10,13 @@ import play.api.mvc.{ActionFilter, Result, Results}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AdminPermissionFilter(config: Config)(implicit ec: ExecutionContext) extends ActionFilter[UserRequest] with Logging {
+class AdminPermissionFilter(
+                             config: Config,
+                             permissions: PermissionsProvider
+                           )(implicit ec: ExecutionContext) extends ActionFilter[UserRequest] with Logging {
   override protected def executionContext: ExecutionContext = ec
 
   private val adminPermission: PermissionDefinition = PermissionDefinition("workflow_admin", "workflow")
-
-  private val permissions: PermissionsProvider = {
-    val permissionsStage = if(config.isProd) { "PROD" } else { "CODE" }
-    PermissionsProvider(PermissionsConfig(permissionsStage, AWS.region.getName, AWS.credentialsProvider))
-  }
 
   override def filter[A](request:UserRequest[A]): Future[Option[Result]] = Future.successful {
     val email = request.user.email

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -569,3 +569,7 @@
 .planned-print-location, .actual-print-location {
     vertical-align: middle;
 }
+
+.content-list-item__field--pinboard {
+    width: 77px;
+}

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -11,6 +11,8 @@
     cursor: pointer;
     vertical-align: baseline;
 
+    background: white; //default, will be overridden for various reasons e.g. --embargoed
+
     &--selected {
         background-color: $c-grey-200;
     }

--- a/public/components/content-list-item/templates/pinboard.html
+++ b/public/components/content-list-item/templates/pinboard.html
@@ -1,1 +1,5 @@
-<td class="content-list-item__field--pinboard" data-pinboard-id="{{ contentItem.id || contentItem.stubId }}"></td>
+<td class="content-list-item__field--pinboard"
+    data-pinboard-id="{{ contentItem.id || contentItem.stubId }}"
+    data-working-title="{{contentItem.workingTitle}}"
+    data-headline="{{contentItem.headline}}"
+></td>

--- a/public/components/content-list-item/templates/pinboard.html
+++ b/public/components/content-list-item/templates/pinboard.html
@@ -1,0 +1,1 @@
+<td class="content-list-item__field--pinboard" data-pinboard-id="{{ contentItem.id || contentItem.stubId }}"></td>

--- a/public/components/content-list-item/templates/pinboard.html
+++ b/public/components/content-list-item/templates/pinboard.html
@@ -2,4 +2,5 @@
     data-pinboard-id="{{ contentItem.id || contentItem.stubId }}"
     data-working-title="{{contentItem.workingTitle}}"
     data-headline="{{contentItem.headline}}"
+    data-group-title="{{contentItem.status}}"
 ></td>

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -351,7 +351,7 @@ google-auth-banner .alert {
 
     right: 15px;
     width: 180px;
-    z-index: 2;
+    z-index: 3;
 
     // _toolbar-sections-dropdown.scss:71
     background-color: #ffffff;

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -482,3 +482,7 @@ google-auth-banner .alert {
     margin: 0 0 0 6px;
     line-height: 1.42857143; // Bootstrap...
 }
+
+.content-list-head__heading--pinboard {
+    width: 62px;
+}

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -92,6 +92,7 @@ google-auth-banner .alert {
             &--status,
             &--status-in-print,
             &--notes,
+            &--pinboard,
             &--links,
             &--published-state,
             &--wordcount,

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -66,7 +66,7 @@ angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOff
 
                 $rootScope.$watch('contentItemTemplate', () => {
 
-                    var contentListHeading = '<tr class="content-list__group-heading-row content-list--sticky-row" ng-show="currentlySelectedStatusFilters.indexOf(group.title) != -1"><th class="content-list__group-heading" scope="rowgroup" colspan="{{ 9 + columns.length }}"><span class="content-list__group-heading-link">{{ group.title }} <span class="content-list__group-heading-count">{{ group.count || "0" }}</span></span></th></tr>';
+                    var contentListHeading = '<tr class="content-list__group-heading-row content-list--sticky-row" ng-show="currentlySelectedStatusFilters.indexOf(group.title) != -1"><th class="content-list__group-heading" scope="rowgroup" colspan="{{ 9 + columns.length }}" data-group-title="{{group.title}}"><span class="content-list__group-heading-link">{{ group.title }} <span class="content-list__group-heading-count">{{ group.count || "0" }}</span></span></th></tr>';
 
                     var contentListItemDirective = '<tr data-cy="content-list-item-{{contentItem.workingTitle}}" wf-content-list-item class="content-list-item content-list-item--{{contentItem.lifecycleStateKey}}" ng-repeat="contentItem in group.items track by contentItem.id" ';
 

--- a/public/layouts/dashboard/dashboard.html
+++ b/public/layouts/dashboard/dashboard.html
@@ -1,4 +1,4 @@
 <div class="sidebar" ng-include="'/assets/layouts/dashboard/dashboard-sidebar.html'" ng-controller="wfDashboardSidebarController"></div>
 
-<div class="content-list-column" ng-include="'/assets/components/content-list/content-list.html'" ng-controller="wfContentListController as contentList">
+<div class="content-list-column" id="scrollable-area" ng-include="'/assets/components/content-list/content-list.html'" ng-controller="wfContentListController as contentList">
 </div>

--- a/public/layouts/dashboard/dashboard.html
+++ b/public/layouts/dashboard/dashboard.html
@@ -1,4 +1,5 @@
 <div class="sidebar" ng-include="'/assets/layouts/dashboard/dashboard-sidebar.html'" ng-controller="wfDashboardSidebarController"></div>
+<div id="pinboard-area"></div>
 
 <div class="content-list-column" id="scrollable-area" ng-include="'/assets/components/content-list/content-list.html'" ng-controller="wfContentListController as contentList">
 </div>

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -131,7 +131,7 @@ const columnDefaults = [{
     title: '',
     templateUrl: templateRoot + 'pinboard.html',
     template: pinboardTemplate,
-    active: true,
+    active: false,
     isSortable: false,
     isNew: true
 },{

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -126,7 +126,7 @@ const columnDefaults = [{
 },{
     name: 'pinboard',
     prettyName: 'Pinboard 📌',
-    labelHTML: 'Pinboard 📌',
+    labelHTML: '',
     colspan: 1,
     title: '',
     templateUrl: templateRoot + 'pinboard.html',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -14,6 +14,7 @@ import deadlineTemplate              from "components/content-list-item/template
 import sectionTemplate               from "components/content-list-item/templates/section.html";
 import statusTemplate                from "components/content-list-item/templates/status.html";
 import notesTemplate                 from "components/content-list-item/templates/notes.html";
+import pinboardTemplate              from "components/content-list-item/templates/pinboard.html";
 import linksTemplate                 from "components/content-list-item/templates/links.html";
 import publishedStateTemplate        from "components/content-list-item/templates/published-state.html";
 import wordcountTemplate             from "components/content-list-item/templates/wordcount.html";
@@ -122,6 +123,17 @@ const columnDefaults = [{
     active: true,
     isSortable: true,
     sortField: ['note']
+},{
+    name: 'pinboard',
+    prettyName: 'Pinboard 📌',
+    labelHTML: 'Pinboard 📌',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'pinboard.html',
+    template: pinboardTemplate,
+    active: true,
+    isSortable: false,
+    isNew: true
 },{
     name: 'comments',
     prettyName: 'Comments: On/Off',

--- a/public/lib/column-service.js
+++ b/public/lib/column-service.js
@@ -55,14 +55,15 @@ angular.module('wfColumnService', [])
                         return self.columns;
                     }
 
-                    this.getColumns().then((columns) => {
-                        if(columns.find(_ => _.name === "pinboard" && _.active)){
-                            const script = document.createElement('script');
-                            //FIXME wrap in permission check and build domain dynamically
-                            script.src = 'https://pinboard.local.dev-gutools.co.uk/pinboard.loader.js';
-                            document.head.appendChild(script);
-                        }
-                    });
+                    if (_wfConfig.hasPinboardPermission) {
+                        this.getColumns().then((columns) => {
+                            if(columns.find(_ => _.name === "pinboard" && _.active)){
+                                const script = document.createElement('script');
+                                script.src = _wfConfig.pinboardLoaderUrl;
+                                document.head.appendChild(script);
+                            }
+                        });
+                    }
                 }
 
                 getAvailableColumns() {

--- a/public/lib/column-service.js
+++ b/public/lib/column-service.js
@@ -15,7 +15,7 @@ angular.module('wfColumnService', [])
 
                     var self = this;
 
-                    self.availableColums = columnDefaults;
+                    self.availableColums = columnDefaults.filter(col => col.name !== "pinboard" || _wfConfig.hasPinboardPermission);
                     self.contentItemTemplate;
 
                     self.preferencePromise = wfPreferencesService.getPreference('columnConfiguration').then(function resolve (data) {
@@ -55,15 +55,13 @@ angular.module('wfColumnService', [])
                         return self.columns;
                     }
 
-                    if (_wfConfig.hasPinboardPermission) {
-                        this.getColumns().then((columns) => {
-                            if(columns.find(_ => _.name === "pinboard" && _.active)){
-                                const script = document.createElement('script');
-                                script.src = _wfConfig.pinboardLoaderUrl;
-                                document.head.appendChild(script);
-                            }
-                        });
-                    }
+                    this.getColumns().then((columns) => {
+                        if(columns.find(_ => _.name === "pinboard" && _.active)){
+                            const script = document.createElement('script');
+                            script.src = _wfConfig.pinboardLoaderUrl;
+                            document.head.appendChild(script);
+                        }
+                    });
                 }
 
                 getAvailableColumns() {

--- a/public/lib/column-service.js
+++ b/public/lib/column-service.js
@@ -54,6 +54,15 @@ angular.module('wfColumnService', [])
 
                         return self.columns;
                     }
+
+                    this.getColumns().then((columns) => {
+                        if(columns.find(_ => _.name === "pinboard" && _.active)){
+                            const script = document.createElement('script');
+                            //FIXME wrap in permission check and build domain dynamically
+                            script.src = 'https://pinboard.local.dev-gutools.co.uk/pinboard.loader.js';
+                            document.head.appendChild(script);
+                        }
+                    });
                 }
 
                 getAvailableColumns() {


### PR DESCRIPTION
Co-authored-by: @twrichards 
Co-authored-by: @phillipbarron 

https://trello.com/c/s5n4JW0z/176-add-pinboard-visibility-in-a-new-workflow-column

**RELATED: https://github.com/guardian/pinboard/pull/219 - PREREQUISITE, MUST BE MERGED FIRST**

![workflow_pinboard](https://user-images.githubusercontent.com/19289579/207024266-4b9ef3f2-cd94-4123-b27e-55abb09d9f72.gif)

This PR introduces a new column `Pinboard 📌`, which when active* displays a new column containing empty `<td>`s (defined in new file `public/components/content-list-item/templates/pinboard.html`) with class `content-list-item__field--pinboard` and importantly has the following `data` attributes...
- `data-pinboard-id`
- `data-working-title`
- `data-headline`

\* not active by default, but selectable from the column picker <img width="23" alt="image" src="https://user-images.githubusercontent.com/19289579/205272553-1f80600a-9832-4ac0-a657-4e0c21e765af.png"> IF the user has pinboard permission.

If this column is active then it loads the `pinboard.loader.js` script (just like [composer](https://github.com/guardian/flexible-content) and [grid](https://github.com/guardian/grid) do).

This gives pinboard all it needs to take over these elements using [React Portals](https://reactjs.org/docs/portals.html) after finding them via the class name, and extracting the `data` attributes - see https://github.com/guardian/pinboard/pull/219 for more detail.

We also add an empty div with id `pinboard-area` to the dashboard layout, to provide a place to dock the pinboard panel.

Unfortunately, because workflow-frontend has infinite scroll, it doesn't look possible to make the view sortable by the pinboard column (by unread messages for example) - but might revisit in future.

