### PR TITLE
Standardise configs with workflow backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ It can use either a local store, or CODE.
 
  1. Run the setup script `./scripts/setup.sh`
  2. Download the DEV config: `./scripts/fetch-config.sh`
- 3. Open `/etc/gu/workflow-frontend.private.conf` and amend `api.url` as follows:
-
-    api.url="http://localhost:9095/api"
 
 If you encounter a `Module build failed` error due to Node Sass during set up, run `npm rebuild node-sass`.
 
@@ -56,7 +53,7 @@ You will need [ssm-scala](https://github.com/guardian/ssm-scala) installed for t
 
 ### Run
 
-To run workflow-frontend, run the start stript `./scripts/start.sh`. Then navigate to https://workflow.local.dev-gutools.co.uk
+To run workflow-frontend, run the start script `./scripts/start.sh`. Then navigate to https://workflow.local.dev-gutools.co.uk
 
 The lambda that sends notifications does not run automatically locally. You can invoke it:
 

--- a/scripts/fetch-config.sh
+++ b/scripts/fetch-config.sh
@@ -2,7 +2,4 @@
 
 aws s3 \
   --profile workflow \
-  cp s3://workflow-private/DEV/workflow-frontend/applications.defaults.conf /etc/gu/workflow-frontend.private.conf
-
-
-
+  cp s3://workflow-private/DEV/workflow-frontend-application.local.conf ~/.gu/workflow-frontend-application.local.conf

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -21,4 +21,4 @@ fi
 
 yarn build-dev &
 # shellcheck disable=SC2086
-sbt $EXTRA_SBT_ARGS run
+sbt $EXTRA_SBT_ARGS "-Dconfig.file=$HOME/.gu/workflow-frontend-application.local.conf" run


### PR DESCRIPTION
## What does this change?

See https://github.com/guardian/workflow/pull/1109.

This PR follows up on work in workflow backend to standardise our configs. I have also taken the liberty of moving the dev config a folder up in S3, changing the name of it to match the other configs, and switching the `api.url` setting as recommended in the README. I have left the old setting in as a comment in case we need it (normally we could rely on S3, but by moving the file we have lost the version history).

## How to test

With the right Janus permissions (workflow and **capi**):
1. Run the setup script
2. Run the start script
3. Visit the healthcheck endpoint: http://localhost:9090/management/healthcheck

If this url returns healthy, and the sbt console shows no error logs, then we can be relatively confident about these changes. An even better test would be to boot up the backend services locally, navigate to https://workflow.local.dev-gutools.co.uk/dashboard, and test the app's functionality end-to-end.

If you're struggling to get the frontend up and running because of SASS, see: https://github.com/guardian/workflow-frontend/pull/401.

## How can we measure success?

Devs can get set up on Workflow quicker and not get confused about the different config patterns.

## Have we considered potential risks?

The S3 changes mentioned above were a little risky - dev machines on current `main` as of writing will not be able to find the old file. However, this change should only affect local dev work.
