### PR TITLE
Remove timeline feature switch

### DIFF
--- a/public/components/feature-switches/feature-switches.js
+++ b/public/components/feature-switches/feature-switches.js
@@ -21,7 +21,6 @@ function wfFeatureSwitchesDirective() {
     };
 }
 
-export const timelineFeatureSwitchKey = 'timeline';
 export const miniProfilesFeatureSwitchKey = 'miniProfiles';
 
 class FeatureSwitches {
@@ -42,9 +41,8 @@ class FeatureSwitches {
 }
 
 function wfFeatureSwitchesController ($scope, wfPreferencesService) {
-    const featureSwitchKeys = [timelineFeatureSwitchKey, miniProfilesFeatureSwitchKey];
+    const featureSwitchKeys = [miniProfilesFeatureSwitchKey];
     $scope.readableNames = {
-        [timelineFeatureSwitchKey]: 'Timeline',
         [miniProfilesFeatureSwitchKey]: 'Mini profiles',
     }
 

--- a/public/lib/article-format-service.js
+++ b/public/lib/article-format-service.js
@@ -11,10 +11,8 @@ define(['angular'], function (angular) {
                     {name: 'Standard Article', value: 'Standard Article'},
                     {name: 'Key Takeaways', value: 'Key Takeaways'},
                     {name: 'Q&A Explainer', value: 'Q&A Explainer'},
+                    {name: 'Timeline', value: 'Timeline'},
                 ]
-                if (featureSwitches && featureSwitches.timeline){
-                    articleFormats.push({name: 'Timeline', value: 'Timeline'})
-                }
                 if (featureSwitches && featureSwitches.miniProfiles){
                     articleFormats.push({name: 'Mini profiles', value: 'Mini profiles'})
                 }

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -19,10 +19,8 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                     const articleFormats = {
                         "article": "Article",
                         "keyTakeaways": "Key Takeaways",
-                        "qAndA": "Q&A Explainer"
-                    }
-                    if (featureSwitches && featureSwitches.timeline){
-                        articleFormats.timeline = "Timeline"
+                        "qAndA": "Q&A Explainer",
+                        "timeline": "Timeline",
                     }
                     if (featureSwitches && featureSwitches.miniProfiles){
                         articleFormats.miniProfiles = "Mini profiles"


### PR DESCRIPTION
We're ready to roll out the new format, which means removing the feature switch.

How to review and test:
Load the branch, you should be able to create a timeline article directly without having to activate a feature switch.

Mini profiles should still require one though.

