### PR TITLE
use an ARM amigo recipe

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiTags:
         AmigoStage: PROD
-        Recipe: editorial-tools-focal-java8
+        Recipe: editorial-tools-focal-java8-ARM
         BuiltBy: amigo
       cloudFormationStackName: Workflow-Frontend
       prependStackToCloudFormationStackName: false


### PR DESCRIPTION
...so we can use Graviton (see guardian/editorial-tools-platform#669)

https://trello.com/c/Ru0NS31r/1252-switch-workflow-and-workflow-frontend-instance-types

Graviton is cheaper and it's reservations season, so moving as much as we can over.
