### PR TITLE
Remove mini profiles feature switch

### DIFF
--- a/public/components/feature-switches/feature-switches.js
+++ b/public/components/feature-switches/feature-switches.js
@@ -21,8 +21,6 @@ function wfFeatureSwitchesDirective() {
     };
 }
 
-export const miniProfilesFeatureSwitchKey = 'miniProfiles';
-
 class FeatureSwitches {
     constructor(switches, entries) {
         // this.switches should be a single object with the type { [key]: value }
@@ -41,10 +39,8 @@ class FeatureSwitches {
 }
 
 function wfFeatureSwitchesController ($scope, wfPreferencesService) {
-    const featureSwitchKeys = [miniProfilesFeatureSwitchKey];
-    $scope.readableNames = {
-        [miniProfilesFeatureSwitchKey]: 'Mini profiles',
-    }
+    const featureSwitchKeys = [];
+    $scope.readableNames = {}
 
     const getDefaultFeatureSwitchValues = () => {
         const switches = {};

--- a/public/lib/article-format-service.js
+++ b/public/lib/article-format-service.js
@@ -12,10 +12,8 @@ define(['angular'], function (angular) {
                     {name: 'Key Takeaways', value: 'Key Takeaways'},
                     {name: 'Q&A Explainer', value: 'Q&A Explainer'},
                     {name: 'Timeline', value: 'Timeline'},
+                    {name: 'Mini profiles', value: 'Mini profiles'},
                 ]
-                if (featureSwitches && featureSwitches.miniProfiles){
-                    articleFormats.push({name: 'Mini profiles', value: 'Mini profiles'})
-                }
                 return articleFormats                    
             };
         return {

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -21,9 +21,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         "keyTakeaways": "Key Takeaways",
                         "qAndA": "Q&A Explainer",
                         "timeline": "Timeline",
-                    }
-                    if (featureSwitches && featureSwitches.miniProfiles){
-                        articleFormats.miniProfiles = "Mini profiles"
+                        "miniProfiles": "Mini profiles"
                     }
 
                     const nonArticleFormats = {


### PR DESCRIPTION
We're ready to roll out the Mini profiles format, which means removing the feature switch.

### How to review and test

Run workflow locally or on CODE. You should be able to create a Mini profiles article without having to activate a feature switch.