### PR TITLE
First go: Add word count suggestions (no default, not mandatory)

### DIFF
--- a/public/components/punters/_punters.scss
+++ b/public/components/punters/_punters.scss
@@ -18,6 +18,10 @@
     }
 }
 
+.punters__button {
+    margin-top: -4px;
+}
+
 .punters__button--inline {
     display: inline-block;
     margin-left: 4px;

--- a/public/components/stub-modal/_stub-modal.scss
+++ b/public/components/stub-modal/_stub-modal.scss
@@ -82,3 +82,12 @@
 .help-block--invisible {
     visibility: hidden;
 }
+
+.commissioned-length-buttons {
+    margin-bottom: 4px;
+}
+
+.commissioned-length-suggestion {
+    margin-right: 3px;
+}
+

--- a/public/components/stub-modal/_stub-modal.scss
+++ b/public/components/stub-modal/_stub-modal.scss
@@ -83,6 +83,17 @@
     visibility: hidden;
 }
 
+.feedback-link, .feedback-link:hover, .feedback-link:visited, .feedback-link:focus {
+    color: black;
+    text-decoration: underline;
+}
+
+.feedback-title {
+    font-weight: normal;
+    font-size: 12px;
+    margin-left: 4px;
+}
+
 .commissioned-length-buttons {
     margin-bottom: 4px;
 }

--- a/public/components/stub-modal/_stub-modal.scss
+++ b/public/components/stub-modal/_stub-modal.scss
@@ -83,6 +83,10 @@
     visibility: hidden;
 }
 
+.commissioning-desk-margin, .section-margin, .format-dropdown {
+    margin-bottom: 15px;
+}
+
 .feedback-link, .feedback-link:hover, .feedback-link:visited, .feedback-link:focus {
     color: black;
     text-decoration: underline;
@@ -101,4 +105,3 @@
 .commissioned-length-suggestion {
     margin-right: 3px;
 }
-

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -52,13 +52,11 @@
                 </div>
                 <label for="commissionedLength">Commissioned Length</label>
                 <div class="commissioned-length-buttons">
-                    <button class="btn btn-default btn-sm" ng-model="stub.isBreakingNews" btn-radio="true" ng-click="resetCommissionedLength()">Breaking News</button>
                     <button
                         ng:repeat="commissionedLengthSuggestion in commissionedLengthSuggestions"
                         class="btn btn-default btn-sm commissioned-length-suggestion"
                         ng-model="stub.commissionedLength"
                         btn-radio="commissionedLengthSuggestion"
-                        ng-click="resetIsBreakingNews()"
                     >
                         {{ commissionedLengthSuggestion }}
                     </button>
@@ -70,7 +68,6 @@
                       type="number"
                       ng-model="stub.commissionedLength"
                       placeholder="Choose a custom commissioned length"
-                      ng-change="resetIsBreakingNews()"
                   />
                 </div>
             </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -54,13 +54,20 @@
                     <span class="feedback-title" title="Send Feedback">Send Feedback</span>
                 </a>
                 <div class="commissioned-length-buttons">
-                    <button class="btn btn-default btn-sm" ng-model="stub.isBreakingNews" btn-radio="true" ng-click="resetCommissionedLength()">Breaking News</button>
+                    <button
+                        class="btn btn-default btn-sm"
+                        ng-model="stub.missingCommissionedLengthReason"
+                        btn-radio="'BreakingNews'"
+                        ng-click="resetCommissionedLength()"
+                    >
+                        Breaking News
+                    </button>
                     <button
                         ng:repeat="commissionedLengthSuggestion in commissionedLengthSuggestions"
                         class="btn btn-default btn-sm commissioned-length-suggestion"
                         ng-model="stub.commissionedLength"
                         btn-radio="commissionedLengthSuggestion"
-                        ng-click="resetIsBreakingNews()"
+                        ng-click="resetMissingCommissionedLengthReason()"
                     >
                         {{ commissionedLengthSuggestion }}
                     </button>
@@ -72,7 +79,7 @@
                       type="number"
                       ng-model="stub.commissionedLength"
                       placeholder="Choose a custom commissioned length"
-                      ng-change="resetIsBreakingNews()"
+                      ng-change="resetMissingCommissionedLengthReason()"
                   />
                 </div>
             </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -51,8 +51,27 @@
                     <p class="help-block">Selecting commissioning info is temporarily unavailable</p>
                 </div>
                 <label for="commissionedLength">Commissioned Length</label>
+                <div class="commissioned-length-buttons">
+                    <button class="btn btn-default btn-sm" ng-model="stub.isBreakingNews" btn-radio="true" ng-click="resetCommissionedLength()">Breaking News</button>
+                    <button
+                        ng:repeat="commissionedLengthSuggestion in commissionedLengthSuggestions"
+                        class="btn btn-default btn-sm commissioned-length-suggestion"
+                        ng-model="stub.commissionedLength"
+                        btn-radio="commissionedLengthSuggestion"
+                        ng-click="resetIsBreakingNews()"
+                    >
+                        {{ commissionedLengthSuggestion }}
+                    </button>
+                </div>
                 <div>
-                  <input name="commissionedLength" type="number" ng-model="stub.commissionedLength"/>
+                  <input
+                      class="form-control"
+                      name="commissionedLength"
+                      type="number"
+                      ng-model="stub.commissionedLength"
+                      placeholder="Choose a custom commissioned length"
+                      ng-change="resetIsBreakingNews()"
+                  />
                 </div>
             </div>
             <div class="form-group pull-right col-xs-5">

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -13,7 +13,7 @@
             <input type="text" ng-model="formData.importUrl" ng-change="importUrlChanged()" id="import_url" name="import_url" class="form-control" required  wf-focus focus-me="{{ mode === 'import' }}">
         </div>
         <div class="form-horizontal clearfix">
-                <div ng-if="(showFormatDropdown && (stubFormat === 'Standard Article' || stubFormat === 'Key Takeaways' || stubFormat === 'Q&A Explainer' || stubFormat === 'Timeline' || stubFormat === 'Mini profiles'))">
+                <div class="format-dropdown" ng-if="(showFormatDropdown && (stubFormat === 'Standard Article' || stubFormat === 'Key Takeaways' || stubFormat === 'Q&A Explainer' || stubFormat === 'Timeline' || stubFormat === 'Mini profiles'))">
                 <label for="stub_format">Format</label>
                     <div>
                         <select id="stub_format" name="articleFormat" ng-model="stub.articleFormat" ng-options="f.value as f.name for f in articleFormats"></select>
@@ -43,12 +43,11 @@
             </div>
             <div class="form-group pull-left col-xs-8" ng-if="mode !== 'import' && contentName !== 'Atom'">
                 <label for="stub_cdesk">Commissioning info</label>
-
                 <div ng-if="cdesks.length > 0">
-                    <select id="stub_cdesk" name="cdesk" ng-model="stub.commissioningDesks" ng-options="cdesk.id.toString() as cdesk.externalName for cdesk in cdesks"></select>
+                    <select class="commissioning-desk-margin" id="stub_cdesk" name="cdesk" ng-model="stub.commissioningDesks" ng-options="cdesk.id.toString() as cdesk.externalName for cdesk in cdesks"></select>
                 </div>
                 <div ng-if="cdesks.length === 0">
-                    <p class="help-block">Selecting commissioning info is temporarily unavailable</p>
+                    <p class="commissioning-desk-margin">Selecting commissioning info is temporarily unavailable</p>
                 </div>
                 <label for="commissionedLength">Commissioned Length</label>
                 <a class="feedback-link"  href="https://docs.google.com/forms/d/e/1FAIpQLSeZje55T3OnErlTI_8iGuyZERjDy2Pybh8fdPmbnjy1PNFDAw/viewform" target="_blank">
@@ -80,7 +79,7 @@
             <div class="form-group pull-right col-xs-5">
                 <label for="stub_section">Section *</label>
                 <div>
-                    <select id="stub_section" name="section" ng-model="stub.section" ng-options="section.name for section in sections" required>
+                    <select class="section-margin" id="stub_section" name="section" ng-model="stub.section" ng-options="section.name for section in sections" required>
                     </select>
                 </div>
                 <div ng-if="contentName === 'Article'">

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -52,11 +52,13 @@
                 </div>
                 <label for="commissionedLength">Commissioned Length</label>
                 <div class="commissioned-length-buttons">
+                    <button class="btn btn-default btn-sm" ng-model="stub.isBreakingNews" btn-radio="true" ng-click="resetCommissionedLength()">Breaking News</button>
                     <button
                         ng:repeat="commissionedLengthSuggestion in commissionedLengthSuggestions"
                         class="btn btn-default btn-sm commissioned-length-suggestion"
                         ng-model="stub.commissionedLength"
                         btn-radio="commissionedLengthSuggestion"
+                        ng-click="resetIsBreakingNews()"
                     >
                         {{ commissionedLengthSuggestion }}
                     </button>
@@ -68,6 +70,7 @@
                       type="number"
                       ng-model="stub.commissionedLength"
                       placeholder="Choose a custom commissioned length"
+                      ng-change="resetIsBreakingNews()"
                   />
                 </div>
             </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -51,6 +51,9 @@
                     <p class="help-block">Selecting commissioning info is temporarily unavailable</p>
                 </div>
                 <label for="commissionedLength">Commissioned Length</label>
+                <a class="feedback-link"  href="https://docs.google.com/forms/d/e/1FAIpQLSeZje55T3OnErlTI_8iGuyZERjDy2Pybh8fdPmbnjy1PNFDAw/viewform" target="_blank">
+                    <span class="feedback-title" title="Send Feedback">Send Feedback</span>
+                </a>
                 <div class="commissioned-length-buttons">
                     <button class="btn btn-default btn-sm" ng-model="stub.isBreakingNews" btn-radio="true" ng-click="resetCommissionedLength()">Breaking News</button>
                     <button

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -261,11 +261,11 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     ]
 
     $scope.resetCommissionedLength = () => {
-        $scope.stub.commissionedLength = "";
+        $scope.stub.commissionedLength = null;
     }
 
-    $scope.resetIsBreakingNews = () => {
-        $scope.stub.isBreakingNews = false;
+    $scope.resetMissingCommissionedLengthReason = () => {
+        $scope.stub.missingCommissionedLengthReason = null;
     }
 
     $scope.submit = function (form) {

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -260,14 +260,6 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         1200,
     ]
 
-    $scope.resetCommissionedLength = () => {
-        $scope.stub.commissionedLength = "";
-    }
-
-    $scope.resetIsBreakingNews = () => {
-        $scope.stub.isBreakingNews = false;
-    }
-
     $scope.submit = function (form) {
         if (form.$invalid)
             return;  // Form is not ready to submit

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -260,6 +260,14 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         1200,
     ]
 
+    $scope.resetCommissionedLength = () => {
+        $scope.stub.commissionedLength = "";
+    }
+
+    $scope.resetIsBreakingNews = () => {
+        $scope.stub.isBreakingNews = false;
+    }
+
     $scope.submit = function (form) {
         if (form.$invalid)
             return;  // Form is not ready to submit

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -253,6 +253,21 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         }
     };
 
+    $scope.commissionedLengthSuggestions = [
+        350,
+        600,
+        900,
+        1200,
+    ]
+
+    $scope.resetCommissionedLength = () => {
+        $scope.stub.commissionedLength = "";
+    }
+
+    $scope.resetIsBreakingNews = () => {
+        $scope.stub.isBreakingNews = false;
+    }
+
     $scope.submit = function (form) {
         if (form.$invalid)
             return;  // Form is not ready to submit

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -111,14 +111,15 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService) {
         }
     }
 
-    this.create = function createInComposer(type, commissioningDesks, commissionedLength, prodOffice, template, articleFormat) {
+    this.create = function createInComposer(type, commissioningDesks, commissionedLength, prodOffice, template, articleFormat, missingCommissionedLengthReason) {
         var selectedDisplayHint = getDisplayHint(articleFormat);
         
         var params = {
             'type': getType(type),
             'tracking': commissioningDesks,
             'productionOffice': prodOffice,
-            'displayHint': selectedDisplayHint
+            'displayHint': selectedDisplayHint,
+            'missingCommissionedLengthReason': missingCommissionedLengthReason
         };
 
         if(commissionedLength) params['initialCommissionedLength'] = commissionedLength;

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -111,7 +111,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                  * Also will create the stub if it doesn't have an id.
                  */
                 createInComposer(stub, statusOption) {
-                    return wfComposerService.create(stub.contentType, stub.commissioningDesks, stub.commissionedLength, stub.prodOffice, stub.template, stub.articleFormat)
+                    return wfComposerService.create(stub.contentType, stub.commissioningDesks, stub.commissionedLength, stub.prodOffice, stub.template, stub.articleFormat, stub.missingCommissionedLengthReason)
                         .then((response) => wfComposerService.parseComposerData(response, stub))
                         .then((updatedStub) => {
 


### PR DESCRIPTION
## What does this change?

Adds word count (commissioned length) suggestions to the Create article field in Workflow.

| Before    | After |
| -------- | ------- |
| <img width="644" alt="image" src="https://github.com/user-attachments/assets/0322f2fb-b63a-48f5-909a-e56d2ae6f5ea">  |  <img width="644" alt="image" src="https://github.com/user-attachments/assets/4b4a98a2-7407-43ea-aa7b-f9e489907bae">  |

### Notes

This does not (yet) make word count mandatory. We want to see how the buttons perform first before rolling out that work.

Buttons are radio buttons (but without a default). The buttons are linked to the custom input, and vice versa, by the data model.

The feedback link re-uses our pre-existing form and opens in a new tab. The buttons should be tab-able.

Tidied up some margins while we're here - still not perfect, but less of an eyesore.

### How to test
I've [deployed](https://riffraff.gutools.co.uk/deployment/history?projectName=Editorial%20Tools%3A%3AWorkflow%3A%3AWorkflow%20Frontend&page=1) this branch to [CODE](https://workflow.code.dev-gutools.co.uk/dashboard). Play around with the UX. Does it create articles with the appropriate word counts?