### PR TITLE
Fix create new dropdown 

### DIFF
--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -40,8 +40,10 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                     })} 
 
                 getTypes() {
-                    return wfPreferencesService.getPreference('featureSwitch').then((isSwitchActive) => {
+                    return wfPreferencesService.getPreference('featureSwitch')
+                    .then((isSwitchActive) => {
                         return isSwitchActive === true ? this.provideStandardAndNewFormats() : this.provideStandardFormats()})
+                    .catch((err) => {console.log(err); return this.provideStandardFormats()})
                 }
 
                 /* what types of stub should be treated as atoms? */

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -43,7 +43,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                     return wfPreferencesService.getPreference('featureSwitch')
                     .then((isSwitchActive) => {
                         return isSwitchActive === true ? this.provideStandardAndNewFormats() : this.provideStandardFormats()})
-                    .catch((err) => {console.log(err); return this.provideStandardFormats()})
+                    .catch((err) => {return this.provideStandardFormats()})
                 }
 
                 /* what types of stub should be treated as atoms? */


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fixes a bug introduced by #415 where the request for the user's featureSwitch preference was causing the dropdown to not show any contentTypes if that preference hadn't been set previously. 
