### PR TITLE
fix admin navbar position (was obscuring stuff beneath)

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -9,16 +9,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!--<meta name="viewport" content="width=device-width, initial-scale=1">-->
     <title>@title</title>
-    <style>
-        .admin {
-            padding-top: 72px;
-        }
-    </style>
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("build/app.css")"/>
 </head>
 
 <body>
-<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+<div class="navbar navbar-inverse navbar-fixed-top" style="position: sticky" role="navigation">
     <div class="container-fluid">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">


### PR DESCRIPTION
Noticed the tabs were obscured when trying to add a Section. Looks like there was a previous attempt at this which wasn't working but also padding content down by an arbitrary amount to accommodate navbar is not great, so I've removed in favour of a `position: sticky` directly on the element, so it can be seen alongside the `navbar-fixed-top` Bootstrap class, since its changing that behaviour (Bootstrap doesn't have a `navbar-sticky` or `navbar-sticky-top`).

### Before
<img width="915" alt="image" src="https://github.com/guardian/workflow-frontend/assets/19289579/be13ec80-688e-470f-83f1-925a92cc2ae3">

### After
