### PR TITLE
Add originatingSystem=workflow on created content

### DIFF
--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -118,7 +118,8 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService) {
             'type': getType(type),
             'tracking': commissioningDesks,
             'productionOffice': prodOffice,
-            'displayHint': selectedDisplayHint
+            'displayHint': selectedDisplayHint,
+            'originatingSystem': 'workflow'
         };
 
         if(commissionedLength) params['initialCommissionedLength'] = commissionedLength;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Workflow-created content does not add 'originatingSystem'; every other known article-creating tool does, and workflow is the most-used originator

## Have we considered potential risks?

Do we consider workflow the originating system for this content? It's a bit different to incopy, MAM, R2 etc. where the content is authored there, and then pushed into composer for mild editing and publishing.