### PR TITLE
expose `composerId` to Pinboard

### DIFF
--- a/public/components/content-list-item/templates/pinboard.html
+++ b/public/components/content-list-item/templates/pinboard.html
@@ -1,5 +1,6 @@
 <td class="content-list-item__field--pinboard"
     data-pinboard-id="{{ contentItem.id || contentItem.stubId }}"
+    data-composer-id="{{ contentItem.composerId }}"
     data-working-title="{{contentItem.workingTitle}}"
     data-headline="{{contentItem.headline}}"
     data-group-title="{{contentItem.status}}"


### PR DESCRIPTION
This tweaks the `content-list-item__field--pinboard` cells (added in https://github.com/guardian/workflow-frontend/pull/385) to also expose `composerId` to Pinboard via `data-composer-id` attribute, primarily to facilitate https://github.com/guardian/pinboard/pull/276.
