### PR TITLE
Update training and various links

### DIFF
--- a/app/views/training.scala.html
+++ b/app/views/training.scala.html
@@ -27,13 +27,13 @@
     <ul>
         <li><a target="_blank" href="https://docs.google.com/a/guardian.co.uk/document/d/1Y_2BNgejq9lcf-irfipFigiaum-LlABokuYB3d9ch-8/edit#heading=h.7ovwlya0d96o">Workflow training documentation.</a> This will be the best way to keep up to date, as this documentation will always be updated and current</li>
         <li><a target="_blank" href="https://sites.google.com/a/guardian.co.uk/composer-blog/">Composer help</a></li>
-        <li><a target="_blank" href="https://sites.google.com/a/guardian.co.uk/esd/composer">ESD Composer documentation</a></li>
-        <li><a target="_blank" href="https://docs.google.com/document/d/1dINs5J8QQTl9PGrntWx_j3bT9DQENMpM_t0FOOdHt_0">The digital optimisation bible.</a> A work-in-progress guide to best practice around digital headlines and optimisation.</li>
+        <li><a target="_blank" href="https://sites.google.com/a/guardian.co.uk/esd/web-tools/composer-workflow">ESD Composer and Workflow documentation</a></li>
+        <li><a target="_blank" href="https://docs.google.com/document/d/1MgQfsl1JaSS0UfE3NCsA06ErY99gbQyF7nAXjmu1uiA">Web headline guide.</a> Guide from the Audience team to our common approaches to headlines.</li>
     </ul>
 
     <h2>Miscellaneous</h2>
     <ul>
-        <li><a target="_blank" href="http://wires/">Wires tool</a></li>
+        <li><a target="_blank" href="https://editorial-wires.gutools.co.uk">Wires tool</a></li>
     </ul>
 </div>
 <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("layouts/infopages/info.min.css")"/>

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -114,7 +114,7 @@
                             <span class="drawer__item-content" ng-if="contentItem.optimisedForWeb">Optimised</span>
                             <span class="drawer__item-content" ng-if="!contentItem.optimisedForWeb && !contentItem.optimisedForWebChanged">Not optimised</span>
                             <span class="drawer__item-content" ng-if="contentItem.optimisedForWebChanged">Modified since being optimised</span>
-                            <span class="drawer__item-content"><a target="_blank" href="https://docs.google.com/document/d/1dINs5J8QQTl9PGrntWx_j3bT9DQENMpM_t0FOOdHt_0/edit">Optimisation bible</a></span>
+                            <span class="drawer__item-content"><a target="_blank" href="https://docs.google.com/document/d/1MgQfsl1JaSS0UfE3NCsA06ErY99gbQyF7nAXjmu1uiA">Web headline guide</a></span>
                         </li>
                         <li class="drawer__item">
                             <span class="drawer__item-title">Content type</span>


### PR DESCRIPTION
This updates a link to working version of SEO doc already available in Composer:

![image](https://github.com/guardian/workflow-frontend/assets/6032869/ae6455b7-cb3e-44b6-9da9-c02107ba0536)

And updates some other minor things nobody clicks on… Some stuff was from 1976… Highlight: `/training` contains link to Workflow itself 🤣 