### PR TITLE
Remove akka agent

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -330,10 +330,8 @@ class Api(
   }
 
   def statusus = {
-    APIAuthAction.async { implicit req =>
-      for(statuses <- StatusDatabase.statuses) yield {
-        Ok(renderJsonResponse(statuses).asJson.noSpaces)
-      }
+    APIAuthAction { implicit req =>
+      Ok(renderJsonResponse(StatusDatabase.statuses).asJson.noSpaces)
     }
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -98,7 +98,6 @@ class Application(
 
   def app(title: String) = AuthAction.async { request =>
     for {
-      statuses <- StatusDatabase.statuses
       sections <-  getSortedSections()
       desks <- getSortedDesks()
       sectionsInDesks <- getSectionsInDesks()
@@ -112,6 +111,7 @@ class Application(
       )
     }
     yield {
+      val statuses = StatusDatabase.statuses
       val user = request.user
 
       val jsonConfig = Json.obj(

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,6 @@ lazy val commonLib = project("common-lib")
       ++ logbackDependencies
       ++ testDependencies
       ++ awsDependencies
-      ++ akkaDependencies
       ++ jsonDependencies
       ++ webPushDependencies
       ++ cacheDependencies
@@ -65,7 +64,6 @@ lazy val root = playProject(application)
     libraryDependencies
       ++= awsDependencies
       ++ authDependencies
-      ++ akkaDependencies
       ++ testDependencies
       ++ jsonDependencies
       ++ permissionsDependencies

--- a/common-lib/src/main/scala/com/gu/workflow/lib/StatusDatabase.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/StatusDatabase.scala
@@ -10,7 +10,7 @@ object StatusDatabase {
 
   private val store: Agent[List[Status]] = Agent(Status.values.toList)
 
-  def statuses: Future[List[Status]] = store.future()
+  def statuses: List[Status] = store.get()
 
   def find(name: String): Option[Status] = store.get().find(_.entryName.toUpperCase == name.toUpperCase)
 }

--- a/common-lib/src/main/scala/com/gu/workflow/lib/StatusDatabase.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/StatusDatabase.scala
@@ -1,16 +1,10 @@
 package com.gu.workflow.lib
 
-import akka.agent.Agent
 import models.Status
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 object StatusDatabase {
 
-  private val store: Agent[List[Status]] = Agent(Status.values.toList)
+  val statuses: List[Status] = Status.values.toList
 
-  def statuses: List[Status] = store.get()
-
-  def find(name: String): Option[Status] = store.get().find(_.entryName.toUpperCase == name.toUpperCase)
+  def find(name: String): Option[Status] = statuses.find(_.entryName.toUpperCase == name.toUpperCase)
 }

--- a/common-lib/src/main/scala/com/gu/workflow/lib/StatusDatabase.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/StatusDatabase.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
 
 object StatusDatabase {
 
-  val store: Agent[List[Status]] = Agent(Status.values.toList)
+  private val store: Agent[List[Status]] = Agent(Status.values.toList)
 
   def statuses: Future[List[Status]] = store.future()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,15 +27,7 @@ object Dependencies {
         "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % version
     )
   }
-
-  val akkaDependencies = Seq(
-    // akka-agent 2.5.X has deprecated Agents,
-    // so use the latest version that still has it
-    // TODO move to latest version of akka-agent
-    "com.typesafe.akka" %% "akka-agent" % "2.4.20",
-    "com.typesafe.akka" %% "akka-slf4j" % "2.4.20"
-  )
-
+  
   val authDependencies = Seq(
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
     "com.gu" %% "hmac-headers" % "1.1.2",


### PR DESCRIPTION
## What does this change?

Akka-agent was removed from Akka years ago. Let's stop using it in workflow-frontend.

Conveniently the only place we were using it was to wrap a constant value, so it was easy to remove.