### PR TITLE
Upgrade Scala/Play/SBT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             - uses: actions/setup-java@v3
               with:
                   distribution: "corretto"
-                  java-version: "8"
+                  java-version: "11"
                   cache: "sbt"
 
             - name: AWS Auth

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -6,7 +6,7 @@ import com.gu.workflow.util._
 import play.Logger
 import play.api.{Configuration, Logging}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {

--- a/app/controllers/Admin.scala
+++ b/app/controllers/Admin.scala
@@ -134,7 +134,7 @@ class Admin(
   )
 
   def assignSectionToDesk = (AuthAction andThen PermissionFilter).async { implicit request =>
-    assignSectionToDeskForm.bindFromRequest.fold(
+    assignSectionToDeskForm.bindFromRequest().fold(
       formWithErrors => Future(BadRequest("failed to update section assignments")),
       sectionAssignment => {
         sectionDeskMappingsAPI.assignSectionsToDesk(sectionAssignment.desk, sectionAssignment.sections.map(id => id.toLong))
@@ -154,7 +154,7 @@ class Admin(
    */
 
   def addSection = (AuthAction andThen PermissionFilter).async { implicit request =>
-    addSectionForm.bindFromRequest.fold(
+    addSectionForm.bindFromRequest().fold(
       formWithErrors => Future(BadRequest("failed to add section")),
       section => {
         sectionsAPI.upsertSection(section).asFuture.map {
@@ -168,7 +168,7 @@ class Admin(
   }
 
   def removeSection = (AuthAction andThen PermissionFilter).async { implicit request =>
-    addSectionForm.bindFromRequest.fold(
+    addSectionForm.bindFromRequest().fold(
       formWithErrors => Future(BadRequest("failed to remove section")),
       section => {
         for {
@@ -184,7 +184,7 @@ class Admin(
    */
 
   def addDesk = (AuthAction andThen PermissionFilter).async { implicit request =>
-    addDeskForm.bindFromRequest.fold(
+    addDeskForm.bindFromRequest().fold(
       formWithErrors => Future(BadRequest(s"failed to add desk ${formWithErrors.errors}")),
       desk => {
         desksAPI.upsertDesk(desk).asFuture.map {
@@ -198,7 +198,7 @@ class Admin(
   }
 
   def removeDesk = (AuthAction andThen PermissionFilter).async { implicit request =>
-    addDeskForm.bindFromRequest.fold(
+    addDeskForm.bindFromRequest().fold(
       formWithErrors => Future(BadRequest("failed to remove desk")),
       desk => {
         for {
@@ -265,7 +265,7 @@ class Admin(
   }
 
   def addSectionTag() = (AuthAction andThen PermissionFilter) { implicit request =>
-    addSectionTagForm.bindFromRequest.fold(
+    addSectionTagForm.bindFromRequest().fold(
       formWithErrors => {
         BadRequest("failed to execute controllers.admin.addSectionTag()")
       },
@@ -277,7 +277,7 @@ class Admin(
   }
 
   def removeSectionTag() = (AuthAction andThen PermissionFilter) { implicit request =>
-    removeSectionTagForm.bindFromRequest.fold(
+    removeSectionTagForm.bindFromRequest().fold(
       formWithErrors => {
         BadRequest("failed to execute controllers.admin.removeSectionTag()")
       },

--- a/app/controllers/Admin.scala
+++ b/app/controllers/Admin.scala
@@ -71,7 +71,7 @@ class Admin(
     }.getOrElse(Future(sectionListFromDB))
   }
 
-  def index() = (AuthAction andThen PermissionFilter) {
+  def index = (AuthAction andThen PermissionFilter) {
     Redirect("/admin/desks-and-sections")
   }
 
@@ -241,7 +241,7 @@ class Admin(
     val tagIdsFuture: Future[List[String]] = selectedSectionIdOption match {
       case Some(selectedSectionId) =>
         val tagIdsFt: Future[Either[ApiError, List[String]]] = sectionsAPI.getTagsForSectionFt(selectedSectionId).asFuture
-        tagIdsFt.map(_.right.get)
+        tagIdsFt.map(_.toOption.get)
       case None => Future.successful(List())
     }
     for {
@@ -250,7 +250,7 @@ class Admin(
       tagIds <- tagIdsFuture
       selectedSectionOption <- selectedSectionOptionFt
     } yield {
-      val capiKeyJson: Json = parser.parse(s"""{"CAPI_API_KEY": ${config.capiKey}}""").right.get
+      val capiKeyJson: Json = parser.parse(s"""{"CAPI_API_KEY": ${config.capiKey}}""").toOption.get
       Ok(
         views.html.admin.sectionsAndTags(
           capiKeyJson,
@@ -264,7 +264,7 @@ class Admin(
     }
   }
 
-  def addSectionTag() = (AuthAction andThen PermissionFilter) { implicit request =>
+  def addSectionTag = (AuthAction andThen PermissionFilter) { implicit request =>
     addSectionTagForm.bindFromRequest().fold(
       formWithErrors => {
         BadRequest("failed to execute controllers.admin.addSectionTag()")
@@ -276,7 +276,7 @@ class Admin(
     )
   }
 
-  def removeSectionTag() = (AuthAction andThen PermissionFilter) { implicit request =>
+  def removeSectionTag = (AuthAction andThen PermissionFilter) { implicit request =>
     removeSectionTagForm.bindFromRequest().fold(
       formWithErrors => {
         BadRequest("failed to execute controllers.admin.removeSectionTag()")

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -95,7 +95,7 @@ class Api(
   }
 
 
-  def createContent() = {
+  def createContent = {
     APIAuthAction.async { request =>
       ApiResponseFt[models.api.ContentUpdate](for {
         json <- readJsonFromRequestResponse(request.body)

--- a/app/controllers/EditorialSupportTeamsController.scala
+++ b/app/controllers/EditorialSupportTeamsController.scala
@@ -7,7 +7,7 @@ import models.{EditorialSupportStaff, StaffUpdate}
 import play.api.libs.ws.WSClient
 import play.api.mvc.{BaseController, ControllerComponents}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class EditorialSupportTeamsController(
   override val config: Config,

--- a/app/controllers/PreferencesProxy.scala
+++ b/app/controllers/PreferencesProxy.scala
@@ -33,7 +33,7 @@ class PreferencesProxy(
       .withFollowRedirects(false) // ensure browser handles all redirects NOT this proxy
       .execute(request.method)
       .map { response =>
-        val responseHeaders = response.headers.mapValues(_.head) + (
+        val responseHeaders = response.headers.view.mapValues(_.head).toMap + (
           "Cache-Control" -> "private, no-cache, no-store, must-revalidate, max-age=0", // do not cache whatsoever
         )
         new Status(response.status)(response.body).withHeaders(responseHeaders.toSeq: _*)

--- a/app/lib/LoggingFilter.scala
+++ b/app/lib/LoggingFilter.scala
@@ -1,7 +1,7 @@
 package lib
 
 import com.gu.workflow.util.LoggingContext
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import com.gu.pandahmac.HMACHeaderNames
 import play.api.{Logger, Logging}
 import play.api.mvc._

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.sys.env
 
 Test / parallelExecution := false
 
-val scalaVersionNumber = "2.12.15"
+val scalaVersionNumber = "2.13.12"
 
 val buildInfo = Seq(
   buildInfoPackage := "build",

--- a/build.sbt
+++ b/build.sbt
@@ -33,9 +33,7 @@ def playProject(path: String): Project =
   Project(path, file("."))
     .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
     .settings(
-      libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % "2.8.21",
-      //Necessary to override jackson-databind versions due to AWS and Play incompatibility
-      dependencyOverrides ++= jacksonDependencyOverrides,
+      libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % "2.9.1",
       pipelineStages := Seq(digest, gzip)
     )
     .settings(commonSettings ++ buildInfo)
@@ -45,7 +43,7 @@ def playProject(path: String): Project =
 lazy val commonLib = project("common-lib")
   .settings(
     libraryDependencies
-      ++= Seq("com.typesafe.play" %% "play" % "2.8.21", "com.typesafe.play" %% "play-ahc-ws" % "2.8.21")
+      ++= Seq("com.typesafe.play" %% "play" % "2.9.1", "com.typesafe.play" %% "play-ahc-ws" % "2.9.1")
       ++ logbackDependencies
       ++ testDependencies
       ++ awsDependencies

--- a/build.sbt
+++ b/build.sbt
@@ -77,11 +77,10 @@ lazy val root = playProject(application)
       // name of the pid file must be play.pid
       s"-Dpidfile.path=/var/run/${packageName.value}/play.pid"
     ),
-    debianPackageDependencies := Seq("openjdk-8-jre-headless"),
     Universal / javaOptions ++= Seq(
       "-Dpidfile.path=/dev/null"
     ),
-    debianPackageDependencies := Seq("openjdk-8-jre-headless"),
+    debianPackageDependencies := Seq("java11-runtime-headless"),
     maintainer := "Digital CMS <digitalcms.dev@guardian.co.uk>",
     packageSummary := "workflow-frontend",
     packageDescription := """Workflow, part of the suite of Guardian CMS tools"""

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ def playProject(path: String): Project =
   Project(path, file("."))
     .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
     .settings(
-      libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % "2.9.1",
+      libraryDependencies += "org.playframework" %% "play-ahc-ws" % "3.0.1",
       pipelineStages := Seq(digest, gzip)
     )
     .settings(commonSettings ++ buildInfo)
@@ -43,7 +43,7 @@ def playProject(path: String): Project =
 lazy val commonLib = project("common-lib")
   .settings(
     libraryDependencies
-      ++= Seq("com.typesafe.play" %% "play" % "2.9.1", "com.typesafe.play" %% "play-ahc-ws" % "2.9.1")
+      ++= Seq("org.playframework" %% "play" % "3.0.1", "org.playframework" %% "play-ahc-ws" % "3.0.1")
       ++ logbackDependencies
       ++ testDependencies
       ++ awsDependencies

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ def playProject(path: String): Project =
   Project(path, file("."))
     .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin, BuildInfoPlugin)
     .settings(
-      libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % "2.8.9",
+      libraryDependencies += "com.typesafe.play" %% "play-ahc-ws" % "2.8.21",
       //Necessary to override jackson-databind versions due to AWS and Play incompatibility
       dependencyOverrides ++= jacksonDependencyOverrides,
       pipelineStages := Seq(digest, gzip)
@@ -45,8 +45,7 @@ def playProject(path: String): Project =
 lazy val commonLib = project("common-lib")
   .settings(
     libraryDependencies
-      //Necessary to have a mix of play library versions due to scala-java8-compat incompatibility
-      ++= Seq("com.typesafe.play" %% "play" % "2.8.11", "com.typesafe.play" %% "play-ahc-ws" % "2.8.9")
+      ++= Seq("com.typesafe.play" %% "play" % "2.8.21", "com.typesafe.play" %% "play-ahc-ws" % "2.8.21")
       ++ logbackDependencies
       ++ testDependencies
       ++ awsDependencies

--- a/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/SubscriptionsAPI.scala
@@ -9,7 +9,7 @@ import models.{Subscription, SubscriptionEndpoint, SubscriptionUpdate}
 import nl.martijndwars.webpush.{Notification, PushService}
 import play.api.Logging
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class SubscriptionsAPI(stage: Stage, webPushPublicKey: String, webPushPrivateKey: String) extends Dynamo with Logging {
   private val tableName = stage match {

--- a/common-lib/src/main/scala/com/gu/workflow/lib/Caching.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/Caching.scala
@@ -2,7 +2,8 @@ package com.gu.workflow.lib
 
 import scalacache._
 import caffeine._
+import scalacache.serialization.InMemoryRepr
 
 trait Caching {
-  implicit val scalaCache = ScalaCache(CaffeineCache())
+  implicit val scalaCache: ScalaCache[InMemoryRepr] = ScalaCache(CaffeineCache())
 }

--- a/common-lib/src/main/scala/com/gu/workflow/lib/Caching.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/Caching.scala
@@ -1,9 +1,0 @@
-package com.gu.workflow.lib
-
-import scalacache._
-import caffeine._
-import scalacache.serialization.InMemoryRepr
-
-trait Caching {
-  implicit val scalaCache: ScalaCache[InMemoryRepr] = ScalaCache(CaffeineCache())
-}

--- a/common-lib/src/main/scala/com/gu/workflow/lib/ClientMessageLoggable.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/ClientMessageLoggable.scala
@@ -4,7 +4,7 @@ import net.logstash.logback.marker.Markers._
 import play.api.Logger
 import play.api.libs.json.{Json, Reads}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class ClientLog( message: String,
                       level: String,

--- a/common-lib/src/main/scala/com/gu/workflow/lib/ClientMessageLoggable.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/ClientMessageLoggable.scala
@@ -16,7 +16,7 @@ object ClientLog {
 
 }
 object ClientMessageLoggable {
-  def logClientMessage(log: ClientLog) {
+  def logClientMessage(log: ClientLog): Unit = {
     val scalaMap = Map("client_timestamp" -> log.timestamp) ++
       log.fields.getOrElse(Map.empty)
 

--- a/common-lib/src/main/scala/com/gu/workflow/lib/ContentAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/ContentAPI.scala
@@ -58,7 +58,7 @@ class ContentAPI(
             .downField("tag")
             .downField("internalName")
               .as[Option[String]]
-              .right
+              .toOption
               .get
         case Left(e) =>
           logger.warn("Unable to communicate with CAPI", e)

--- a/common-lib/src/main/scala/com/gu/workflow/lib/ContentAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/lib/ContentAPI.scala
@@ -1,17 +1,17 @@
 package com.gu.workflow.lib
 
 import java.net.URI
-
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import com.gu.contentapi.client.IAMSigner
 import com.gu.workflow.api.{ApiUtils, WSUtils}
 import com.gu.workflow.util.AWS
 import io.circe.parser
 import play.api.Logging
 import play.api.libs.ws.{WSClient, WSResponse}
-import scalacache.memoization._
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -19,7 +19,7 @@ class ContentAPI(
   capiPreviewRole: String,
   override val apiRoot: String,
   override val ws: WSClient
-) extends ApiUtils with WSUtils with Caching with Logging {
+) extends ApiUtils with WSUtils with Logging {
 
   private val previewSigner = {
     val capiPreviewCredentials = new AWSCredentialsProviderChain(
@@ -44,7 +44,17 @@ class ContentAPI(
     getRequest(path, params, headers)
   }
 
-  def getTagInternalName(tagId: Long)(implicit ec: ExecutionContext): Future[Option[String]] = memoize(60.minutes) {
+  private val tagCache: AsyncLoadingCache[Long, Option[String]] = {
+    Scaffeine()
+      .expireAfterWrite(1.hour)
+      .maximumSize(500)
+      .buildAsyncFuture[Long, Option[String]](getTagInternalNameUnderlying)
+  }
+
+  def getTagInternalName(tagId: Long)(implicit ec: ExecutionContext): Future[Option[String]] =
+    tagCache.get(tagId)
+
+  private def getTagInternalNameUnderlying(tagId: Long): Future[Option[String]] = {
     val path = s"internal-code/tag/$tagId"
     val params = List(("page-size", "0"))
     val headers = getHeaders(path, params)

--- a/common-lib/src/main/scala/com/gu/workflow/util/AWS.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/util/AWS.scala
@@ -10,7 +10,7 @@ import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.util.EC2MetadataUtils
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object AWS {
   lazy val credentialsProvider = new AWSCredentialsProviderChain(

--- a/common-lib/src/main/scala/com/gu/workflow/util/LoggingContext.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/util/LoggingContext.scala
@@ -4,7 +4,7 @@ import org.slf4j.MDC
 import play.Logger
 import play.api.Logging
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 

--- a/common-lib/src/main/scala/models/DateFormat.scala
+++ b/common-lib/src/main/scala/models/DateFormat.scala
@@ -8,13 +8,13 @@ import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 object DateFormat {
   private val formatter = ISODateTimeFormat.dateTime()
 
-  implicit val dateTimeEncoder = new Encoder[DateTime] {
+  implicit val dateTimeEncoder: Encoder[DateTime] = new Encoder[DateTime] {
     def apply(d: DateTime): Json = {
       val utc = d.withZone(DateTimeZone.UTC)
       formatter.print(utc).asJson
     }
   }
-  implicit val dateTimeDecoder = new Decoder[DateTime] {
+  implicit val dateTimeDecoder: Decoder[DateTime] = new Decoder[DateTime] {
     def apply(c: HCursor): Decoder.Result[DateTime] = {
       val dateTime = for {
         value <- c.focus
@@ -23,13 +23,13 @@ object DateFormat {
       dateTime.fold[Decoder.Result[DateTime]](Left(DecodingFailure("could not decode date", c.history)))(dt => Right(dt))
     }
   }
-  implicit val localDateStartOfDayEncoder = new Encoder[LocalDate] {
+  implicit val localDateStartOfDayEncoder: Encoder[LocalDate] = new Encoder[LocalDate] {
     def apply(d: LocalDate): Json = {
       val utc = d.toDateTimeAtStartOfDay(DateTimeZone.UTC).withZone(DateTimeZone.UTC)
       formatter.print(utc).asJson
     }
   }
-  implicit val localDateDecoder = new Decoder[LocalDate] {
+  implicit val localDateDecoder: Decoder[LocalDate] = new Decoder[LocalDate] {
     def apply(c: HCursor): Decoder.Result[LocalDate] = {
       val dateTime = for {
         value <- c.focus

--- a/common-lib/src/main/scala/models/EditorialSupportStaff.scala
+++ b/common-lib/src/main/scala/models/EditorialSupportStaff.scala
@@ -37,7 +37,7 @@ object EditorialSupportStaff {
     Item.fromJSON(staff.asJson.toString())
 
   def fromItem(item: Item): EditorialSupportStaff =
-    decode[EditorialSupportStaff](item.toJSON).right.get
+    decode[EditorialSupportStaff](item.toJSON).toOption.get
 
   def groupByTeams(staff: List[EditorialSupportStaff]): List[EditorialSupportTeam] = {
     staff.foldLeft(Map.empty[String, List[EditorialSupportStaff]]) { (teams, member) =>

--- a/common-lib/src/main/scala/models/Subscription.scala
+++ b/common-lib/src/main/scala/models/Subscription.scala
@@ -95,5 +95,5 @@ object Subscription {
       .withString("id", id(sub))
 
   def fromItem(item: Item): Subscription =
-    decode[Subscription](item.toJSON).right.get
+    decode[Subscription](item.toJSON).toOption.get
 }

--- a/common-lib/src/main/scala/models/api/Response.scala
+++ b/common-lib/src/main/scala/models/api/Response.scala
@@ -58,7 +58,7 @@ case class FutureO[+A](future: Future[Option[A]]) extends AnyVal {
 
 case class ApiResponseFt[A] private (underlying: Future[Either[ApiError, A]]) extends Logging {
 
-  def map[B](f: A => B)(implicit ec: ExecutionContext): ApiResponseFt[B] = ApiResponseFt(underlying.map(ft => ft.right.map(a => f(a))))
+  def map[B](f: A => B)(implicit ec: ExecutionContext): ApiResponseFt[B] = ApiResponseFt(underlying.map(ft => ft.map(a => f(a))))
 
   def flatMap[B](f: A => ApiResponseFt[B])(implicit ec: ExecutionContext): ApiResponseFt[B] = ApiResponseFt {
     asFuture.flatMap {

--- a/common-lib/src/test/scala/lib/Response.scala
+++ b/common-lib/src/test/scala/lib/Response.scala
@@ -11,5 +11,5 @@ class Response(val response: CloseableHttpResponse) {
 
   def header(name: String) = response.getFirstHeader(name).getValue
 
-  def disconnect() { response.close() }
+  def disconnect(): Unit = { response.close() }
 }

--- a/common-lib/src/test/scala/lib/TestData.scala
+++ b/common-lib/src/test/scala/lib/TestData.scala
@@ -7,7 +7,7 @@ import org.joda.time.DateTime
 
 object TestData {
 
-  val randomSeed = Config.randomSeed.getOrElse(scala.util.Random.nextLong)
+  val randomSeed = Config.randomSeed.getOrElse(scala.util.Random.nextLong())
 
   private val random = new scala.util.Random(randomSeed)
 
@@ -35,11 +35,11 @@ object TestData {
 
   def opt[A](a: A): Option[A] = if(chooseBool) Some(a) else None
 
-  def chooseId: String = random.nextDouble.toString
+  def chooseId: String = random.nextDouble().toString
 
-  def chooseInt: Int = random.nextInt
+  def chooseInt: Int = random.nextInt()
 
-  def chooseLong: Long = random.nextLong
+  def chooseLong: Long = random.nextLong()
 
   def randomStub: Stub = generateRandomStub()
 
@@ -106,7 +106,7 @@ object TestData {
       due = opt(chooseDate),
       assignee = opt(chooseItem(email)),
       assigneeEmail = opt(chooseItem(email)),
-      composerId = Some(random.nextDouble.toString),
+      composerId = Some(random.nextDouble().toString),
       contentType = chooseItem(contentTypes),
       priority = chooseItem(priority),
       needsLegal = chooseItem(needsLegal),

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiTags:
         AmigoStage: PROD
-        Recipe: editorial-tools-focal-java8-ARM-WITH-cdk-base
+        Recipe: editorial-tools-focal-java11-ARM-WITH-cdk-base
         BuiltBy: amigo
       cloudFormationStackName: Workflow-Frontend
       prependStackToCloudFormationStackName: false

--- a/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
+++ b/notification/src/main/scala/com/gu/workflow/notification/Notifier.scala
@@ -83,7 +83,7 @@ class Notifier(stage: Stage, override val secret: String, subsApi: Subscriptions
 
     parser.parse(responseText) match {
       case Right(json) =>
-        val content = json.as[ContentResponse].right.get
+        val content = json.as[ContentResponse].toOption.get
         val allStubs = content.content.toList
 
         allStubs.flatMap { case(status, stubs) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,19 +19,10 @@ object Dependencies {
     "com.gu" %% "content-api-client-aws" % "0.7"
   )
 
-  val jacksonDependencyOverrides: Seq[ModuleID] = {
-    val version = "2.11.4"
-    Seq(
-        "com.fasterxml.jackson.core" % "jackson-core" % version,
-        "com.fasterxml.jackson.core" % "jackson-databind" % version,
-        "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % version
-    )
-  }
-
   val authDependencies = Seq(
-    "com.gu" %% "pan-domain-auth-play_2-8" % "3.0.1",
+    "com.gu" %% "pan-domain-auth-play_2-9" % "3.0.1",
     "com.gu" %% "hmac-headers" % "2.0.0",
-    "com.gu" %% "panda-hmac-play_2-8" % "3.0.1"
+    "com.gu" %% "panda-hmac-play_2-9" % "3.0.1"
   )
 
   val testDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   )
 
   val cacheDependencies = Seq(
-    "com.github.cb372" %% "scalacache-caffeine" % "0.28.0"
+    "com.github.blemale" %% "scaffeine" % "5.2.1"
   )
 
   val cryptoDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,9 +20,9 @@ object Dependencies {
   )
 
   val authDependencies = Seq(
-    "com.gu" %% "pan-domain-auth-play_2-9" % "3.0.1",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "3.0.1",
     "com.gu" %% "hmac-headers" % "2.0.0",
-    "com.gu" %% "panda-hmac-play_2-9" % "3.0.1"
+    "com.gu" %% "panda-hmac-play_3-0" % "3.0.1"
   )
 
   val testDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,11 +27,11 @@ object Dependencies {
         "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % version
     )
   }
-  
+
   val authDependencies = Seq(
-    "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
-    "com.gu" %% "hmac-headers" % "1.1.2",
-    "com.gu" %% "panda-hmac-play_2-8" % "2.0.1"
+    "com.gu" %% "pan-domain-auth-play_2-8" % "3.0.1",
+    "com.gu" %% "hmac-headers" % "2.0.0",
+    "com.gu" %% "panda-hmac-play_2-8" % "3.0.1"
   )
 
   val testDependencies = Seq(
@@ -56,7 +56,7 @@ object Dependencies {
   )
 
   val cacheDependencies = Seq(
-    "com.github.cb372" %% "scalacache-caffeine" % "0.9.3"
+    "com.github.cb372" %% "scalacache-caffeine" % "0.28.0"
   )
 
   val cryptoDependencies = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.9.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts (Artifact("jdeb", "jar", "jar"))
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts (Artifact("jdeb", "jar", "jar"))
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts (Artifact("jdeb", "jar", "jar"))
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,7 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
+
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)


### PR DESCRIPTION
## What does this change?

Upgrades to Java 11, Scala 2.13, SBT 1.9.6 and Play 2.9.1

Also swaps out scalacache-caffeine for scaffeine. The API for scalacache-caffeine had changed quite a bit with the bump to a Scala 2.13 compatible version, and it only has milestone releases for v1.0. In contrast, Scaffeine seems better supported and is used in other projects

## How to test

Deploy to CODE, check app behaves as expected.

## How can we measure success?

No one notices, but Snyk vulnerabilities drop
