### PR TITLE
Add rights editing to table

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -47,7 +47,10 @@ case class ExternalData(
                          shortActualPrintLocationDescription: Option[String] = None,
                          longActualPrintLocationDescription: Option[String] = None,
                          statusInPrint: Option[OctopusStatus] = None,
-                         lastModifiedInPrintBy: Option[String] = None) {
+                         lastModifiedInPrintBy: Option[String] = None,
+                         rightsSyndicationAggregate: Boolean = false,
+                         rightsSubscriptionDatabases: Boolean = false,
+                         rightsDeveloperCommunity: Boolean = false) {
 }
 
 object ExternalData {

--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -48,9 +48,9 @@ case class ExternalData(
                          longActualPrintLocationDescription: Option[String] = None,
                          statusInPrint: Option[OctopusStatus] = None,
                          lastModifiedInPrintBy: Option[String] = None,
-                         rightsSyndicationAggregate: Boolean = false,
-                         rightsSubscriptionDatabases: Boolean = false,
-                         rightsDeveloperCommunity: Boolean = false) {
+                         rightsSyndicationAggregate: Option[Boolean] = None,
+                         rightsSubscriptionDatabases: Option[Boolean] = None,
+                         rightsDeveloperCommunity: Option[Boolean] = None) {
 }
 
 object ExternalData {
@@ -85,7 +85,8 @@ case class Stub(id: Option[Long] = None,
                 plannedNewspaperPublicationDate: Option[LocalDate] = None,
                 // Description enriched for use by WF front end client code.
                 shortPlannedPrintLocationDescription: Option[String] = None,
-                longPlannedPrintLocationDescription: Option[String] = None)
+                longPlannedPrintLocationDescription: Option[String] = None,
+               )
 
 object Stub {
   implicit val customConfig: Configuration = Configuration.default.withDefaults

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -447,9 +447,9 @@
                             <div class="drawer__item-printlocation">
                                 <span>Publication date:</span>
                                 <span ng-if="contentItem.actualNewspaperPublicationDate">{{contentItem.actualNewspaperPublicationDate | wfFormatDateTime:'date'}}</span>
-                                <button
-                                    ng-hide="publicationDateTimeEdit || contentItem.actualNewspaperPublicationDate"
-                                    ng-click="publicationDateTimeEdit = true"
+                                <button 
+                                    ng-hide="publicationDateTimeEdit || contentItem.actualNewspaperPublicationDate" 
+                                    ng-click="publicationDateTimeEdit = true" 
                                     ng-class="{ 'drawer__section-data-row--editable': contentItem.plannedNewspaperPublicationDate, 'drawer__section-data-row--editable-empty': !contentItem.plannedNewspaperPublicationDate, 'editable__edit-button': true }"
                                     title="{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || '' }}"
                                     >
@@ -482,15 +482,10 @@
                             <p class="drawer__item-title">Status in print</p>
                             <span class="drawer__item-content" ng-show="contentItem.statusInPrint">{{ contentItem.statusInPrint }}</span>
                         </li>
-                        <li class="drawer__item">
-                          <p class="drawer__item-title">Rights</p>
-                          <span class="drawer__item-content">
-                            <ui-edit-rights content-item="contentItem" />
-                          </span>
-                        </li>
+
                     </ul>
 
-
+            
                     <ul class="drawer__column drawer__column--wide">
                         <li class="drawer__item">
                             <p class="drawer__item-title">Office</p>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -447,9 +447,9 @@
                             <div class="drawer__item-printlocation">
                                 <span>Publication date:</span>
                                 <span ng-if="contentItem.actualNewspaperPublicationDate">{{contentItem.actualNewspaperPublicationDate | wfFormatDateTime:'date'}}</span>
-                                <button 
-                                    ng-hide="publicationDateTimeEdit || contentItem.actualNewspaperPublicationDate" 
-                                    ng-click="publicationDateTimeEdit = true" 
+                                <button
+                                    ng-hide="publicationDateTimeEdit || contentItem.actualNewspaperPublicationDate"
+                                    ng-click="publicationDateTimeEdit = true"
                                     ng-class="{ 'drawer__section-data-row--editable': contentItem.plannedNewspaperPublicationDate, 'drawer__section-data-row--editable-empty': !contentItem.plannedNewspaperPublicationDate, 'editable__edit-button': true }"
                                     title="{{ (contentItem.plannedNewspaperPublicationDate | wfFormatDateTime:'date') || '' }}"
                                     >
@@ -482,10 +482,15 @@
                             <p class="drawer__item-title">Status in print</p>
                             <span class="drawer__item-content" ng-show="contentItem.statusInPrint">{{ contentItem.statusInPrint }}</span>
                         </li>
-
+                        <li class="drawer__item">
+                          <p class="drawer__item-title">Rights</p>
+                          <span class="drawer__item-content">
+                            <ui-edit-rights content-item="contentItem" />
+                          </span>
+                        </li>
                     </ul>
 
-            
+
                     <ul class="drawer__column drawer__column--wide">
                         <li class="drawer__item">
                             <p class="drawer__item-title">Office</p>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -482,10 +482,15 @@
                             <p class="drawer__item-title">Status in print</p>
                             <span class="drawer__item-content" ng-show="contentItem.statusInPrint">{{ contentItem.statusInPrint }}</span>
                         </li>
-
+                        <li class="drawer__item">
+                          <p class="drawer__item-title">Rights</p>
+                          <span class="drawer__item-content">
+                            <ui-edit-rights content-item="contentItem" />
+                          </span>
+                        </li>
                     </ul>
 
-            
+
                     <ul class="drawer__column drawer__column--wide">
                         <li class="drawer__item">
                             <p class="drawer__item-title">Office</p>

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -176,7 +176,8 @@
         &--optimisedForWeb,
         &--sensitive,
         &--legally-sensitive,
-        &--printlocation {
+        &--printlocation,
+        &--rights {
             @extend %fs-data-1;
             @extend %content-list__field-padding;
         }
@@ -360,10 +361,6 @@
             @include largeScreen {
                 width: auto;
             }
-        }
-
-        &--rights {
-          width: 200px;
         }
     }
 

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -361,6 +361,10 @@
                 width: auto;
             }
         }
+
+        &--rights {
+          width: 200px;
+        }
     }
 
     .content-list-item__field--commissionedLength {

--- a/public/components/content-list-item/templates/rights.html
+++ b/public/components/content-list-item/templates/rights.html
@@ -1,0 +1,4 @@
+<script src="../../directives/ui-edit-rights.js"></script>
+<td class="content-list-item__field--rights">
+  <ui-edit-rights content-item="contentItem" />
+</td>

--- a/public/components/content-list-item/templates/rights.html
+++ b/public/components/content-list-item/templates/rights.html
@@ -1,4 +1,4 @@
 <script src="../../directives/ui-edit-rights.js"></script>
 <td class="content-list-item__field--rights">
-  <ui-edit-rights content-item="contentItem" />
+  <ui-edit-rights content-item="contentItem" inline="true" />
 </td>

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -103,7 +103,8 @@ google-auth-banner .alert {
             &--last-modified,
             &--last-modified-by,
             &--last-modified-in-print-by,
-            &--printlocation {
+            &--printlocation,
+            &--rights {
                 padding: 15px 10px 5px 5px;
                 @extend %fs-data-2;
 
@@ -272,6 +273,17 @@ google-auth-banner .alert {
       }
 
     }
+
+  .content-list-item__field--rights {
+    .rights-field__input-label {
+      @extend %fs-data-1;
+      font-weight: normal;
+    }
+
+    .rights-field__input {
+      margin-right: 5px;
+    }
+  }
 
 }
 

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -198,8 +198,9 @@ google-auth-banner .alert {
             &--last-modified-by {
                 min-width: 110px;
             }
+
             &--rights {
-                min-width: 300px;
+              min-width: 175px;
             }
         }
     }

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -200,7 +200,7 @@ google-auth-banner .alert {
             }
 
             &--rights {
-              min-width: 175px;
+              min-width: 125px;
             }
         }
     }
@@ -278,10 +278,6 @@ google-auth-banner .alert {
       }
 
     }
-
-  .content-list-item__field--rights {
-    width: 300px;
-  }
 }
 
 // column-configurator

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -1,4 +1,5 @@
 @import "layouts/global/mixins";
+@import "components/directives/ui-edit-rights";
 
  /**
  * Content-list styles.
@@ -197,6 +198,9 @@ google-auth-banner .alert {
             &--last-modified-by {
                 min-width: 110px;
             }
+            &--rights {
+                min-width: 300px;
+            }
         }
     }
 
@@ -275,16 +279,8 @@ google-auth-banner .alert {
     }
 
   .content-list-item__field--rights {
-    .rights-field__input-label {
-      @extend %fs-data-1;
-      font-weight: normal;
-    }
-
-    .rights-field__input {
-      margin-right: 5px;
-    }
+    width: 300px;
   }
-
 }
 
 // column-configurator

--- a/public/components/content-list/content-list.js
+++ b/public/components/content-list/content-list.js
@@ -25,6 +25,7 @@ import { wfContentListDrawer } from 'components/content-list-drawer/content-list
 import { wfLoader } from 'components/loader/loader';
 import { uiFilterList } from '../directives/ui-filter-list'
 import { getSortField } from '../../lib/column-defaults';
+import {uiEditRights} from "../directives/ui-edit-rights";
 
 angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOfficeService', 'wfPresenceService', 'wfEditableField', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService', 'wfSettingsService', 'wfComposerService','wfTagApiService'])
     .service('wfContentItemParser', ['config', 'wfFormatDateTimeFilter', 'statusLabels', 'sections', wfContentItemParser])
@@ -36,6 +37,7 @@ angular.module('wfContentList', ['wfContentService', 'wfDateService', 'wfProdOff
     .controller('wfCommissionedLengthCtrl', ['$scope', wfCommissionedLengthCtrl])
     .directive('uiFilterList', ['$q','$window', uiFilterList])
     .directive('wfContentListDrawer', ['$rootScope', 'config', '$timeout', '$window', 'wfContentService', 'wfProdOfficeService', 'wfGoogleApiService', 'wfCapiContentService', 'wfCapiAtomService', 'wfAtomService', 'wfSettingsService', 'wfComposerService', 'wfTagApiService', 'wfFormatDateTimeFilter', 'legalValues', 'pictureDeskValues', wfContentListDrawer])
+    .directive('uiEditRights', ['wfComposerService', uiEditRights])
     .directive("bindCompiledHtml", function($compile) {
         return {
             scope: {

--- a/public/components/directives/ui-edit-rights.js
+++ b/public/components/directives/ui-edit-rights.js
@@ -30,17 +30,6 @@ export const uiEditRights = (wfComposerService) => ({
           </label>
         </div>
         <div>
-          <label class="ui-edit-rights__label" for="rights-subscription-databases">
-            <input type="checkbox"
-                   id="rights-subscription-databases"
-                   class="ui-edit-rights__input"
-                   ng-model="contentItem.item.rightsSubscriptionDatabases"
-                   ng-click="$event.stopPropagation()"
-                   ng-change="updateRights()" />
-            <span>Subscription databases</span>
-          </label>
-        </div>
-        <div>
           <label class="ui-edit-rights__label" for="rights-developer-community">
             <input type="checkbox"
                    id="rights-developer-community"
@@ -49,6 +38,17 @@ export const uiEditRights = (wfComposerService) => ({
                    ng-click="$event.stopPropagation()"
                    ng-change="updateRights()" />
             <span>Developer community</span>
+          </label>
+        </div>
+        <div>
+          <label class="ui-edit-rights__label" for="rights-subscription-databases">
+            <input type="checkbox"
+                   id="rights-subscription-databases"
+                   class="ui-edit-rights__input"
+                   ng-model="contentItem.item.rightsSubscriptionDatabases"
+                   ng-click="$event.stopPropagation()"
+                   ng-change="updateRights()" />
+            <span>Subscription databases</span>
           </label>
         </div>
       </div>

--- a/public/components/directives/ui-edit-rights.js
+++ b/public/components/directives/ui-edit-rights.js
@@ -11,10 +11,10 @@ export const uiEditRights = (wfComposerService) => ({
           </span>
           <span ng-if="!hasRightsData()">
               <button class="btn btn-xs btn-info margin-right-small" ng-click="setAllRights(true); $event.stopPropagation()">
-                  Add all
+                  Add all rights
               </button>
-              <button class="btn btn-xs btn-info" ng-click="setAllRights(false); $event.stopPropagation()">
-                  Remove all
+              <button class="btn btn-xs btn-warning" ng-click="setAllRights(false); $event.stopPropagation()">
+                  Remove all rights
               </button>
           </span>
       </div>

--- a/public/components/directives/ui-edit-rights.js
+++ b/public/components/directives/ui-edit-rights.js
@@ -1,42 +1,85 @@
 export const uiEditRights = (wfComposerService) => ({
   scope: {
-    contentItem: '=contentItem'
+    contentItem: '=contentItem',
+    inline: '@inline'
   },
   template: `
-    <label class="rights-field__input-label">
-      <input type="checkbox"
-             class="rights-field__input"
-             ng-model="contentItem.item.rightsSyndicationAggregate"
-             ng-click="$event.stopPropagation()"
-             ng-change="updateRights()"
-      />
-      <span>Syndicatable</span>
-    </label>
-    <label class="rights-field__input-label">
-      <input type="checkbox"
-             class="rights-field__input"
-             ng-model="contentItem.item.rightsSubscriptionDatabases"
-             ng-click="$event.stopPropagation()"
-             ng-change="updateRights()" />
-      <span>Subscription databases</span>
-    </label>
-    <label class="rights-field__input-label">
-      <input type="checkbox"
-             class="rights-field__input"
-             ng-model="contentItem.item.rightsDeveloperCommunity"
-             ng-click="$event.stopPropagation()"
-             ng-change="updateRights()" />
-      <span>Developer community</span>
-    </label>
+    <div class="ui-edit-rights">
+      <div ng-if="inline">
+          <span ng-if="hasRightsData()">
+              Reviewed
+          </span>
+          <span ng-if="!hasRightsData()">
+              <button class="btn btn-xs btn-info margin-right-small" ng-click="setAllRights(true); $event.stopPropagation()">
+                  Add all
+              </button>
+              <button class="btn btn-xs btn-info" ng-click="setAllRights(false); $event.stopPropagation()">
+                  Remove all
+              </button>
+          </span>
+      </div>
+      <div ng-if="!inline">
+        <div>
+          <label class="ui-edit-rights__label" for="rights-syndication-aggregate">
+            <input type="checkbox"
+                   id="rights-syndication-aggregate"
+                   class="ui-edit-rights__input"
+                   ng-model="contentItem.item.rightsSyndicationAggregate"
+                   ng-click="$event.stopPropagation()"
+                   ng-change="updateRights()"
+            />
+            <span>Syndicatable</span>
+          </label>
+        </div>
+        <div>
+          <label class="ui-edit-rights__label" for="rights-subscription-databases">
+            <input type="checkbox"
+                   id="rights-subscription-databases"
+                   class="ui-edit-rights__input"
+                   ng-model="contentItem.item.rightsSubscriptionDatabases"
+                   ng-click="$event.stopPropagation()"
+                   ng-change="updateRights()" />
+            <span>Subscription databases</span>
+          </label>
+        </div>
+        <div>
+          <label class="ui-edit-rights__label" for="rights-developer-community">
+            <input type="checkbox"
+                   id="rights-developer-community"
+                   class="ui-edit-rights__input"
+                   ng-model="contentItem.item.rightsDeveloperCommunity"
+                   ng-click="$event.stopPropagation()"
+                   ng-change="updateRights()" />
+            <span>Developer community</span>
+          </label>
+        </div>
+      </div>
+    </div>
   `,
   restrict: 'E',
   link(scope) {
+    scope.showAllOptions = false;
+
+    scope.toggleShowAllOptions = () => scope.showAllOptions = !scope.showAllOptions;
+
+    scope.hasRightsData = () =>
+        scope.contentItem.item.rightsSyndicationAggregate !== null &&
+        scope.contentItem.item.rightsSubscriptionDatabases !== null &&
+        scope.contentItem.item.rightsDeveloperCommunity !== null;
+
     scope.updateRights = () => {
       wfComposerService.updateRights(scope.contentItem.composerId, {
         syndicationAggregate: scope.contentItem.item.rightsSyndicationAggregate,
         subscriptionDatabases: scope.contentItem.item.rightsSubscriptionDatabases,
         developerCommunity: scope.contentItem.item.rightsDeveloperCommunity
       })
+    };
+
+    scope.setAllRights = (hasRights) => {
+      scope.contentItem.item.rightsSyndicationAggregate = hasRights;
+      scope.contentItem.item.rightsSubscriptionDatabases = hasRights;
+      scope.contentItem.item.rightsDeveloperCommunity = hasRights;
+      scope.updateRights();
     }
   }
 })

--- a/public/components/directives/ui-edit-rights.js
+++ b/public/components/directives/ui-edit-rights.js
@@ -1,0 +1,42 @@
+export const uiEditRights = (wfComposerService) => ({
+  scope: {
+    contentItem: '=contentItem'
+  },
+  template: `
+    <label class="rights-field__input-label">
+      <input type="checkbox"
+             class="rights-field__input"
+             ng-model="contentItem.item.rightsSyndicationAggregate"
+             ng-click="$event.stopPropagation()"
+             ng-change="updateRights()"
+      />
+      <span>Syndicatable</span>
+    </label>
+    <label class="rights-field__input-label">
+      <input type="checkbox"
+             class="rights-field__input"
+             ng-model="contentItem.item.rightsSubscriptionDatabases"
+             ng-click="$event.stopPropagation()"
+             ng-change="updateRights()" />
+      <span>Subscription databases</span>
+    </label>
+    <label class="rights-field__input-label">
+      <input type="checkbox"
+             class="rights-field__input"
+             ng-model="contentItem.item.rightsDeveloperCommunity"
+             ng-click="$event.stopPropagation()"
+             ng-change="updateRights()" />
+      <span>Developer community</span>
+    </label>
+  `,
+  restrict: 'E',
+  link(scope) {
+    scope.updateRights = () => {
+      wfComposerService.updateRights(scope.contentItem.composerId, {
+        syndicationAggregate: scope.contentItem.item.rightsSyndicationAggregate,
+        subscriptionDatabases: scope.contentItem.item.rightsSubscriptionDatabases,
+        developerCommunity: scope.contentItem.item.rightsDeveloperCommunity
+      })
+    }
+  }
+})

--- a/public/components/directives/ui-edit-rights.js
+++ b/public/components/directives/ui-edit-rights.js
@@ -6,15 +6,13 @@ export const uiEditRights = (wfComposerService) => ({
   template: `
     <div class="ui-edit-rights">
       <div ng-if="inline">
-          <span ng-if="hasRightsData()">
-              Reviewed
+          <span ng-if="hasAnyRights()">
+              Has rights
           </span>
-          <span ng-if="!hasRightsData()">
-              <button class="btn btn-xs btn-info margin-right-small" ng-click="setAllRights(true); $event.stopPropagation()">
+          <span ng-if="!hasAnyRights()">
+              No rights.
+              <button class="btn btn-xs btn-info" ng-click="setAllRights(true); $event.stopPropagation()">
                   Add all rights
-              </button>
-              <button class="btn btn-xs btn-warning" ng-click="setAllRights(false); $event.stopPropagation()">
-                  Remove all rights
               </button>
           </span>
       </div>
@@ -62,10 +60,10 @@ export const uiEditRights = (wfComposerService) => ({
 
     scope.toggleShowAllOptions = () => scope.showAllOptions = !scope.showAllOptions;
 
-    scope.hasRightsData = () =>
-        scope.contentItem.item.rightsSyndicationAggregate !== null &&
-        scope.contentItem.item.rightsSubscriptionDatabases !== null &&
-        scope.contentItem.item.rightsDeveloperCommunity !== null;
+    scope.hasAnyRights = () =>
+        scope.contentItem.item.rightsSyndicationAggregate ||
+        scope.contentItem.item.rightsSubscriptionDatabases  ||
+        scope.contentItem.item.rightsDeveloperCommunity;
 
     scope.updateRights = () => {
       wfComposerService.updateRights(scope.contentItem.composerId, {

--- a/public/components/directives/ui-edit-rights.scss
+++ b/public/components/directives/ui-edit-rights.scss
@@ -8,6 +8,7 @@
 
   .ui-edit-rights__input {
     margin-right: 5px;
+    cursor: pointer;
   }
 }
 

--- a/public/components/directives/ui-edit-rights.scss
+++ b/public/components/directives/ui-edit-rights.scss
@@ -1,0 +1,13 @@
+.ui-edit-rights {
+  @extend %fs-data-1;
+
+  .ui-edit-rights__label {
+    font-weight: normal;
+    cursor: pointer;
+  }
+
+  .ui-edit-rights__input {
+    margin-right: 5px;
+  }
+}
+

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -132,7 +132,7 @@ const columnDefaults = [{
   title: '',
   template: contentRightsTemplate,
   active: false,
-  isNew: true,
+  isNew: false,
   isSortable: true,
   sortField: ['rightsSyndicationAggregate', 'rightsSubscriptionDatabases', 'rightsDeveloperCommunity']
 },{

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -126,8 +126,8 @@ const columnDefaults = [{
     sortField: ['note']
 },{
   name: 'rights',
-  prettyName: 'Content rights',
-  labelHTML: 'Content rights',
+  prettyName: 'Syndication',
+  labelHTML: 'Syndication',
   colspan: 2,
   title: '',
   template: contentRightsTemplate,

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -27,6 +27,7 @@ import printLocationTemplate         from "components/content-list-item/template
 import needsPictureDeskTemplate      from "components/content-list-item/templates/needsPictureDesk.html";
 import statusInPrintTemplate         from "components/content-list-item/templates/statusInPrint.html";
 import lastModifiedInPrintByTemplate from "components/content-list-item/templates/lastModifiedInPrintBy.html";
+import contentRightsTemplate         from "components/content-list-item/templates/rights.html";
 
 /**
  * This array represents the default ordering and display of the content-list-item columns for workflow.
@@ -123,6 +124,17 @@ const columnDefaults = [{
     active: true,
     isSortable: true,
     sortField: ['note']
+},{
+  name: 'rights',
+  prettyName: 'Content rights',
+  labelHTML: 'Content rights',
+  colspan: 2,
+  title: '',
+  template: contentRightsTemplate,
+  active: false,
+  isNew: true,
+  isSortable: true,
+  sortField: ['rightsSyndicationAggregate', 'rightsSubscriptionDatabases', 'rightsDeveloperCommunity']
 },{
     name: 'pinboard',
     prettyName: 'Pinboard 📌',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -128,7 +128,7 @@ const columnDefaults = [{
   name: 'rights',
   prettyName: 'Syndication',
   labelHTML: 'Syndication',
-  colspan: 2,
+  colspan: 1,
   title: '',
   template: contentRightsTemplate,
   active: false,

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -136,4 +136,26 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService) {
         return request(req);
     };
 
+  /**
+   * Update rights information for the given piece.
+   * @param {string} composerId
+   * @param {{
+   *     developerCommunity: boolean,
+   *     subscriptionDatabases: boolean,
+   *     syndicationAggregate: boolean
+   * }} rightsData
+   * @returns Promise<Response>
+   */
+  this.updateRights = function (
+    composerId,
+    rightsData
+  ) {
+    let req = {
+      method: 'PUT',
+      url: `${composerContentFetch}${contentId}/rights`,
+      data: JSON.stringify(rightsData),
+      withCredentials: true
+    };
+    return request(req);
+  };
 }

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -136,26 +136,27 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService) {
         return request(req);
     };
 
-  /**
-   * Update rights information for the given piece.
-   * @param {string} composerId
-   * @param {{
-   *     developerCommunity: boolean,
-   *     subscriptionDatabases: boolean,
-   *     syndicationAggregate: boolean
-   * }} rightsData
-   * @returns Promise<Response>
-   */
-  this.updateRights = function (
-    composerId,
-    rightsData
-  ) {
-    let req = {
-      method: 'PUT',
-      url: `${composerContentFetch}${contentId}/rights`,
-      data: JSON.stringify(rightsData),
-      withCredentials: true
+    /**
+     * Update rights information for the given piece.
+     * @param {string} composerId
+     * @param {{
+     *     developerCommunity: boolean,
+     *     subscriptionDatabases: boolean,
+     *     syndicationAggregate: boolean
+     * }} rightsData
+     * @returns Promise<Response>
+     */
+    this.updateRights = function (
+        composerId,
+        rightsData
+    ) {
+        let req = {
+          method: 'PUT',
+          url: `${composerContentFetch}${composerId}/rights`,
+          data: JSON.stringify(rightsData),
+          withCredentials: true
+        };
+
+        return request(req);
     };
-    return request(req);
-  };
 }

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -246,7 +246,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         'trashed': modelParams['trashed'] || null,
                         'hasPrintInfo': modelParams['hasPrintInfo'] || null,
                         'hasMainMedia': modelParams['hasMainMedia'] || null,
-                        'hasRightsData': modelParams['hasRightsData'] || null,
+                        'hasAnyRights': modelParams['hasAnyRights'] || null,
                     };
 
                     return params;

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -246,6 +246,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         'trashed': modelParams['trashed'] || null,
                         'hasPrintInfo': modelParams['hasPrintInfo'] || null,
                         'hasMainMedia': modelParams['hasMainMedia'] || null,
+                        'hasRightsData': modelParams['hasRightsData'] || null,
                     };
 
                     return params;

--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -190,6 +190,16 @@ var filterDefaults = function (statuses, wfFiltersService) {
             ]
         },
         {
+            title: 'Rights',
+            namespace: 'hasRightsData',
+            listIsOpen: false,
+            multi: false,
+            filterOptions: [
+                { caption: 'Has rights data', value: 'true' },
+                { caption: 'No rights data', value: 'false' }
+            ]
+        },
+        {
             title: 'Trashed',
             namespace: 'trashed',
             listIsOpen: false,

--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -190,7 +190,7 @@ var filterDefaults = function (statuses, wfFiltersService) {
             ]
         },
         {
-            title: 'Rights',
+            title: 'Syndication',
             namespace: 'hasRightsData',
             listIsOpen: false,
             multi: false,

--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -195,7 +195,7 @@ var filterDefaults = function (statuses, wfFiltersService) {
             listIsOpen: false,
             multi: false,
             filterOptions: [
-                { caption: 'Has rights set', value: 'true' },
+                { caption: 'Has any rights set', value: 'true' },
                 { caption: 'No rights set', value: 'false' }
             ]
         },

--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -191,12 +191,12 @@ var filterDefaults = function (statuses, wfFiltersService) {
         },
         {
             title: 'Syndication',
-            namespace: 'hasRightsData',
+            namespace: 'hasAnyRights',
             listIsOpen: false,
             multi: false,
             filterOptions: [
-                { caption: 'Has rights data', value: 'true' },
-                { caption: 'No rights data', value: 'false' }
+                { caption: 'Has rights set', value: 'true' },
+                { caption: 'No rights set', value: 'false' }
             ]
         },
         {

--- a/public/lib/filters-service.js
+++ b/public/lib/filters-service.js
@@ -155,8 +155,8 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                     $rootScope.$broadcast('getContent');
                 });
 
-                $rootScope.$on('filtersChanged.hasRightsData', function(event, data) {
-                  self.update('hasRightsData', data);
+                $rootScope.$on('filtersChanged.hasAnyRights', function(event, data) {
+                  self.update('hasAnyRights', data);
                   $rootScope.$broadcast('getContent');
                 });
             }
@@ -200,7 +200,7 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                         'editorId'       : params['editorId'],
                         'hasPrintInfo'   : params['hasPrintInfo'],
                         'hasMainMedia'   : params['hasMainMedia'],
-                        'hasRightsData'  : params['hasRightsData']
+                        'hasAnyRights'   : params['hasAnyRights']
                     };
 
                     $rootScope.currentlySelectedStatusFilters = self.transformStatusList(self.filters['status']);

--- a/public/lib/filters-service.js
+++ b/public/lib/filters-service.js
@@ -155,6 +155,10 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                     $rootScope.$broadcast('getContent');
                 });
 
+                $rootScope.$on('filtersChanged.hasRightsData', function(event, data) {
+                  self.update('hasRightsData', data);
+                  $rootScope.$broadcast('getContent');
+                });
             }
 
             init() {
@@ -195,7 +199,8 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                         'plan-end-date'  : params['plan-end-date'],
                         'editorId'       : params['editorId'],
                         'hasPrintInfo'   : params['hasPrintInfo'],
-                        'hasMainMedia'   : params['hasMainMedia']
+                        'hasMainMedia'   : params['hasMainMedia'],
+                        'hasRightsData'  : params['hasRightsData']
                     };
 
                     $rootScope.currentlySelectedStatusFilters = self.transformStatusList(self.filters['status']);


### PR DESCRIPTION
## What does this change?

Adds the ability to filter by rights information in the content table, and set rights – either all of them via the column, or on a per-right basis in the 'management' drawer.

https://user-images.githubusercontent.com/7767575/210387748-f0a99d1c-ca66-404f-bafc-9295c2a10fed.mov

See https://github.com/guardian/workflow/pull/1101 for notes on how the data is stored.

## How to test

In CODE, try to:

- Add/remove rights via the table or management drawer
- Use the filter on the left hand side

Does this behave as expected? 

~NB: there's one bug! Because we go back to Composer to set this information, and then wait for Composer to report the new value via flexible-content-stream, sometimes workflow-frontend will update _before_ Composer has a chance to report the new value. Our client cannot distinguish between these sorts of updates, so if you click the button, it will occasionally revert to the old value before eventually displaying the new one:~

https://user-images.githubusercontent.com/7767575/210393319-386022b5-e52b-4967-943d-de6d4acf8aa6.mov

~There are a few ways I can imagine solving (you could pause state updates until the data reflected what you expected, for example), but I think it makes sense to get this out first.~

Above bug should be fixed by [eac696b](https://github.com/guardian/workflow-frontend/pull/393/commits/eac696b71717d63f56fb8fe35f9ceda86444d24f).