### PR TITLE
Upgrade panda to v4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,9 +21,9 @@ object Dependencies {
   )
 
   val authDependencies = Seq(
-    "com.gu" %% "pan-domain-auth-play_3-0" % "3.0.1",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
     "com.gu" %% "hmac-headers" % "2.0.0",
-    "com.gu" %% "panda-hmac-play_3-0" % "3.0.1"
+    "com.gu" %% "panda-hmac-play_3-0" % "4.0.0"
   )
 
   val testDependencies = Seq(


### PR DESCRIPTION
This PR upgrades our [pan-domain-authentication](https://github.com/guardian/pan-domain-authentication) (panda) libraries to v4, which is a vital step towards our plan to improve key rotation.

### How to review and test
[Check](https://riffraff.gutools.co.uk/deployment/history?projectName=Editorial+Tools%3A%3AWorkflow%3A%3AWorkflow+Frontend&stage=CODE&pageSize=20&page=1) if this branch is deployed to CODE. If not, deploy to [CODE](https://workflow.code.dev-gutools.co.uk/)[^1].

We want to test that the Panda library can: 
(1) verify valid Panda cookies
(2) issue Panda cookies through OAuth
(3) issue cookies that work 'pan domain', i.e. across tools on the same domain (in this case, dev-gutools.co.uk)
(4) handle HMAC requests correctly

Choose another tool on the same domain to test with. For example, [Composer CODE](https://composer.code.dev-gutools.co.uk/).

### 1. Verification
Open the other tool. If the tool asks you to login through Google Auth, log in. This will issue you a Panda cookie. If you are not directed to Google Auth, you already have a Panda cookie to test with.

Open Story Packages. You should see Story Packages as normal. Check your network tab - you should see **no** requests to OAuth.

This should give confidence that Panda has verified your cookie.

### 2. Issuing
Open Story Packages.

In the DevTools, under the Application panel, you can find the Panda cookie. It has the name `gutoolsAuth-assym`:
![image](https://github.com/user-attachments/assets/58d54450-310d-4552-ac10-d8046145211f)

Delete the cookie, and refresh the page. You should see Workflow as normal[^2]. Check the network tab. You should see a request to OAuth. 

Check the Application tab again. You should have a new `gutoolsAuth-assym` cookie - though it looks very similar to the old one!

This should give confidence that Panda has issued you a cookie.

### 3. Pan-Domain
Open the other tool. 

You should see the tool as normal. Check your network tab - you should see **no** requests to OAuth.

This should give confidence that your new cookie (issued by Workflow) works across the domain[^3].

### 4. HMAC

You might want to also test that machine-to-machine Panda auth works as before. HMAC is used by the `/api/content/:composerId` endpoint in Workflow. To test this you will need to click import content in Workflow's create dropdown:
![image](https://github.com/user-attachments/assets/70933a88-c45a-49da-a4bd-459a5e0a2edd)

And paste a link from a Composer CODE article into the Content URL field:
![image](https://github.com/user-attachments/assets/d0270352-b530-4abd-8a1f-279561073657)

If you check the network tab you should see a successful request to https://composer.code.dev-gutools.co.uk/api/content/[COMPOSER-ID]?includePreview=true.


[^1]: You can also test this locally, but you will need to test with another local tool. CODE and local are scoped to different domains (`.code.dev-gutools.co.uk` and `.local.dev-gutools.co.uk`).
[^2]: If you are redirected to Google Auth, then your Auth session with Google may have expired. This is fine. Log in through Google Auth and repeat the test. If it _keeps_ directing you to Google Auth, then there may be an issue!
[^3]: If you check the Application tab in the other tool, you might find the cookie has changed! This is still the same cookie, but it has been slightly edited. Each tool you access with the cookie will be added to the cookie's `authedIn` list. The edits are hard to see as the cookie is encrypted. If you check the first tool again, you will see the cookie has stabilised.