### PR TITLE
Add manual review flag

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -291,8 +291,8 @@ class Api(
       } yield id
     )}
   }
-  
-  def putStubPlannedNewspaperPublicationDate(stubId: Long) = 
+
+  def putStubPlannedNewspaperPublicationDate(stubId: Long) =
    {
     APIAuthAction.async { request =>
       ApiResponseFt[Long](for {
@@ -302,6 +302,17 @@ class Api(
         id <- stubsApi.putStubPlannedNewspaperPublicationDate(stubId, date)
       } yield id
     )}
+  }
+
+  def putStubRightsReviewed(stubId: Long) = {
+    APIAuthAction.async { request =>
+      ApiResponseFt[Long](for {
+        json <- readJsonFromRequestResponse(request.body)
+        rightsReviewed <- extractDataResponse[Boolean](json)
+        id <- stubsApi.putStubRightsReviewed(stubId, rightsReviewed)
+      } yield id
+      )
+    }
   }
 
   def deleteContent(composerId: String) = {

--- a/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
@@ -136,42 +136,49 @@ class StubAPI(
       json <- parseBody(res.body)
       item <- extractDataResponse[Long](json)
     } yield item
-  
+
   def putStubPlannedPublicationId(stubId: Long, plannedPublicationId: Long): ApiResponseFt[Long] =
       for {
         res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$stubId/plannedPublicationId", plannedPublicationId.asJson))
         json <- parseBody(res.body)
         item <- extractDataResponse[Long](json)
       } yield item
-  
+
   def putStubPlannedBookId(stubId: Long, plannedBookId: Long): ApiResponseFt[Long] =
       for {
         res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$stubId/plannedBookId", plannedBookId.asJson))
         json <- parseBody(res.body)
         item <- extractDataResponse[Long](json)
       } yield item
-  
+
   def putStubPlannedBookSectionId(stubId: Long, plannedBookSectionId: Long): ApiResponseFt[Long] =
       for {
         res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$stubId/plannedBookSectionId", plannedBookSectionId.asJson))
         json <- parseBody(res.body)
         item <- extractDataResponse[Long](json)
       } yield item
-  
+
   def putStubPlannedNewspaperPageNumber(stubId: Long, plannedNewspaperPageNumber: Int): ApiResponseFt[Long] =
       for {
         res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$stubId/plannedNewspaperPageNumber", plannedNewspaperPageNumber.asJson))
         json <- parseBody(res.body)
         item <- extractDataResponse[Long](json)
       } yield item
-  
+
   def putStubPlannedNewspaperPublicationDate(stubId: Long, plannedNewspaperPublicationDate: LocalDate): ApiResponseFt[Long] =
       for {
         res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$stubId/plannedNewspaperPublicationDate", plannedNewspaperPublicationDate.asJson))
         json <- parseBody(res.body)
         item <- extractDataResponse[Long](json)
       } yield item
-  
+
+  def putStubRightsReviewed(stubId: Long, reviewed: Boolean): ApiResponseFt[Long] =
+    for {
+      res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$stubId/rightsReviewed", reviewed.asJson))
+      json <- parseBody(res.body)
+      item <- extractDataResponse[Long](json)
+    } yield item
+
   def deleteContentByStubId(id: Long): ApiResponseFt[Option[String]] =
     for {
       res <- ApiResponseFt.Async.Right(deleteRequest(s"stubs/$id"))

--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -86,7 +86,7 @@ case class Stub(id: Option[Long] = None,
                 // Description enriched for use by WF front end client code.
                 shortPlannedPrintLocationDescription: Option[String] = None,
                 longPlannedPrintLocationDescription: Option[String] = None,
-                rightsReviewed: Option[Boolean] = None
+                rightsReviewed: Boolean = false
                )
 
 object Stub {

--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -86,6 +86,7 @@ case class Stub(id: Option[Long] = None,
                 // Description enriched for use by WF front end client code.
                 shortPlannedPrintLocationDescription: Option[String] = None,
                 longPlannedPrintLocationDescription: Option[String] = None,
+                rightsReviewed: Option[Boolean] = None
                )
 
 object Stub {

--- a/conf/routes
+++ b/conf/routes
@@ -50,6 +50,7 @@ PUT            /api/stubs/:stubId/plannedBookId            controllers.Api.putSt
 PUT            /api/stubs/:stubId/plannedBookSectionId     controllers.Api.putStubPlannedBookSectionId(stubId: Long)
 PUT            /api/stubs/:stubId/plannedNewspaperPageNumber          controllers.Api.putStubPlannedNewspaperPageNumber(stubId: Long)
 PUT            /api/stubs/:stubId/plannedNewspaperPublicationDate     controllers.Api.putStubPlannedNewspaperPublicationDate(stubId: Long)
+PUT            /api/stubs/:stubId/rightsReviewed           controllers.Api.putStubRightsReviewed(stubId: Long)
 DELETE         /api/stubs/:stubId                          controllers.Api.deleteStub(stubId: Long)
 
 GET            /api/statuses                               controllers.Api.statusus

--- a/public/components/directives/ui-edit-rights.js
+++ b/public/components/directives/ui-edit-rights.js
@@ -51,6 +51,16 @@ export const uiEditRights = (wfComposerService) => ({
             <span>Subscription databases</span>
           </label>
         </div>
+        <hr />
+        <label class="ui-edit-rights__label" for="rights-reviewed">
+          <input type="checkbox"
+                 id="rights-reviewed"
+                 class="ui-edit-rights__input"
+                 ng-model="contentItem.item.rightsReviewed"
+                 ng-click="$event.stopPropagation()"
+                 wf-content-item-update-action="rightsReviewed" />
+          <span>Rights have been reviewed</span>
+        </label>
       </div>
     </div>
   `,

--- a/public/components/directives/ui-edit-rights.scss
+++ b/public/components/directives/ui-edit-rights.scss
@@ -10,5 +10,10 @@
     margin-right: 5px;
     cursor: pointer;
   }
+
+  hr {
+    margin: 10px 0;
+    border-top: 1px solid #ddd;
+  }
 }
 

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -246,7 +246,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         'trashed': modelParams['trashed'] || null,
                         'hasPrintInfo': modelParams['hasPrintInfo'] || null,
                         'hasMainMedia': modelParams['hasMainMedia'] || null,
-                        'hasAnyRights': modelParams['hasAnyRights'] || null,
+                        'rights': modelParams['rights'] || null,
                     };
 
                     return params;

--- a/public/lib/filter-defaults.js
+++ b/public/lib/filter-defaults.js
@@ -191,12 +191,14 @@ var filterDefaults = function (statuses, wfFiltersService) {
         },
         {
             title: 'Syndication',
-            namespace: 'hasAnyRights',
+            namespace: 'rights',
             listIsOpen: false,
             multi: false,
             filterOptions: [
-                { caption: 'Has any rights set', value: 'true' },
-                { caption: 'No rights set', value: 'false' }
+                { caption: 'Has any rights set', value: 'has-rights' },
+                { caption: 'No rights set', value: 'no-rights' },
+                { caption: 'Reviewed', value: 'reviewed' },
+                { caption: 'Needs review', value: 'not-reviewed' }
             ]
         },
         {

--- a/public/lib/filters-service.js
+++ b/public/lib/filters-service.js
@@ -155,8 +155,8 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                     $rootScope.$broadcast('getContent');
                 });
 
-                $rootScope.$on('filtersChanged.hasAnyRights', function(event, data) {
-                  self.update('hasAnyRights', data);
+                $rootScope.$on('filtersChanged.rights', function(event, data) {
+                  self.update('rights', data);
                   $rootScope.$broadcast('getContent');
                 });
             }
@@ -200,7 +200,7 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                         'editorId'       : params['editorId'],
                         'hasPrintInfo'   : params['hasPrintInfo'],
                         'hasMainMedia'   : params['hasMainMedia'],
-                        'hasAnyRights'   : params['hasAnyRights']
+                        'hasAnyRights'   : params['rights']
                     };
 
                     $rootScope.currentlySelectedStatusFilters = self.transformStatusList(self.filters['status']);


### PR DESCRIPTION
## What does this change?

Adds a `rights_reviewed` flag, local to workflow, and filters to let the Rights Ops mark content as reviewed.

https://user-images.githubusercontent.com/7767575/211064419-9312c9c8-223a-4c6d-8b52-9bb83c3e4abd.mov

See https://github.com/guardian/workflow/pull/1102 for why this approach was taken.

## How to test

Running locally, with datastore and Composer, or (more easily!) in CODE in concert with https://github.com/guardian/workflow/pull/1102:

- Add content from Composer. Is it initially marked as unreviewed?
- Mark it as reviewed, and refresh the page. Does the setting persist?
- Try using the filters on the left hand side to isolate reviewed and unreviewed content, and content with and without rights. Do the filters behave as expected?