### PR TITLE
Forward body bytes rather than attempting to decode to utf-8

### DIFF
--- a/app/controllers/PreferencesProxy.scala
+++ b/app/controllers/PreferencesProxy.scala
@@ -38,7 +38,9 @@ class PreferencesProxy(
         val responseHeaders = response.headers.view.mapValues(_.head).toMap + (
           "Cache-Control" -> "private, no-cache, no-store, must-revalidate, max-age=0", // do not cache whatsoever
         )
-        new Status(response.status)(response.body).withHeaders(responseHeaders.toSeq: _*)
+        new Status(response.status)(response.bodyAsBytes)
+          .withHeaders(responseHeaders.removed("Content-Type").toSeq: _*)
+          .as(responseHeaders.getOrElse("Content-Type", "application/octet-stream"))
       }
       .recover {
         case _ if config.isDev =>


### PR DESCRIPTION
## What does this change?

This makes the proxy more transparent, by passing on the raw body bytes rather than attempting to decode as a utf-8 string first. This avoids issues when the origin returns compressed (e.g. brotli) responses. This will become an issue once we switch preferences to use Cloudfront.

The PR also updated the proxy to correctly forward on the content-type header, avoiding the logged error 
```
Explicitly set HTTP header 'Content-Type: application/json' is ignored, explicit `Content-Type` header is not allowed. Set `HttpResponse.entity.contentType` instead.
```

## Further detail

While testing https://github.com/guardian/editorial-tools-platform/pull/802, which adds cloudfront to preferences, I noticed that requests to https://workflow.code.dev-gutools.co.uk/preferences/david.furey@guardian.co.uk/workflow returned the rather strange error "Content decoding failed"

<img width="1316" alt="Screenshot 2024-08-22 at 10 42 39" src="https://github.com/user-attachments/assets/adfde11a-c020-4747-9c8c-219ffdec75ca">

I tried fetching the resource using curl, by using the helpful Chrome feature "Copy as cURL" to get the appropriate cookie values, but adding `-v` to show the response headers, and `-H 'Accept-Encoding: gzip, deflate, br, zstd'`. It seems that Chrome's Copy as cURL feature doesn't include the accept-encoding header, and it seemed that it might be important to keep it consistent since the original error was to do with content decoding.

The response that curl returned was binary data. I tried decoding it as gzip, deflate, br and zstd, but none worked.

I switched to debugging by running workflow-frontend locally, but pointing at preferences CODE. This doesn't naturally work, since the cookie that is forwarded is for LOCAL rather than CODE. So I temporarily modified `PreferencesProxy` to inject a valid CODE cookie (copy+pasted from chrome) when proxying.

Adding some logging, I could see that the response from preferences was also binary data, but that the raw bytes did validly decode as brotli.

## To test

* Ensure https://github.com/guardian/editorial-tools-platform/pull/802 is deployed.
* Deploy workflow-frontend main to CODE. See that https://workflow.code.dev-gutools.co.uk/preferences/david.furey@guardian.co.uk/workflow returns a content decoding failure in dev tools
* Deploy this branch to CODE. See that https://workflow.code.dev-gutools.co.uk/preferences/david.furey@guardian.co.uk/workflow returns some valid JSON
