### PR TITLE
Build with GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
                   sbt clean compile test Debian/packageBin
             - name: Notification Lambda
               run: |
-                  sbt "project/notification" clean compile Universal/packageBin
+                  sbt "project notification" clean compile Universal/packageBin
 
 
             - uses: guardian/actions-riff-raff@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,9 @@ jobs:
             - name: Build and Test project
               run: |
                   sbt clean compile test Debian/packageBin
-                  cd notification && sbt clean compile test Universal/packageBin
-
-            # - name: Notification Lambda
-            #   working-directory: ./notification
-            #   run: |
-            #     sbt clean compile test Universal/packageBin
+            - name: Notification Lambda
+              run: |
+                  sbt project notification clean compile Universal/packageBin
 
 
             - uses: guardian/actions-riff-raff@v2
@@ -72,4 +69,4 @@ jobs:
                         - fluentbit/parsers.conf
                         - fluentbit/td-agent-bit.conf
                       workflow-notification:
-                        - notification/target/workflow-notification.zip
+                        - notification/target/universal/workflow-notification.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,11 @@ jobs:
                   role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
                   aws-region: eu-west-1
 
-
-
-
             - name: Install Node
               uses: actions/setup-node@v3
               with:
                 node-version-file: '.nvmrc'
+
             - name: Install dependencies, build & run tests
               run: |
                   set -e
@@ -52,10 +50,10 @@ jobs:
             - name: Build and Test project
               run: |
                   sbt clean compile test Debian/packageBin
+
             - name: Notification Lambda
               run: |
                   sbt "project notification" clean compile Universal/packageBin
-
 
             - uses: guardian/actions-riff-raff@v2
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,12 @@ jobs:
             - name: Build and Test project
               run: |
                   sbt clean compile test Debian/packageBin
-            - name: Notification Lambda
-              working-directory: ./notification
-              run: |
-                sbt clean compile test Universal/packageBin
+                  cd notification && sbt clean compile test Universal/packageBin
+
+            # - name: Notification Lambda
+            #   working-directory: ./notification
+            #   run: |
+            #     sbt clean compile test Universal/packageBin
 
 
             - uses: guardian/actions-riff-raff@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: build
+
+on:
+    push:
+        branches: ["main"]
+    pull_request:
+    workflow_dispatch:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        permissions: # required by aws-actions/configure-aws-credentials
+            id-token: write
+            contents: read
+
+        steps:
+            # Seed the build number with last number from TeamCity.
+            # This env var is used by the JS, and SBT builds, and guardian/actions-riff-raff.
+            # Set the value early, rather than `buildNumberOffset` in guardian/actions-riff-raff, to ensure each usage has the same number.
+            # For some reason, it's not possible to mutate GITHUB_RUN_NUMBER, so set BUILD_NUMBER instead.
+            - name: Set BUILD_NUMBER environment variable
+              run: |
+                  LAST_TEAMCITY_BUILD=1603
+                  echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
+            - uses: actions/checkout@v4
+            - uses: actions/setup-java@v3
+              with:
+                  distribution: "corretto"
+                  java-version: "8"
+                  cache: "sbt"
+
+            - name: AWS Auth
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+                  aws-region: eu-west-1
+
+
+
+
+            - name: Install Node
+              uses: actions/setup-node@v3
+              with:
+                node-version-file: '.nvmrc'
+            - name: Install dependencies, build & run tests
+              run: |
+                  set -e
+                  yarn install --frozen-lockfile
+                  yarn build
+
+            - name: Build and Test project
+              run: |
+                  sbt clean compile test Debian/packageBin
+
+
+            - uses: guardian/actions-riff-raff@v2
+              with:
+                  projectName: Editorial Tools::Workflow::Workflow Frontend
+                  buildNumber: ${{ env.BUILD_NUMBER }}
+                  configPath: riff-raff.yaml
+                  contentDirectories: |
+                      workflow-frontend:
+                        - workflow-frontend/target/workflow-frontend_0.1_all.deb
+                      workflow-frontend-fluentbit:
+                        - fluentbit/parsers.conf
+                        - fluentbit/td-agent-bit.conf
+                      workflow-notification:
+                        - notification/target/workflow-notification.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
               with:
                 node-version-file: '.nvmrc'
 
-            - name: Install dependencies
+            - name: Install JS dependencies
               run: yarn install --frozen-lockfile
 
-            - name: Yarn build
+            - name: JS build
               run: yarn build
 
             - name: Build, test and package the scala app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
                   configPath: conf/riff-raff.yaml
                   contentDirectories: |
                       workflow-frontend:
-                        - workflow-frontend/target/workflow-frontend_0.1_all.deb
+                        - target/workflow-frontend_0.1_all.deb
                       workflow-frontend-fluentbit:
                         - fluentbit/parsers.conf
                         - fluentbit/td-agent-bit.conf
-                      workflow-notification:
-                        - notification/target/workflow-notification.zip
+                    #   workflow-notification:
+                    #     - notification/target/workflow-notification.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
             - name: Build and Test project
               run: |
                   sbt clean compile test Debian/packageBin
+            - name: Notification Lambda
+              working-directory: ./notification
+              run: |
+                sbt clean compile test Universal/packageBin
 
 
             - uses: guardian/actions-riff-raff@v2
@@ -65,5 +69,5 @@ jobs:
                       workflow-frontend-fluentbit:
                         - fluentbit/parsers.conf
                         - fluentbit/td-agent-bit.conf
-                    #   workflow-notification:
-                    #     - notification/target/workflow-notification.zip
+                      workflow-notification:
+                        - notification/target/workflow-notification.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
                   sbt clean compile test Debian/packageBin
             - name: Notification Lambda
               run: |
-                  sbt project notification clean compile Universal/packageBin
+                  sbt "project/notification" clean compile Universal/packageBin
 
 
             - uses: guardian/actions-riff-raff@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
               with:
                   projectName: Editorial Tools::Workflow::Workflow Frontend
                   buildNumber: ${{ env.BUILD_NUMBER }}
-                  configPath: riff-raff.yaml
+                  configPath: conf/riff-raff.yaml
                   contentDirectories: |
                       workflow-frontend:
                         - workflow-frontend/target/workflow-frontend_0.1_all.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,20 @@ jobs:
               with:
                 node-version-file: '.nvmrc'
 
-            - name: Install dependencies, build & run tests
-              run: |
-                  set -e
-                  yarn install --frozen-lockfile
-                  yarn build
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
 
-            - name: Build and Test project
+            - name: Yarn build
+              run: yarn build
+
+            - name: Yarn test
+              run: yarn test
+
+            - name: Build, test and package the scala app
               run: |
                   sbt clean compile test Debian/packageBin
 
-            - name: Notification Lambda
+            - name: Build and package the notification Lambda
               run: |
                   sbt "project notification" clean compile Universal/packageBin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,6 @@ jobs:
             - name: Yarn build
               run: yarn build
 
-            - name: Yarn test
-              run: yarn test
-
             - name: Build, test and package the scala app
               run: |
                   sbt clean compile test Debian/packageBin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
             - name: Install JS dependencies
               run: yarn install --frozen-lockfile
 
+            - name: test JS
+              run: yarn test
+
             - name: JS build
               run: yarn build
 

--- a/app/views/healthcheck.scala.html
+++ b/app/views/healthcheck.scala.html
@@ -1,3 +1,2 @@
 <h1>Healthcheck OK</h1>
 <h2>build-commit-id: @build.BuildInfo.gitCommitId</h2>
-<h2>build-number: @build.BuildInfo.buildNumber</h2>

--- a/app/views/layout.scala.html
+++ b/app/views/layout.scala.html
@@ -41,7 +41,6 @@
 @content
 
 <!-- build-commit-id: @build.BuildInfo.gitCommitId -->
-<!-- build-number: @build.BuildInfo.buildNumber -->
 
 </body>
 </html>

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import play.sbt.PlayImport.PlayKeys._
 import Dependencies._
 import sbtbuildinfo.BuildInfo
 import scala.sys.env
-// import com.gu.riffraff.artifact.BuildInfo
 
 Test / parallelExecution := false
 
@@ -82,19 +81,6 @@ lazy val root = playProject(application)
       s"-Dpidfile.path=/var/run/${packageName.value}/play.pid"
     ),
     debianPackageDependencies := Seq("openjdk-8-jre-headless"),
-    // riffRaffPackageType := (Debian / packageBin).value,
-    // riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    // riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    // riffRaffPackageName := s"editorial-tools:workflow:$application",
-    // riffRaffManifestProjectName := riffRaffPackageName.value,
-    // fileDescriptorLimit := Option("32768"),
-    // riffRaffArtifactResources := Seq(
-    //   riffRaffPackageType.value -> s"$application/${riffRaffPackageType.value.getName}",
-    //   (notificationLambda / Universal / packageBin).value -> s"${(notificationLambda / name).value}/${(notificationLambda / Universal / packageBin).value.getName}",
-    //   baseDirectory.value / "conf" / "riff-raff.yaml" -> "riff-raff.yaml",
-    //   baseDirectory.value / "fluentbit/td-agent-bit.conf" -> "workflow-frontend-fluentbit/td-agent-bit.conf",
-    //   baseDirectory.value / "fluentbit/parsers.conf" -> "workflow-frontend-fluentbit/parsers.conf"
-    // ),
     Universal / javaOptions ++= Seq(
       "-Dpidfile.path=/dev/null"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import play.sbt.PlayImport.PlayKeys._
 import Dependencies._
-import com.gu.riffraff.artifact.BuildInfo
+import sbtbuildinfo.BuildInfo
+import scala.sys.env
+// import com.gu.riffraff.artifact.BuildInfo
 
 Test / parallelExecution := false
 
@@ -8,15 +10,11 @@ val scalaVersionNumber = "2.12.15"
 
 val buildInfo = Seq(
   buildInfoPackage := "build",
-  buildInfoKeys ++= {
-    val buildInfo = BuildInfo(baseDirectory.value)
-
-    Seq[BuildInfoKey](
-      "gitCommitId" -> buildInfo.revision,
-      "buildNumber" -> buildInfo.buildIdentifier
-    )
-  }
+  buildInfoKeys +=
+      "gitCommitId" -> env.getOrElse("GITHUB_SHA", "Unknown"),
 )
+
+
 
 val commonSettings = Seq(
   scalaVersion := scalaVersionNumber,
@@ -63,7 +61,7 @@ lazy val commonLib = project("common-lib")
 val application = "workflow-frontend"
 
 lazy val root = playProject(application)
-  .enablePlugins(RiffRaffArtifact, JDebPackaging)
+  .enablePlugins(JDebPackaging, BuildInfoPlugin)
   .settings(
     libraryDependencies
       ++= awsDependencies
@@ -84,19 +82,19 @@ lazy val root = playProject(application)
       s"-Dpidfile.path=/var/run/${packageName.value}/play.pid"
     ),
     debianPackageDependencies := Seq("openjdk-8-jre-headless"),
-    riffRaffPackageType := (Debian / packageBin).value,
-    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    riffRaffPackageName := s"editorial-tools:workflow:$application",
-    riffRaffManifestProjectName := riffRaffPackageName.value,
-    fileDescriptorLimit := Option("32768"),
-    riffRaffArtifactResources := Seq(
-      riffRaffPackageType.value -> s"$application/${riffRaffPackageType.value.getName}",
-      (notificationLambda / Universal / packageBin).value -> s"${(notificationLambda / name).value}/${(notificationLambda / Universal / packageBin).value.getName}",
-      baseDirectory.value / "conf" / "riff-raff.yaml" -> "riff-raff.yaml",
-      baseDirectory.value / "fluentbit/td-agent-bit.conf" -> "workflow-frontend-fluentbit/td-agent-bit.conf",
-      baseDirectory.value / "fluentbit/parsers.conf" -> "workflow-frontend-fluentbit/parsers.conf"
-    ),
+    // riffRaffPackageType := (Debian / packageBin).value,
+    // riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
+    // riffRaffUploadManifestBucket := Option("riffraff-builds"),
+    // riffRaffPackageName := s"editorial-tools:workflow:$application",
+    // riffRaffManifestProjectName := riffRaffPackageName.value,
+    // fileDescriptorLimit := Option("32768"),
+    // riffRaffArtifactResources := Seq(
+    //   riffRaffPackageType.value -> s"$application/${riffRaffPackageType.value.getName}",
+    //   (notificationLambda / Universal / packageBin).value -> s"${(notificationLambda / name).value}/${(notificationLambda / Universal / packageBin).value.getName}",
+    //   baseDirectory.value / "conf" / "riff-raff.yaml" -> "riff-raff.yaml",
+    //   baseDirectory.value / "fluentbit/td-agent-bit.conf" -> "workflow-frontend-fluentbit/td-agent-bit.conf",
+    //   baseDirectory.value / "fluentbit/parsers.conf" -> "workflow-frontend-fluentbit/parsers.conf"
+    // ),
     Universal / javaOptions ++= Seq(
       "-Dpidfile.path=/dev/null"
     ),

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,6 +67,6 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
+    singleRun: true
   });
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build-dev": "webpack --config ./conf/webpack.conf.js --watch",
     "build": "webpack --config ./conf/webpack.prod.conf.js",
     "test": "karma start",
+    "test-watch": "yarn test --no-single-run",
     "lint": "eslint ./public/**/**/*.js"
   },
   "devDependencies": {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,6 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts (Artifact("jdeb", "jar", "jar"))
 
-// addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
-
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,12 +6,12 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
+// addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 


### PR DESCRIPTION
## What does this change?

Adopts GitHub Actions for CI, replacing TeamCity, and using actions riff raff instead of sbt riffraff artifact.

As workflow-frontend relied on a `buildInfo` provided by sbt riffraff artifact for prout's checks, this PR also adapts some of the logic used for this, following the example in [this implementation](https://github.com/guardian/story-packages/pull/187/files), 

## How to test

This branch has been built through GHA and successfully deployed to the code stage, which seems to be working as normal.

## How can we measure success/mitigate risks?

Prod gets deployed successfully and workflow continues working. Any issues with the deployment should end up getting rolled back automatically.

## Rollout

- [X]  Pause the TeamCity build
- [ ]  Merge this PR
- [ ]  Adjust branch protection rules, requiring the GHA build to pass before merge
- [ ]  Ensure all open PRs are rebased against main to ensure their build runs

