### PR TITLE
[tactical] increase preferences request timeout (to avoid users on slow connections, effectively losing their preferences)

### DIFF
--- a/public/lib/preferences-service.js
+++ b/public/lib/preferences-service.js
@@ -6,7 +6,7 @@ angular.module('wfPreferencesService', [])
     .factory('wfPreferencesService', ['$rootScope', '$http', '$log', '$window',
         function($rootScope, $http, $log, $window) {
 
-            var TIMEOUT = 5000;
+            var TIMEOUT = 10000;
 
             class PreferencesService {
 


### PR DESCRIPTION
Users in AUS have reported losing their wofklow column preferences, I suspect because of the increased latency there and the fact that if workflow fails to retrieve preferences (after 5s currently) it gives up, users then go to adjust their preferences and it stomps over their previous preferences.

It doesn't help that workflow itself sits behind cloudfront to improve the AUS latency situation, but editorial-preferences does not... watch for a follow-up PR on this (probably some new workflow-frontend endpoints to proxy preferences for this reason)