### PR TITLE
Add logging for WorkflowAccess check

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -32,29 +32,29 @@ class AppComponents(context: Context)
     s3Client = AWS.S3Client
   )
 
+  val permissions: PermissionsProvider =
+    PermissionsProvider(PermissionsConfig(stage = if (config.isProd) "PROD" else "CODE", AWS.region.getName, AWS.credentialsProvider))
+
   val managementController = new Management(controllerComponents)
-  val loginController = new Login(config, controllerComponents, wsClient, panDomainRefresher)
-  val capiServiceController = new CAPIService(config, controllerComponents, wsClient, panDomainRefresher)
+  val loginController = new Login(config, controllerComponents, wsClient, panDomainRefresher, permissions)
+  val capiServiceController = new CAPIService(config, controllerComponents, wsClient, panDomainRefresher, permissions)
   val sectionsApi = new SectionsAPI(config.apiRoot, wsClient)
   val desksApi = new DesksAPI(config.apiRoot, wsClient)
   val sectionsDeskMappingsApi = new SectionDeskMappingsAPI(config.apiRoot, wsClient)
   val stubsApi = new StubAPI(config.apiRoot, wsClient)
   val tagService = new TagService(config.tagManagerUrl, wsClient)
-
-  val permissions: PermissionsProvider =
-    PermissionsProvider(PermissionsConfig(stage =  if (config.isProd) "PROD" else "CODE", AWS.region.getName, AWS.credentialsProvider))
-
+  
   val adminController = new Admin(sectionsApi, desksApi, sectionsDeskMappingsApi, permissions, config, controllerComponents, wsClient, panDomainRefresher)
-  val editorialSupportTeamsController = new EditorialSupportTeamsController(config, controllerComponents, wsClient, panDomainRefresher)
-  val apiController = new Api(stubsApi, sectionsApi, editorialSupportTeamsController, config, controllerComponents, wsClient, panDomainRefresher)
+  val editorialSupportTeamsController = new EditorialSupportTeamsController(config, controllerComponents, wsClient, panDomainRefresher, permissions)
+  val apiController = new Api(stubsApi, sectionsApi, editorialSupportTeamsController, config, controllerComponents, wsClient, panDomainRefresher, permissions)
   val applicationController = new Application(editorialSupportTeamsController, sectionsApi, tagService, desksApi, sectionsDeskMappingsApi, permissions, config, controllerComponents, wsClient, panDomainRefresher, stubsApi)
   val peopleServiceController = new PeopleService(config, controllerComponents, wsClient, panDomainRefresher, permissions)
 
-  val notificationsController = new Notifications(config, controllerComponents, wsClient, panDomainRefresher)
+  val notificationsController = new Notifications(config, controllerComponents, wsClient, panDomainRefresher, permissions)
 
-  val preferencesProxyController = new PreferencesProxy(config, controllerComponents, wsClient, panDomainRefresher)
+  val preferencesProxyController = new PreferencesProxy(config, controllerComponents, wsClient, panDomainRefresher, permissions)
 
-  val supportController = new Support(config, controllerComponents, wsClient, panDomainRefresher)
+  val supportController = new Support(config, controllerComponents, wsClient, panDomainRefresher, permissions)
 
   override val router = new Routes(
     httpErrorHandler,

--- a/app/controllers/Admin.scala
+++ b/app/controllers/Admin.scala
@@ -22,7 +22,7 @@ class Admin(
   sectionsAPI: SectionsAPI,
   desksAPI: DesksAPI,
   sectionDeskMappingsAPI: SectionDeskMappingsAPI,
-  permissions: PermissionsProvider,
+  override val permissions: PermissionsProvider,
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -3,6 +3,7 @@ package controllers
 import com.gu.pandahmac.HMACAuthActions
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.pandomainauth.action.UserRequest
+import com.gu.permissions.PermissionsProvider
 import com.gu.workflow.api.{ApiUtils, SectionsAPI, StubAPI}
 import com.gu.workflow.lib.DBToAPIResponse.getResponse
 import com.gu.workflow.lib.{ContentAPI, Priorities, StatusDatabase}
@@ -30,7 +31,8 @@ class Api(
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
-  override val panDomainSettings: PanDomainAuthSettingsRefresher
+  override val panDomainSettings: PanDomainAuthSettingsRefresher,
+  override val permissions: PermissionsProvider,
 ) extends BaseController
   with PanDomainAuthActions
   with SharedSecretAuth

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -24,7 +24,7 @@ class Application(
   val tagService: TagService,
   val desksAPI: DesksAPI,
   val sectionDeskMappingsAPI: SectionDeskMappingsAPI,
-  val permissions: PermissionsProvider,
+  override val permissions: PermissionsProvider,
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,

--- a/app/controllers/CAPIService.scala
+++ b/app/controllers/CAPIService.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import com.gu.workflow.lib.ContentAPI
 import config.Config
 import play.api.libs.ws.WSClient
@@ -10,7 +11,8 @@ class CAPIService(
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
-  override val panDomainSettings: PanDomainAuthSettingsRefresher
+  override val panDomainSettings: PanDomainAuthSettingsRefresher,
+  override val permissions: PermissionsProvider,
 ) extends BaseController with PanDomainAuthActions {
 
   private val contentApi = new ContentAPI(config.capiPreviewRole, config.capiPreviewIamUrl, wsClient)

--- a/app/controllers/EditorialSupportTeamsController.scala
+++ b/app/controllers/EditorialSupportTeamsController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import com.gu.workflow.util.Dynamo
 import config.Config
 import models.{EditorialSupportStaff, StaffUpdate}
@@ -13,7 +14,8 @@ class EditorialSupportTeamsController(
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
-  override val panDomainSettings: PanDomainAuthSettingsRefresher
+  override val panDomainSettings: PanDomainAuthSettingsRefresher,
+  override val permissions: PermissionsProvider
 ) extends BaseController with PanDomainAuthActions with Dynamo {
 
   private val editorialSupportTable = dynamoDb.getTable(config.editorialSupportDynamoTable)

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,10 +1,11 @@
 package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import config.Config
 import play.api.libs.ws.WSClient
 import play.api.mvc._
-import play.api.{ Logging }
+import play.api.Logging
 import play.filters.headers.SecurityHeadersFilter
 
 import scala.concurrent.Future
@@ -14,7 +15,8 @@ class Login(
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
-  override val panDomainSettings: PanDomainAuthSettingsRefresher
+  override val panDomainSettings: PanDomainAuthSettingsRefresher,
+  override val permissions: PermissionsProvider,
 ) extends BaseController with PanDomainAuthActions with Logging {
 
   def oauthCallback = Action.async { implicit request =>

--- a/app/controllers/Notifications.scala
+++ b/app/controllers/Notifications.scala
@@ -2,6 +2,7 @@ package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.pandomainauth.model.User
+import com.gu.permissions.PermissionsProvider
 import com.gu.workflow.api.{ApiUtils, SubscriptionsAPI}
 import config.Config
 import models.api.ApiResponseFt
@@ -15,7 +16,8 @@ class Notifications(
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
-  override val panDomainSettings: PanDomainAuthSettingsRefresher
+  override val panDomainSettings: PanDomainAuthSettingsRefresher,
+  override val permissions: PermissionsProvider,
 ) extends BaseController with PanDomainAuthActions with ApiUtils {
 
   private val subsApi = new SubscriptionsAPI(config.stage, config.webPushPublicKey, config.webPushPrivateKey)

--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -2,16 +2,39 @@ package controllers
 
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
+import com.gu.permissions.{PermissionDefinition, PermissionsProvider}
 import config.Config
+import lib.Permissions.{accessPermission, adminPermission}
 import play.api.{Logger, Logging}
 import play.api.mvc._
 
 trait PanDomainAuthActions extends AuthActions with Results with Logging {
   def config: Config
+  def permissions: PermissionsProvider
+
+  // nb. if you need to change cacheValidation to true, this will have an impact on
+  // the ability of the app to respond to changes in Workflow access permissions.
+  override def cacheValidation: Boolean = false
+
+  private def hasAtLeastAccessPermission(email: String) = {
+    permissions.hasPermission(adminPermission, email) ||
+      permissions.hasPermission(accessPermission, email)
+  }
+
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
-    (authedUser.user.emailDomain == "guardian.co.uk") &&
-    (authedUser.multiFactor || (config.no2faUser.length > 0 && config.no2faUser == authedUser.user.email))
+    val isValid = (authedUser.user.emailDomain == "guardian.co.uk") &&
+      (authedUser.multiFactor || (config.no2faUser.length > 0 && config.no2faUser == authedUser.user.email))
+
+    if (!isValid) {
+      logger.warn(s"User ${authedUser.user.email} failed validation")
+    } else if (hasAtLeastAccessPermission(authedUser.user.email)) {
+      logger.info(s"User ${authedUser.user.email} access permission check passed")
+    } else {
+      logger.warn(s"User ${authedUser.user.email} access permission check denied")
+    }
+
+    isValid
   }
 
   override def authCallbackUrl: String = config.host + "/oauthCallback"

--- a/app/controllers/PeopleService.scala
+++ b/app/controllers/PeopleService.scala
@@ -14,7 +14,7 @@ class PeopleService(
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
   override val panDomainSettings: PanDomainAuthSettingsRefresher,
-  val permissions: PermissionsProvider,
+  override val permissions: PermissionsProvider,
 ) extends BaseController with PanDomainAuthActions {
 
   @volatile private var emailsPartsCache: Set[(String, Array[String])] = Set.empty

--- a/app/controllers/PreferencesProxy.scala
+++ b/app/controllers/PreferencesProxy.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import com.gu.workflow.util.{Code, Dev}
 import config.Config
 import play.api.Logging
@@ -14,7 +15,8 @@ class PreferencesProxy(
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
-  override val panDomainSettings: PanDomainAuthSettingsRefresher
+  override val panDomainSettings: PanDomainAuthSettingsRefresher,
+  override val permissions: PermissionsProvider,
 ) extends BaseController with PanDomainAuthActions with Logging {
 
   private def proxyRequest(relativePath: String) = APIAuthAction(parse.byteString).async { request =>

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import com.gu.workflow.lib.{ClientLog, ClientMessageLoggable}
 import config.Config
 import play.api.Logging
@@ -11,7 +12,8 @@ class Support(
   override val config: Config,
   override val controllerComponents: ControllerComponents,
   override val wsClient: WSClient,
-  override val panDomainSettings: PanDomainAuthSettingsRefresher
+  override val panDomainSettings: PanDomainAuthSettingsRefresher,
+  override val permissions: PermissionsProvider,
 ) extends BaseController with PanDomainAuthActions with Logging {
   def sendLog: Action[AnyContent] = APIAuthAction { implicit request =>
     (for {

--- a/app/lib/AdminPermissionFilter.scala
+++ b/app/lib/AdminPermissionFilter.scala
@@ -5,6 +5,7 @@ import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsP
 import com.gu.workflow.util.AWS
 import config.Config
 import io.circe.Json
+import lib.Permissions.adminPermission
 import play.api.Logging
 import play.api.mvc.{ActionFilter, Result, Results}
 
@@ -16,7 +17,6 @@ class AdminPermissionFilter(
                            )(implicit ec: ExecutionContext) extends ActionFilter[UserRequest] with Logging {
   override protected def executionContext: ExecutionContext = ec
 
-  private val adminPermission: PermissionDefinition = PermissionDefinition("workflow_admin", "workflow")
 
   override def filter[A](request:UserRequest[A]): Future[Option[Result]] = Future.successful {
     val email = request.user.email

--- a/app/lib/Permissions.scala
+++ b/app/lib/Permissions.scala
@@ -1,0 +1,11 @@
+package lib
+
+import com.gu.permissions.PermissionDefinition
+
+object Permissions {
+  val app = "workflow"
+
+  val adminPermission: PermissionDefinition = PermissionDefinition("workflow_admin", app)
+  val accessPermission: PermissionDefinition = PermissionDefinition("workflow_access", app)
+
+}


### PR DESCRIPTION
Co-authored-by: @andrew-nowak @twrichards @blishen @KarenFrankel9 

## What does this change?

Adds a check in the `validateUser` method in the Panda auth actions trait. This allows us to log whether users have the `WorkflowAccess` permission ([introduced in this Permissions PR](https://github.com/guardian/permissions/pull/183)) or the `WorkflowAdmin` permission.

This is in preparation for adding these as active checks, excluding human users who don't have one of these permissions from using the Workflow tool.

This has also required us to wire in the permissions provider to all the controllers that use Panda.

Actual auth behaviour shouldn't change for now; the actual check will be enabled in a separate PR.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] CODE deployment
- [x] Grant permissions, check that expected logs show up
- [x] Revoke permissions, check logs

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
