### PR TITLE
Hide format dropdown behind switch

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -13,12 +13,12 @@
             <input type="text" ng-model="formData.importUrl" ng-change="importUrlChanged()" id="import_url" name="import_url" class="form-control" required  wf-focus focus-me="{{ mode === 'import' }}">
         </div>
         <div class="form-horizontal clearfix">
-            <div class="form-group col-xs-8" ng-if="stubFormat === 'Standard Article' || stubFormat === 'Key Takeaways'">
+                <div ng-if="(showFormatDropdown && (stubFormat === 'Standard Article' || stubFormat === 'Key Takeaways'))">
                 <label for="stub_format">Format</label>
-                <div>
-                    <select id="stub_format" name="articleFormat" ng-model="stub.articleFormat" ng-options="f.value as f.name for f in articleFormats"></select>
+                    <div>
+                        <select id="stub_format" name="articleFormat" ng-model="stub.articleFormat" ng-options="f.value as f.name for f in articleFormats"></select>
+                    </div>
                 </div>
-            </div>
             <div class="form-group col-xs-8">
                 <label for="stub_title">Working title *</label>
                 <input type="text" ng-model="stub.title" id="stub_title" name="title" class="form-control" required wf-focus focus-me="{{ !(mode === 'import') }}">

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -35,6 +35,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         $scope.$watch('stub.articleFormat', (newValue) => {
             $scope.stubFormat = newValue;
         })
+
+        wfPreferencesService.getPreference('featureSwitch').then((data) => { $scope.showFormatDropdown = data;})
         
         $scope.modalTitle = ({
             'create': `Create ${$scope.contentName}`,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This bit of logic was absent from #415 but still necessary at this stage as we don't want the modal to show format variations yet. 

## Testing

On code, if the key takeaways feature switch isn't activated, the modal should not display a format dropdown. If it is, it should only when creating an article or key takeaway.