### PR TITLE
required commission length (unless 'breaking news') for articles

### DIFF
--- a/public/components/stub-modal/_stub-modal.scss
+++ b/public/components/stub-modal/_stub-modal.scss
@@ -105,3 +105,7 @@
 .commissioned-length-suggestion {
     margin-right: 3px;
 }
+
+.breaking-news {
+    margin-left: -3px;
+}

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -55,17 +55,28 @@
                 </a>
                 <div class="commissioned-length-buttons">
                     <button
+                        class="btn btn-default btn-sm"
+                        ng-model="stub.missingCommissionedLengthReason"
+                        btn-radio="'BreakingNews'"
+                        ng-click="resetCommissionedLength()"
+                    >
+                        Breaking News
+                    </button>
+                    <button
                         ng:repeat="commissionedLengthSuggestion in commissionedLengthSuggestions"
                         class="btn btn-default btn-sm commissioned-length-suggestion"
                         ng-model="stub.commissionedLength"
                         btn-radio="commissionedLengthSuggestion"
-                        ng-click="sendTelemetry(commissionedLengthSuggestion)"
+                        ng-click="
+                            resetMissingCommissionedLengthReason();
+                            sendTelemetry(commissionedLengthSuggestion);
+                        "
                     >
                         {{ commissionedLengthSuggestion }}
                     </button>
                 </div>
                 <div>
-                  <input ng-if="isCommissionedLengthRequired()"
+                  <input
                     class="form-control"
                     name="commissionedLength"
                     min="0"
@@ -74,17 +85,8 @@
                     string-to-number
                     ng-model="stub.commissionedLength"
                     placeholder="Choose a custom commissioned length"
-                    required
-                  />
-                  <input ng-if="!isCommissionedLengthRequired()"
-                    class="form-control"
-                    name="commissionedLength"
-                    min="0"
-                    step="50"
-                    type="number"
-                    string-to-number
-                    ng-model="stub.commissionedLength"
-                    placeholder="Choose a custom commissioned length"
+                    ng-change="resetMissingCommissionedLengthReason()"
+                    ng-required="requiredAttrForCommissionedLength()"
                   />
                 </div>
             </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -173,9 +173,10 @@
             <button type="button" class="btn btn-default" id="testing-create-stub" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
                 Save stub
             </button>
-            <button  type="button" 
+            <button
+                type="button"
                 class="btn btn-primary" 
-                ng-class="{ 'disabled': disabled || stubForm.$invalid }" 
+                ng-class="{ 'disabled': disabled || stubForm.$invalid || warningMessages.length > 0 }"
                 id="testing-create-in-composer" 
                 ng-click="submit(stubForm)" 
                 ng-show="stub.status !== 'Stub' && contentName !== 'Atom'">

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -49,48 +49,51 @@
                 <div ng-if="cdesks.length === 0">
                     <p class="commissioning-desk-margin">Selecting commissioning info is temporarily unavailable</p>
                 </div>
-                <label for="commissionedLength">Commissioned Length <span ng-if="isCommissionedLengthRequired()">*</span></label>
-                <a class="feedback-link"  href="https://docs.google.com/forms/d/e/1FAIpQLSeZje55T3OnErlTI_8iGuyZERjDy2Pybh8fdPmbnjy1PNFDAw/viewform" target="_blank">
-                    <span class="feedback-title" title="Send Feedback">Send Feedback</span>
-                </a>
-                <div class="commissioned-length-buttons">
-                    <button
-                        class="btn btn-default btn-sm"
-                        ng-model="stub.missingCommissionedLengthReason"
-                        btn-radio="'BreakingNews'"
-                        ng-click="resetCommissionedLength()"
-                        type="button"
-                    >
-                        Breaking News
-                    </button>
-                    <button
-                        ng:repeat="commissionedLengthSuggestion in commissionedLengthSuggestions"
-                        class="btn btn-default btn-sm commissioned-length-suggestion"
-                        ng-model="stub.commissionedLength"
-                        btn-radio="commissionedLengthSuggestion"
-                        type="button"
-                        ng-click="
-                            resetMissingCommissionedLengthReason();
-                            sendTelemetry(commissionedLengthSuggestion);
-                        "
-                    >
-                        {{ commissionedLengthSuggestion }}
-                    </button>
-                </div>
-                <div>
-                  <input
-                    class="form-control"
-                    name="commissionedLength"
-                    min="0"
-                    step="50"
-                    type="number"
-                    string-to-number
-                    ng-model="stub.commissionedLength"
-                    placeholder="Choose a custom commissioned length"
-                    ng-change="resetMissingCommissionedLengthReason()"
-                    ng-required="requiredAttrForCommissionedLength()"
-                  />
-                </div>
+
+                <section style="display: contents;" ng-if="isCommissionedLengthRequired()" >
+                    <label for="commissionedLength">Commissioned Length <span ng-if="isCommissionedLengthRequired()">*</span></label>
+                    <a class="feedback-link"  href="https://docs.google.com/forms/d/e/1FAIpQLSeZje55T3OnErlTI_8iGuyZERjDy2Pybh8fdPmbnjy1PNFDAw/viewform" target="_blank">
+                        <span class="feedback-title" title="Send Feedback">Send Feedback</span>
+                    </a>
+                    <div class="commissioned-length-buttons">
+                        <button
+                            class="btn btn-default btn-sm"
+                            ng-model="stub.missingCommissionedLengthReason"
+                            btn-radio="'BreakingNews'"
+                            ng-click="resetCommissionedLength()"
+                            type="button"
+                        >
+                            Breaking News
+                        </button>
+                        <button
+                            ng:repeat="commissionedLengthSuggestion in commissionedLengthSuggestions"
+                            class="btn btn-default btn-sm commissioned-length-suggestion"
+                            ng-model="stub.commissionedLength"
+                            btn-radio="commissionedLengthSuggestion"
+                            type="button"
+                            ng-click="
+                                resetMissingCommissionedLengthReason();
+                                sendTelemetry(commissionedLengthSuggestion);
+                            "
+                        >
+                            {{ commissionedLengthSuggestion }}
+                        </button>
+                    </div>
+                    <div>
+                        <input
+                            class="form-control"
+                            name="commissionedLength"
+                            min="0"
+                            step="50"
+                            type="number"
+                            string-to-number
+                            ng-model="stub.commissionedLength"
+                            placeholder="Choose a custom commissioned length"
+                            ng-change="resetMissingCommissionedLengthReason()"
+                            ng-required="requiredAttrForCommissionedLength()"
+                        />
+                    </div>
+                </section>
             </div>
             <div class="form-group pull-right col-xs-5">
                 <label for="stub_section">Section *</label>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -49,7 +49,7 @@
                 <div ng-if="cdesks.length === 0">
                     <p class="commissioning-desk-margin">Selecting commissioning info is temporarily unavailable</p>
                 </div>
-                <label for="commissionedLength">Commissioned Length</label>
+                <label for="commissionedLength">Commissioned Length *</label>
                 <a class="feedback-link"  href="https://docs.google.com/forms/d/e/1FAIpQLSeZje55T3OnErlTI_8iGuyZERjDy2Pybh8fdPmbnjy1PNFDAw/viewform" target="_blank">
                     <span class="feedback-title" title="Send Feedback">Send Feedback</span>
                 </a>
@@ -142,6 +142,11 @@
         <div class="pull-left">
             <button type="button" class="btn btn-default pull-left" data-dismiss="modal" ng-click="delete()" ng-if="stub.id">Delete</button>
             <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="cancel()">Cancel</button>
+            <span ng-if="warningMessages">
+                
+                <span  ng-repeat="message in warningMessages">{{ message }} </span>
+                
+            </span>
         </div>
         <div class="pull-right">
             <button type="button" class="btn btn-default" id="testing-create-stub" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -57,18 +57,6 @@
                     </a>
                     <div class="commissioned-length-buttons">
                         <button
-                            class="btn btn-default btn-sm"
-                            ng-model="stub.missingCommissionedLengthReason"
-                            btn-radio="'BreakingNews'"
-                            ng-click="
-                                resetCommissionedLength();
-                                sendTelemetry(0, 'BreakingNews');
-                            "
-                            type="button"
-                        >
-                            Breaking News
-                        </button>
-                        <button
                             ng:repeat="commissionedLengthSuggestion in commissionedLengthSuggestions"
                             class="btn btn-default btn-sm commissioned-length-suggestion"
                             ng-model="stub.commissionedLength"
@@ -80,6 +68,18 @@
                             "
                         >
                             {{ commissionedLengthSuggestion }}
+                        </button>
+                        <button
+                            class="btn btn-default btn-sm breaking-news"
+                            ng-model="stub.missingCommissionedLengthReason"
+                            btn-radio="'BreakingNews'"
+                            ng-click="
+                                resetCommissionedLength();
+                                sendTelemetry(0, 'BreakingNews');
+                            "
+                            type="button"
+                        >
+                            Breaking News
                         </button>
                     </div>
                     <div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -60,7 +60,10 @@
                             class="btn btn-default btn-sm"
                             ng-model="stub.missingCommissionedLengthReason"
                             btn-radio="'BreakingNews'"
-                            ng-click="resetCommissionedLength()"
+                            ng-click="
+                                resetCommissionedLength();
+                                sendTelemetry(0, 'BreakingNews');
+                            "
                             type="button"
                         >
                             Breaking News

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -68,6 +68,8 @@
                   <input ng-if="isCommissionedLengthRequired()"
                     class="form-control"
                     name="commissionedLength"
+                    min="0"
+                    step="50"
                     type="number"
                     string-to-number
                     ng-model="stub.commissionedLength"
@@ -77,6 +79,8 @@
                   <input ng-if="!isCommissionedLengthRequired()"
                     class="form-control"
                     name="commissionedLength"
+                    min="0"
+                    step="50"
                     type="number"
                     string-to-number
                     ng-model="stub.commissionedLength"
@@ -159,7 +163,12 @@
             <button type="button" class="btn btn-default" id="testing-create-stub" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
                 Save stub
             </button>
-            <button type="button" class="btn btn-primary" id="testing-create-in-composer" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status !== 'Stub' && contentName !== 'Atom'">
+            <button  type="button" 
+                class="btn btn-primary" 
+                ng-class="{ 'disabled': disabled || stubForm.$invalid }" 
+                id="testing-create-in-composer" 
+                ng-click="submit(stubForm)" 
+                ng-show="stub.status !== 'Stub' && contentName !== 'Atom'">
                 Create new
             </button>
             <button type="button" class="btn btn-primary" id="testing-create-atom" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="contentName === 'Atom' && stub.status !== 'Stub'">

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -49,7 +49,7 @@
                 <div ng-if="cdesks.length === 0">
                     <p class="commissioning-desk-margin">Selecting commissioning info is temporarily unavailable</p>
                 </div>
-                <label for="commissionedLength">Commissioned Length *</label>
+                <label for="commissionedLength">Commissioned Length <span ng-if="isCommissionedLengthRequired()">*</span></label>
                 <a class="feedback-link"  href="https://docs.google.com/forms/d/e/1FAIpQLSeZje55T3OnErlTI_8iGuyZERjDy2Pybh8fdPmbnjy1PNFDAw/viewform" target="_blank">
                     <span class="feedback-title" title="Send Feedback">Send Feedback</span>
                 </a>
@@ -65,13 +65,22 @@
                     </button>
                 </div>
                 <div>
-                  <input
-                      class="form-control"
-                      name="commissionedLength"
-                      type="number"
-                      string-to-number
-                      ng-model="stub.commissionedLength"
-                      placeholder="Choose a custom commissioned length"
+                  <input ng-if="isCommissionedLengthRequired()"
+                    class="form-control"
+                    name="commissionedLength"
+                    type="number"
+                    string-to-number
+                    ng-model="stub.commissionedLength"
+                    placeholder="Choose a custom commissioned length"
+                    required
+                  />
+                  <input ng-if="!isCommissionedLengthRequired()"
+                    class="form-control"
+                    name="commissionedLength"
+                    type="number"
+                    string-to-number
+                    ng-model="stub.commissionedLength"
+                    placeholder="Choose a custom commissioned length"
                   />
                 </div>
             </div>
@@ -142,13 +151,11 @@
         <div class="pull-left">
             <button type="button" class="btn btn-default pull-left" data-dismiss="modal" ng-click="delete()" ng-if="stub.id">Delete</button>
             <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="cancel()">Cancel</button>
-            <span ng-if="warningMessages">
-                
-                <span  ng-repeat="message in warningMessages">{{ message }} </span>
-                
-            </span>
         </div>
         <div class="pull-right">
+            <span ng-if="warningMessages">
+                <span ng-repeat="message in warningMessages">{{ message }} </span>
+            </span>
             <button type="button" class="btn btn-default" id="testing-create-stub" ng-click="submit(stubForm)" ng-disabled="disabled || stubForm.$invalid " ng-show="stub.status === 'Stub'">
                 Save stub
             </button>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -59,6 +59,7 @@
                         ng-model="stub.missingCommissionedLengthReason"
                         btn-radio="'BreakingNews'"
                         ng-click="resetCommissionedLength()"
+                        type="button"
                     >
                         Breaking News
                     </button>
@@ -67,6 +68,7 @@
                         class="btn btn-default btn-sm commissioned-length-suggestion"
                         ng-model="stub.commissionedLength"
                         btn-radio="commissionedLengthSuggestion"
+                        type="button"
                         ng-click="
                             resetMissingCommissionedLengthReason();
                             sendTelemetry(commissionedLengthSuggestion);

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -16,7 +16,7 @@ import 'lib/filters-service';
 import 'lib/prodoffice-service';
 import 'lib/telemetry-service';
 import { punters } from 'components/punters/punters';
-import { generateErrorMessages } from '../../lib/stub-form-validation.ts';
+import { generateErrorMessages, isCommissionedLengthRequired } from '../../lib/stub-form-validation.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -166,6 +166,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         $scope.warningMessages = generateErrorMessages(newStub)
     }, true)
 
+    $scope.isCommissionedLengthRequired = () => isCommissionedLengthRequired($scope.stub.contentType)
+
     /* when a request is made to import an item from another tool,
      * e.g. composer or an atom editor, then we will check to see if
      * it is already being tracked by Workflow. If, this function will
@@ -277,13 +279,16 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     }
 
     $scope.submit = function (form) {
-        if (form.$invalid)
+        if (form.$invalid) {
             return;  // Form is not ready to submit
+        }
         if ($scope.actionSuccess) { // Form has already been submitted successfully
-            if ($scope.composerUrl)
+            if ($scope.composerUrl) {
                 window.open($scope.composerUrl, "_blank");
-            if ($scope.editorUrl)
+            }
+            if ($scope.editorUrl) {
                 window.open($scope.editorUrl, "_blank");
+            }
             $scope.cancel()
         }
         else {
@@ -295,7 +300,6 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
 
     $scope.ok = function (addToComposer, addToAtomEditor) {
         const stub = $scope.stub;
-        console.log("stub", stub)
         function createItemPromise() {
             if ($scope.contentName === 'Atom') {
                 stub.contentType = $scope.stub.contentType.toLowerCase();

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -16,6 +16,7 @@ import 'lib/filters-service';
 import 'lib/prodoffice-service';
 import 'lib/telemetry-service';
 import { punters } from 'components/punters/punters';
+import { generateErrorMessages } from '../../lib/stub-form-validation.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -159,6 +160,11 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
 
     $scope.validImport = false;
     $scope.wfComposerState;
+
+    $scope.warningMessages = undefined
+    $scope.$watch('stub', (newStub) => {
+        $scope.warningMessages = generateErrorMessages(newStub)
+    }, true)
 
     /* when a request is made to import an item from another tool,
      * e.g. composer or an atom editor, then we will check to see if

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -16,7 +16,7 @@ import 'lib/filters-service';
 import 'lib/prodoffice-service';
 import 'lib/telemetry-service';
 import { punters } from 'components/punters/punters';
-import { generateErrorMessages, isCommissionedLengthRequired } from '../../lib/stub-form-validation.ts';
+import { generateErrorMessages, doesContentTypeRequireCommissionedLength, useNativeFormFeedback } from '../../lib/stub-form-validation.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -166,9 +166,9 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         $scope.warningMessages = generateErrorMessages(newStub)
     }, true)
 
-    $scope.isCommissionedLengthRequired = () => isCommissionedLengthRequired($scope.stub.contentType)
+    $scope.isCommissionedLengthRequired = () => doesContentTypeRequireCommissionedLength($scope.stub.contentType)
 
-    $scope.requiredAttrForCommissionedLength = () => isCommissionedLengthRequired($scope.stub.contentType) && !$scope.stub.missingCommissionedLengthReason ? 'true' : null
+    $scope.requiredAttrForCommissionedLength = () => doesContentTypeRequireCommissionedLength($scope.stub.contentType) && !$scope.stub.missingCommissionedLengthReason ? 'true' : null
 
     /* when a request is made to import an item from another tool,
      * e.g. composer or an atom editor, then we will check to see if
@@ -289,10 +289,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     }
 
     $scope.submit = function (form) {
-        const formElement = document.querySelector('form[name=stubForm]')
-        console.log($scope.stub)
         if (form.$invalid) {
-            formElement?.reportValidity()
+            useNativeFormFeedback($scope.stub)
             return;  // Form is not ready to submit
         }
         if ($scope.actionSuccess) { // Form has already been submitted successfully

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -168,6 +168,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
 
     $scope.isCommissionedLengthRequired = () => isCommissionedLengthRequired($scope.stub.contentType)
 
+    $scope.requiredAttrForCommissionedLength = () => isCommissionedLengthRequired($scope.stub.contentType) && !$scope.stub.missingCommissionedLengthReason ? 'true' : null
+
     /* when a request is made to import an item from another tool,
      * e.g. composer or an atom editor, then we will check to see if
      * it is already being tracked by Workflow. If, this function will
@@ -262,6 +264,14 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         }
     };
 
+    $scope.resetCommissionedLength = () => {
+        $scope.stub.commissionedLength = null;
+    }
+
+    $scope.resetMissingCommissionedLengthReason = () => {
+        $scope.stub.missingCommissionedLengthReason = null;
+    }
+
     $scope.commissionedLengthSuggestions = [
         400,
         650,
@@ -280,6 +290,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
 
     $scope.submit = function (form) {
         const formElement = document.querySelector('form[name=stubForm]')
+        console.log($scope.stub)
         if (form.$invalid) {
             formElement?.reportValidity()
             return;  // Form is not ready to submit

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -279,7 +279,9 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     }
 
     $scope.submit = function (form) {
+        const formElement = document.querySelector('form[name=stubForm]')
         if (form.$invalid) {
+            formElement?.reportValidity()
             return;  // Form is not ready to submit
         }
         if ($scope.actionSuccess) { // Form has already been submitted successfully

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -166,7 +166,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         $scope.warningMessages = generateErrorMessages(newStub)
     }, true)
 
-    $scope.isCommissionedLengthRequired = () => doesContentTypeRequireCommissionedLength($scope.stub.contentType)
+    $scope.isCommissionedLengthRequired = () => doesContentTypeRequireCommissionedLength($scope.stub.contentType);
 
     $scope.requiredAttrForCommissionedLength = () => doesContentTypeRequireCommissionedLength($scope.stub.contentType) && !$scope.stub.missingCommissionedLengthReason ? 'true' : null
 

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -279,11 +279,17 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         1200,
     ]
 
-    $scope.sendTelemetry = (value) => {
+    $scope.sendTelemetry = (value, missingCommissionedLengthReason = null) => {
         const commissioningDesk = $scope.cdesks.find(desk  => desk.id.toString() === stub.commissioningDesks)?.externalName;
+        const tags = {
+            contentId: stub.id,
+            productionOffice: stub.prodOffice,
+            commissioningDesk
+        }
+        if (missingCommissionedLengthReason) tags['missingCommissionedLengthReason'] = missingCommissionedLengthReason;
         wfTelemetryService.sendTelemetryEvent(
             "WORKFLOW_COMMISSIONED_LENGTH_SUGGESTION_PRESSED",
-            { contentId: stub.id, productionOffice: stub.prodOffice, commissioningDesk },
+            tags,
             value
         )
     }

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -112,7 +112,7 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
         }
     }
 
-    this.create = function createInComposer(type, commissioningDesks, commissionedLength, prodOffice, template, articleFormat, priority) {
+    this.create = function createInComposer(type, commissioningDesks, commissionedLength, prodOffice, template, articleFormat, priority, missingCommissionedLengthReason) {
         var selectedDisplayHint = getDisplayHint(articleFormat);
         
         var params = {
@@ -124,7 +124,8 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
         };
 
         if(commissionedLength) params['initialCommissionedLength'] = commissionedLength;
-        
+        if(missingCommissionedLengthReason) params['missingCommissionedLengthReason'] = missingCommissionedLengthReason;
+
         if(template) {
             params['template'] = template.id;
         }

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -146,14 +146,16 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
             }
         }
 
-        wfTelemetryService.sendTelemetryEvent("WORKFLOW_CREATE_IN_COMPOSER_TRIGGERED", {
+        const tags = {
             contentType: getType(type),
             displayHint: selectedDisplayHint,
             commissionedLength,
             productionOffice: prodOffice,
             commissioningDesk: commissioningDeskExternalName,
             priority: getPriorityName(priority),
-        })
+        }
+        if(missingCommissionedLengthReason) tags.missingCommissionedLengthReason = missingCommissionedLengthReason;
+        wfTelemetryService.sendTelemetryEvent("WORKFLOW_CREATE_IN_COMPOSER_TRIGGERED", tags);
 
         return request({
             method: 'POST',

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -113,6 +113,21 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         .then((response) => wfComposerService.parseComposerData(response, stub))
                         .then((updatedStub) => {
 
+                            // log uses of the missingCommissionedLengthReason option
+                            if (stub.missingCommissionedLengthReason) {
+                                const data = {
+                                    message: `Draft created without commissionedLength: ${stub.missingCommissionedLengthReason}`,
+                                    missingCommissionedLengthReason: stub.missingCommissionedLengthReason,
+                                    composerId: updatedStub.composerId ?? null,
+                                    prodOffice: updatedStub.prodOffice,
+                                    contentType: updatedStub.contentType,
+                                    section: updatedStub.section?.name,
+                                    title: updatedStub.title,
+                                }
+                                $log.info(JSON.stringify(data))
+                            }
+
+
                             if (statusOption) {
                                 updatedStub['status'] = statusOption;
                             }

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -109,7 +109,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                  * Also will create the stub if it doesn't have an id.
                  */
                 createInComposer(stub, statusOption) {
-                    return wfComposerService.create(stub.contentType, stub.commissioningDesks, stub.commissionedLength, stub.prodOffice, stub.template, stub.articleFormat, stub.priority)
+                    return wfComposerService.create(stub.contentType, stub.commissioningDesks, stub.commissionedLength, stub.prodOffice, stub.template, stub.articleFormat, stub.priority, stub.missingCommissionedLengthReason)
                         .then((response) => wfComposerService.parseComposerData(response, stub))
                         .then((updatedStub) => {
 

--- a/public/lib/model/stub.ts
+++ b/public/lib/model/stub.ts
@@ -1,0 +1,40 @@
+export type ContentType =
+  | "article"
+  | "liveblog"
+  | "gallery"
+  | "interactive"
+  | "picture"
+  | "video"
+  | "audio";
+
+export type Stub = {
+  contentType: ContentType;
+  commissionedLength?: number;
+};
+
+/*
+TO DO - model the rest of the Stub
+{
+    "articleFormat": "Standard Article",
+    "contentType": "article",
+    "section": {
+        "name": "Cities",
+        "selected": false,
+        "id": 1,
+        "$$hashKey": "object:59"
+    },
+    "priority": 0,
+    "needsLegal": "NA",
+    "needsPictureDesk": "NA",
+    "prodOffice": "UK",
+    "status": "Writers",
+    "title": "for",
+    "template": {
+        "id": "Comments test_2015-04-17T15:10:53.356",
+        "display": "Comments test - 17th April 2015",
+        "$$hashKey": "object:1736"
+    },
+    "due": "2024-10-08T00:05:00.000Z"
+}
+
+*/

--- a/public/lib/model/stub.ts
+++ b/public/lib/model/stub.ts
@@ -11,35 +11,18 @@ export type ContentType =
   | "timeline"
   | "miniProfiles";
 
+type FlagValue = "NA" | "REQUIRED" | "COMPLETE";
+
 export type Stub = {
+  title?: string;
+  articleFormat?: string;
   contentType: ContentType;
   commissionedLength?: number;
   missingCommissionedLengthReason?: string | null | undefined;
+  needsLegal?: FlagValue;
+  needsPictureDesk?: FlagValue;
+  priority?: number;
+  prodOffice?: string;
+  note?: string;
 };
 
-/*
-TO DO - model the rest of the Stub
-{
-    "articleFormat": "Standard Article",
-    "contentType": "article",
-    "section": {
-        "name": "Cities",
-        "selected": false,
-        "id": 1,
-        "$$hashKey": "object:59"
-    },
-    "priority": 0,
-    "needsLegal": "NA",
-    "needsPictureDesk": "NA",
-    "prodOffice": "UK",
-    "status": "Writers",
-    "title": "for",
-    "template": {
-        "id": "Comments test_2015-04-17T15:10:53.356",
-        "display": "Comments test - 17th April 2015",
-        "$$hashKey": "object:1736"
-    },
-    "due": "2024-10-08T00:05:00.000Z"
-}
-
-*/

--- a/public/lib/model/stub.ts
+++ b/public/lib/model/stub.ts
@@ -5,7 +5,11 @@ export type ContentType =
   | "interactive"
   | "picture"
   | "video"
-  | "audio";
+  | "audio"
+  | "keyTakeaways"
+  | "qAndA"
+  | "timeline"
+  | "miniProfiles";
 
 export type Stub = {
   contentType: ContentType;

--- a/public/lib/model/stub.ts
+++ b/public/lib/model/stub.ts
@@ -10,6 +10,7 @@ export type ContentType =
 export type Stub = {
   contentType: ContentType;
   commissionedLength?: number;
+  missingCommissionedLengthReason?: string | null | undefined;
 };
 
 /*

--- a/public/lib/stub-form-validation.ts
+++ b/public/lib/stub-form-validation.ts
@@ -5,7 +5,22 @@ const MESSAGING = {
 };
 
 const doesContentTypeRequireCommissionedLength = (contentType: ContentType) => {
-  return ["interactive", "article"].includes(contentType);
+  switch (contentType) {
+    case "liveblog":
+    case "gallery":
+    case "picture":
+    case "video":
+    case "audio":
+      return false;
+    case "article":
+    case "interactive":
+    case "keyTakeaways":
+    case "qAndA":
+    case "timeline":
+    case "miniProfiles":
+    default:
+      return true;
+  }
 };
 
 const stubIsMissingRequiredLength = (stub: Stub) =>

--- a/public/lib/stub-form-validation.ts
+++ b/public/lib/stub-form-validation.ts
@@ -1,0 +1,21 @@
+import { ContentType, Stub } from "./model/stub";
+
+const isCommissionedLengthRequired = (contentType: ContentType) => {
+  return ["interactive", "article"].includes(contentType);
+};
+
+const generateErrorMessages = (stub: Stub): string[] | undefined => {
+  const errors: string[] = [];
+
+  if (
+    isCommissionedLengthRequired(stub.contentType) &&
+    !stub.commissionedLength
+  ) {
+    errors.push("A commissioned length is required");
+  }
+
+  console.log(errors)
+  return errors.length > 0 ? errors : undefined;
+};
+
+export { generateErrorMessages };

--- a/public/lib/stub-form-validation.ts
+++ b/public/lib/stub-form-validation.ts
@@ -1,20 +1,52 @@
 import { ContentType, Stub } from "./model/stub";
 
-const isCommissionedLengthRequired = (contentType: ContentType) => {
+const MESSAGING = {
+  commissionLengthRequired: "A commissioned length is required",
+};
+
+const doesContentTypeRequireCommissionedLength = (contentType: ContentType) => {
   return ["interactive", "article"].includes(contentType);
 };
 
+const stubIsMissingRequiredLength = (stub: Stub) =>
+  doesContentTypeRequireCommissionedLength(stub.contentType) &&
+  !stub.commissionedLength &&
+  !stub.missingCommissionedLengthReason;
+
 const generateErrorMessages = (stub: Stub): string[] | undefined => {
   const errors: string[] = [];
-
-  if (
-    isCommissionedLengthRequired(stub.contentType) &&
-    !stub.commissionedLength
-  ) {
-    errors.push("A commissioned length is required");
+  if (stubIsMissingRequiredLength(stub)) {
+    errors.push(MESSAGING.commissionLengthRequired);
   }
-
   return errors.length > 0 ? errors : undefined;
 };
 
-export { generateErrorMessages, isCommissionedLengthRequired };
+const useNativeFormFeedback = (stub: Stub) => {
+  const formElement = document.querySelector<HTMLFormElement>(
+    "form[name=stubForm]"
+  );
+  if (!formElement) {
+    return;
+  }
+
+  const commissionedLengthInput = formElement.querySelector<HTMLInputElement>(
+    "input[name=commissionedLength]"
+  );
+  if (commissionedLengthInput) {
+    if (stubIsMissingRequiredLength(stub)) {
+      commissionedLengthInput.setCustomValidity(
+        MESSAGING.commissionLengthRequired
+      );
+    } else {
+      commissionedLengthInput.setCustomValidity("");
+    }
+  }
+
+  formElement.reportValidity();
+};
+
+export {
+  generateErrorMessages,
+  doesContentTypeRequireCommissionedLength,
+  useNativeFormFeedback,
+};

--- a/public/lib/stub-form-validation.ts
+++ b/public/lib/stub-form-validation.ts
@@ -14,8 +14,7 @@ const generateErrorMessages = (stub: Stub): string[] | undefined => {
     errors.push("A commissioned length is required");
   }
 
-  console.log(errors)
   return errors.length > 0 ? errors : undefined;
 };
 
-export { generateErrorMessages };
+export { generateErrorMessages, isCommissionedLengthRequired };

--- a/public/lib/stub-form-validation.ts
+++ b/public/lib/stub-form-validation.ts
@@ -2,6 +2,7 @@ import { ContentType, Stub } from "./model/stub";
 
 const MESSAGING = {
   commissionLengthRequired: "A commissioned length is required",
+  commissionLengthMinimum: "Commissioned length must be greater than zero"
 };
 
 const doesContentTypeRequireCommissionedLength = (contentType: ContentType) => {
@@ -28,10 +29,18 @@ const stubIsMissingRequiredLength = (stub: Stub) =>
   !stub.commissionedLength &&
   !stub.missingCommissionedLengthReason;
 
+const stubHasInvalidCommissionedLength = (stub: Stub) =>
+    doesContentTypeRequireCommissionedLength(stub.contentType) &&
+    stub.commissionedLength &&
+    stub.commissionedLength <= 0;
+
 const generateErrorMessages = (stub: Stub): string[] | undefined => {
   const errors: string[] = [];
   if (stubIsMissingRequiredLength(stub)) {
     errors.push(MESSAGING.commissionLengthRequired);
+  }
+  if(stubHasInvalidCommissionedLength(stub)) {
+    errors.push(MESSAGING.commissionLengthMinimum);
   }
   return errors.length > 0 ? errors : undefined;
 };
@@ -48,9 +57,13 @@ const useNativeFormFeedback = (stub: Stub) => {
     "input[name=commissionedLength]"
   );
   if (commissionedLengthInput) {
-    if (stubIsMissingRequiredLength(stub)) {
+     if (stubIsMissingRequiredLength(stub)) {
       commissionedLengthInput.setCustomValidity(
         MESSAGING.commissionLengthRequired
+      );
+    } else if(stubHasInvalidCommissionedLength(stub)) {
+      commissionedLengthInput.setCustomValidity(
+        MESSAGING.commissionLengthMinimum
       );
     } else {
       commissionedLengthInput.setCustomValidity("");


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
- Adds the "breaking news" button next the the pre-set commissioned length buttons (following @Fweddi 's idea in https://github.com/guardian/workflow-frontend/compare/main...fp/add-breaking-news-button-for-commissioned-length, this sets a property called `stub.missingCommissionedLengthReason` )
- Removes the whole commissioned length sections for `contentType`s where the value is not required,IE:
  - liveblog
  - gallery
  - picture
  - video
  - audio
- On the remaining `contentType`s, the user is required to either set a commissioned length OR a missingCommissionedLengthReason (using the "breaking news" button )
- when a piece is created with a `missingCommissionedLengthReason` the event is tracked in the logs (with the composerId)
- The UI includes validation messages if the user attempts to submit the form while it is incomplete.

Note that the validation is client-side only and the `missingCommissionedLengthReason` is not yet persisted after the content & stub are created.

## How to test

If running locally - run [github.com/guardian/flexible-content](composer) and [workflow](https://github.com/guardian/workflow) as well as this project.

### breaking news (no commissioned length)
 - open the workflow dashboard, click "create new" and select "article" or one of the special formats "key takeaways" etc.
 - the "commissioned length" section will be marked with an asterisk to indicate it is 'required' and the 'breaking news' button will be rendered with the number buttons. The "a commissioned length is required" message will show near the (disabled) submit button
 - add a title and click "submit" - the browser native validation UI should indicate that the commissioned length field need to be complete
 - click 'breaking news' - the button will show the 'selected' state, but the number field will remain empty 
 -  type a number in the field - 'breaking news'  button will loose the 'selected' state. delete the number in the field. The "a commissioned length is required" message will come back
 - click 'breaking news' again
 - click submit and the piece should be created and openable in composer as normal

### content requiring commissioned length
 - as above, but finish with a number for the commissioned length (either from the button or entered manually)

### content not needing commissioned length
- open the workflow dashboard, click "create new" and select "live blog" etc.
- there will be no commissioned length section.
- should be able to create and view content as normal
 

## How can we measure success?
Increase in the % of (relevant) articles which have commissioned length set
Reduced user friction (minor) for creating liveblog, audio etc
Able to extract some management data on the use of the  breaking news button


## Have we considered potential risks?

We know this many not be a popular feature and that our instructions may change after user feedback.

Not persisting `missingCommissionedLengthReason` (and relying on the logging to track) will mean we won't have the best data on usage and yet won't be able to use it to vary behaviour in Composer - but will avoid making changes to our data modelling that may become moot if "breaking news" is not kept as a feature.

It will still be possible for users to create content without commissioned length by creating in composer and tracking in workflow from there.

## Images

<img width="657" alt="Screenshot 2024-10-08 at 17 15 05" src="https://github.com/user-attachments/assets/0d56019f-c8f0-45da-a02d-3f3a7f6bb242">
<img width="657" alt="Screenshot 2024-10-08 at 17 14 55" src="https://github.com/user-attachments/assets/a9180f95-8863-4bf4-9f08-a53515e2f415">
<img width="657" alt="Screenshot 2024-10-08 at 17 14 43" src="https://github.com/user-attachments/assets/a45d3d54-d521-4470-a67e-10ba01bfe392">
(https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
<img width="657" alt="Screenshot 2024-10-08 at 17 14 20" src="https://github.com/user-attachments/assets/2ac1d82a-bf62-46fb-9fe0-c90d71746055">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning]
