### PR TITLE
proxy `preferences` calls via `workflow-frontend` 

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -52,6 +52,8 @@ class AppComponents(context: Context)
 
   val notificationsController = new Notifications(config, controllerComponents, wsClient, panDomainRefresher)
 
+  val preferencesProxyController = new PreferencesProxy(config, controllerComponents, wsClient, panDomainRefresher)
+
   val supportController = new Support(config, controllerComponents, wsClient, panDomainRefresher)
 
   override val router = new Routes(
@@ -65,7 +67,8 @@ class AppComponents(context: Context)
     adminController,
     supportController,
     managementController,
-    assets
+    assets,
+    preferencesProxyController
   )
 
   final override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(context.initialConfiguration).copy(

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -69,11 +69,12 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
   lazy val presenceUrl: String = s"wss://presence.$domain/socket"
   lazy val presenceClientLib: String = s"https://presence.$domain/client/1/lib.js"
 
-  lazy val preferencesUrl: String = s"https://preferences.$domain/preferences"
+  lazy val preferencesHost: String = s"preferences.$domain"
+  lazy val preferencesUrl: String = s"https://$preferencesHost/preferences"
 
-  lazy val pinboardLoaderUrl: String = s"https://pinboard.${stage.appDomain}/pinboard.loader.js"
+  lazy val pinboardLoaderUrl: String = s"https://pinboard.$domain/pinboard.loader.js"
 
-  lazy val tagManagerUrl: String = s"https://tagmanager.${stage.appDomain}"
+  lazy val tagManagerUrl: String = s"https://tagmanager.$domain"
 
   lazy val capiPreviewIamUrl: String = playConfig.get[String]("capi.preview.iamUrl")
   lazy val capiPreviewRole: String = playConfig.get[String]("capi.preview.role")

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -69,7 +69,7 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
   lazy val presenceUrl: String = s"wss://presence.$domain/socket"
   lazy val presenceClientLib: String = s"https://presence.$domain/client/1/lib.js"
 
-  lazy val preferencesUrl: String = s"https://preferences.${stage.appDomain}/preferences"
+  lazy val preferencesUrl: String = s"https://preferences.$domain/preferences"
 
   lazy val pinboardLoaderUrl: String = s"https://pinboard.${stage.appDomain}/pinboard.loader.js"
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -138,7 +138,6 @@ class Application(
         ("viewerUrl", Json.fromString(config.viewerUrl)),
         ("storyPackagesUrl", Json.fromString(config.storyPackagesUrl)),
         ("presenceUrl", Json.fromString(config.presenceUrl)),
-        ("preferencesUrl", Json.fromString(config.preferencesUrl)),
         ("user", parser.parse(user.toJson).getOrElse(Json.Null)),
         ("incopyOpenUrl", Json.fromString(config.incopyOpenUrl)),
         ("incopyExportUrl", Json.fromString(config.incopyExportUrl)),

--- a/app/controllers/PreferencesProxy.scala
+++ b/app/controllers/PreferencesProxy.scala
@@ -1,0 +1,40 @@
+package controllers
+
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.workflow.util.{Code, Dev}
+import config.Config
+import play.api.Logging
+import play.api.libs.ws.WSClient
+import play.api.mvc.{BaseController, ControllerComponents}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/* Proxy for editorial-preferences, to help with latency since workflow-frontend sits behind CloudFront*/
+class PreferencesProxy(
+  override val config: Config,
+  override val controllerComponents: ControllerComponents,
+  override val wsClient: WSClient,
+  override val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends BaseController with PanDomainAuthActions with Logging {
+
+  private def proxyRequest(relativePath: String) = APIAuthAction.async { request =>
+    val url = s"${config.preferencesUrl}/$relativePath"
+    wsClient.url(url)
+      .withHttpHeaders(request.headers.toSimpleMap.toSeq: _*)
+      .execute(request.method)
+      .map { response =>
+        Ok(response.body).withHeaders(response.headers.mapValues(_.head).toSeq: _*)
+      }
+      .recover { case e =>
+        logger.error(s"Error proxying request to $url", e)
+        TemporaryRedirect( // this ensures PUT doesn't get transformed to GET, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#temporary_redirections
+          if (config.isDev) url.replaceAll(Dev.appDomain, Code.appDomain)
+          else url
+        )
+      }
+  }
+
+  def userPref(userId: String, app: String) = proxyRequest(s"$userId/$app")
+  def setPreference(userId: String, app: String, prefKey: String) = proxyRequest(s"$userId/$app/$prefKey")
+  def getPreference(userId: String, app: String, prefKey: String) = proxyRequest(s"$userId/$prefKey")
+}

--- a/app/controllers/PreferencesProxy.scala
+++ b/app/controllers/PreferencesProxy.scala
@@ -19,21 +19,22 @@ class PreferencesProxy(
 
   private def proxyRequest(relativePath: String) = APIAuthAction.async { request =>
     val url = s"${config.preferencesUrl}/$relativePath"
-    val headers = request.headers.toSimpleMap + (
-      "Host" -> config.preferencesHost,
-      "Cache-Control" -> "private, no-cache, no-store, must-revalidate, max-age=0", // do not cache whatsoever
+    val requestHeaders = request.headers.toSimpleMap + (
+      "Host" -> config.preferencesHost
     )
     wsClient.url(url)
-      .withHttpHeaders(headers.toSeq: _*)
+      .withHttpHeaders(requestHeaders.toSeq: _*)
       .execute(request.method)
       .map { response =>
-        new Status(response.status)(response.body).withHeaders(response.headers.mapValues(_.head).toSeq: _*)
+        val responseHeaders = response.headers.mapValues(_.head) + (
+          "Cache-Control" -> "private, no-cache, no-store, must-revalidate, max-age=0", // do not cache whatsoever
+        )
+        new Status(response.status)(response.body).withHeaders(responseHeaders.toSeq: _*)
       }
       .recover {
         case _ if config.isDev =>
           TemporaryRedirect( // this ensures PUT doesn't get transformed to GET, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#temporary_redirections
-            if (config.isDev) url.replaceAll(Dev.appDomain, Code.appDomain)
-            else url
+            url.replaceAll(Dev.appDomain, Code.appDomain)
           )
         case e =>
           logger.error(s"Error proxying request to $url", e)

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -24,6 +24,5 @@ deployments:
   workflow-frontend-fluentbit:
     type: aws-s3
     parameters:
-      bucket: workflow-dist
       cacheControl: private
       publicReadAcl: false

--- a/conf/routes
+++ b/conf/routes
@@ -102,3 +102,8 @@ GET            /management/healthcheck                     controllers.Managemen
 
 # Map static resources from the /public folder to the /assets URL path
 GET            /assets/*file                               controllers.Assets.versioned(path="/public", file: Asset)
+
+# editorial-preferences proxy (to help with latency)
+GET            /preferences/:userId/:app                        controllers.PreferencesProxy.userPref(userId: String, app: String)
+PUT            /preferences/:userId/:app/:prefKey               controllers.PreferencesProxy.setPreference(userId: String, app: String, prefKey: String)
+GET            /preferences/:userId/:app/:prefKey               controllers.PreferencesProxy.getPreference(userId: String, app: String, prefKey: String)

--- a/public/lib/preferences-service.js
+++ b/public/lib/preferences-service.js
@@ -39,7 +39,7 @@ angular.module('wfPreferencesService', [])
                  * @returns {string}
                  */
                 url(user, prefKey) {
-                    return _wfConfig.preferencesUrl + '/' + user + '/workflow' + (prefKey ? '/' + prefKey : '');
+                    return '/preferences/' + user + '/workflow' + (prefKey ? '/' + prefKey : '');
                 }
 
                 /**


### PR DESCRIPTION
...to benefit from CloudFront which is in front of workflow-frontend but not editorial-preferences (mainly to benefit users in AUS).

Related: #407 

BONUS: taken this opportunity to redirect calls to preferences.local to preferences.code when https://github.com/guardian/editorial-preferences is NOT running locally.

## TESTING

- LOCALLY; once running (with the tunnel, as detailed in README) notice your code workflow column choices etc. are use and that if you update* then refresh in CODE workflow you'll see the same choices
- CODE; reading and updating* column configuration etc. works as before (you can observe the preferences related Network calls using Developer Tools - they should be using the workflow domain, not preferences)

\* column configuration can be changed by scrolling to the very right hand side, clicking <img width="52" alt="image" src="https://github.com/guardian/workflow-frontend/assets/19289579/1c9aeff6-4a1e-475b-a3da-df9f4ce416f9"> at the end of the column headings, changing some columns, scrolling to the bottom of the column list and clicking <img width="153" alt="image" src="https://github.com/guardian/workflow-frontend/assets/19289579/3ea7509c-70b4-4031-8b41-5eb031538681">