### PR TITLE
Add byline column

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -50,7 +50,8 @@ case class ExternalData(
                          lastModifiedInPrintBy: Option[String] = None,
                          rightsSyndicationAggregate: Option[Boolean] = None,
                          rightsSubscriptionDatabases: Option[Boolean] = None,
-                         rightsDeveloperCommunity: Option[Boolean] = None) {
+                         rightsDeveloperCommunity: Option[Boolean] = None,
+                         byline: Option[String] = None) {
 }
 
 object ExternalData {

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -288,12 +288,6 @@
             white-space: nowrap;
         }
 
-        &--byline {
-          [data-tag-id] {
-            font-weight: bold;
-          }
-        }
-
         &--notes {
             @extend %fs-data-1;
             padding: 2px 10px;

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -177,7 +177,9 @@
         &--sensitive,
         &--legally-sensitive,
         &--printlocation,
-        &--rights {
+        &--rights,
+        &--byline
+        {
             @extend %fs-data-1;
             @extend %content-list__field-padding;
         }
@@ -284,6 +286,12 @@
         &--last-modified-by,
         &--last-modified-in-print-by {
             white-space: nowrap;
+        }
+
+        &--byline {
+          [data-tag-id] {
+            font-weight: bold;
+          }
         }
 
         &--notes {

--- a/public/components/content-list-item/templates/byline.html
+++ b/public/components/content-list-item/templates/byline.html
@@ -1,4 +1,3 @@
 <td class="content-list-item__field--byline" scope="row" title="Byline">
-  <div ng-bind-html="contentItem.item.byline | wfTrustedHtml">
-  </div>
+  {{contentItem.item.byline}}
 </td>

--- a/public/components/content-list-item/templates/byline.html
+++ b/public/components/content-list-item/templates/byline.html
@@ -1,0 +1,4 @@
+<td class="content-list-item__field--byline" scope="row" title="Byline">
+  <div ng-bind-html="contentItem.item.byline | wfTrustedHtml">
+  </div>
+</td>

--- a/public/components/content-list/_content-list.scss
+++ b/public/components/content-list/_content-list.scss
@@ -105,7 +105,8 @@ google-auth-banner .alert {
             &--last-modified-by,
             &--last-modified-in-print-by,
             &--printlocation,
-            &--rights {
+            &--rights,
+            &--byline {
                 padding: 15px 10px 5px 5px;
                 @extend %fs-data-2;
 
@@ -200,6 +201,10 @@ google-auth-banner .alert {
             }
 
             &--rights {
+              min-width: 125px;
+            }
+
+            &--byline {
               min-width: 125px;
             }
         }

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -1,6 +1,7 @@
 import priorityTemplate              from "components/content-list-item/templates/priority.html";
 import contentTypeTemplate           from "components/content-list-item/templates/content-type.html";
 import titleTemplate                 from "components/content-list-item/templates/title.html";
+import bylineTemplate                from "components/content-list-item/templates/byline.html";
 import commentsTemplate              from "components/content-list-item/templates/comments.html";
 import mainImageTemplate             from "components/content-list-item/templates/main-image.html";
 import incopyTemplate                from "components/content-list-item/templates/incopy.html";
@@ -113,6 +114,17 @@ const columnDefaults = [{
     alwaysShown: true,
     isSortable: true,
     sortField: ['workingTitle']
+},{
+    name: 'byline',
+    prettyName: 'Byline',
+    labelHTML: 'Byline',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'byline.html',
+    template: bylineTemplate,
+    active: false,
+    isNew: false,
+    sortField: ['byline']
 },{
     name: 'notes',
     prettyName: 'Notes',


### PR DESCRIPTION
## What does this change?

Adds a byline column to the content table, to the right of the headline column. It's not visible by default.

![Screenshot 2023-01-12 at 17 25 17](https://user-images.githubusercontent.com/7767575/212136735-e4b27a6f-0601-40ad-8843-93ef45d8a8cf.png)

## How to test

- Deploy both this PR and https://github.com/guardian/workflow/pull/1104 to CODE, and modify a few pieces with bylines, or add bylines to pieces tracked in workflow. Add the byline column to your table. Do the bylines appear as expected?

## How can we measure success?

An easier job for the Rights Ops team as they add rights to content.