### PR TITLE
Add logging of push notifications to track usage

### DIFF
--- a/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
@@ -108,7 +108,7 @@ class Notifier(stage: Stage, override val secret: String, subsApi: Subscriptions
         val body = stub.title
 
         val update = SubscriptionUpdate(title, body, url)
-
+        logger.info(s"Sending notification about ${stub.title} (${stub.composerId}) to ${sub.email}")
         subsApi.sendNotification(update, sub.endpoint)
       }
     } catch {


### PR DESCRIPTION
## What does this change?

Logs usage of push notifications feature so that we can decide whether to upgrade the dependencies required for this feature, or remove the feature.