### PR TITLE
improve pinboard integration

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -139,8 +139,6 @@ class Application(
         ("storyPackagesUrl", Json.fromString(config.storyPackagesUrl)),
         ("presenceUrl", Json.fromString(config.presenceUrl)),
         ("preferencesUrl", Json.fromString(config.preferencesUrl)),
-        ("pinboardLoaderUrl", Json.fromString(config.pinboardLoaderUrl)),
-        ("hasPinboardPermission", Json.fromBoolean(permissions.hasPermission(pinboardPermission, request.user.email))),
         ("user", parser.parse(user.toJson).getOrElse(Json.Null)),
         ("incopyOpenUrl", Json.fromString(config.incopyOpenUrl)),
         ("incopyExportUrl", Json.fromString(config.incopyExportUrl)),
@@ -156,7 +154,16 @@ class Application(
         ("tagManagerUrl",Json.fromString(config.tagManagerUrl))
       )
 
-      Ok(views.html.app(title, Some(user), jsonConfig, config.googleTrackingId, config.presenceClientLib))
+      val hasPinboardPermission = permissions.hasPermission(pinboardPermission, request.user.email)
+
+      Ok(views.html.app(
+        title,
+        Some(user),
+        config = jsonConfig,
+        gaId = config.googleTrackingId,
+        presenceClientLib = config.presenceClientLib,
+        maybePinboardLoaderUrl = if(hasPinboardPermission) Some(config.pinboardLoaderUrl) else None
+      ))
     }
   }
 

--- a/app/views/app.scala.html
+++ b/app/views/app.scala.html
@@ -1,4 +1,11 @@
-@(title: String, user: Option[com.gu.pandomainauth.model.User], config: io.circe.Json, gaId: String, presenceClientLib: String)
+@(
+  title: String,
+  user: Option[com.gu.pandomainauth.model.User],
+  config: io.circe.Json,
+  gaId: String,
+  presenceClientLib: String,
+  maybePinboardLoaderUrl: Option[String]
+)
 
 @layout(title, user, config) {
   <div class="main" ui-view>
@@ -23,5 +30,8 @@
               m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
     </script>
+  }
+  @maybePinboardLoaderUrl.map { pinboardLoaderUrl =>
+    <script async src="@pinboardLoaderUrl"></script>
   }
 }

--- a/public/components/content-list/content-list.html
+++ b/public/components/content-list/content-list.html
@@ -42,7 +42,7 @@
             </label>
         </li>
         <li class="column-configurator__list-item">
-            <button class="btn btn-xs btn-info" ng-click="colChange()" ng-disabled="!columnsEdited">Reload to view changes</button>
+            <button id="apply_column_changes" class="btn btn-xs btn-info" ng-click="colChange()" ng-disabled="!columnsEdited">Reload to view changes</button>
         </li>
     </ul>
 </div>

--- a/public/lib/column-service.js
+++ b/public/lib/column-service.js
@@ -15,7 +15,7 @@ angular.module('wfColumnService', [])
 
                     var self = this;
 
-                    self.availableColums = columnDefaults.filter(col => col.name !== "pinboard" || _wfConfig.hasPinboardPermission);
+                    self.availableColums = columnDefaults;
                     self.contentItemTemplate;
 
                     self.preferencePromise = wfPreferencesService.getPreference('columnConfiguration').then(function resolve (data) {
@@ -54,14 +54,6 @@ angular.module('wfColumnService', [])
 
                         return self.columns;
                     }
-
-                    this.getColumns().then((columns) => {
-                        if(columns.find(_ => _.name === "pinboard" && _.active)){
-                            const script = document.createElement('script');
-                            script.src = _wfConfig.pinboardLoaderUrl;
-                            document.head.appendChild(script);
-                        }
-                    });
                 }
 
                 getAvailableColumns() {


### PR DESCRIPTION
https://trello.com/c/Pw4EGPHn/1660-improve-pinboard-workflow-integration

In https://github.com/guardian/pinboard/pull/295 we look to always display the pinboard floaty in workflow (previously just the column and 'inline mode' which was introduced in #320) so that users never miss an unread item on a pinboard that's not visible with the current workflow filters - because they'll now see the red blob on the pinboard floaty (familiar from other tools).

Previously the pinboard script would only run if the Pinboard column was turned on (which also required a permission check), but since we now want it for every permissioned user, this PR moves the script tag for pinboard.loader.js to the server-side template which is simpler (and as a bonus, more consistent with how Pinboard is loaded in the other tools such as Composer, Grid etc.).

We also add an `id="apply_column_changes"` to the column configuration button so that it can be reliably programmatically  driven by pinboard.

![improved_workflow](https://github.com/guardian/pinboard/assets/19289579/926b0942-0c60-4726-b265-ccd7cc407b52)
