### PR TITLE
Log telemetry event when Workflow create button is clicked

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -36,7 +36,7 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
 
   lazy val mediaAtomMakerUrl: String = s"https://video.$domain"
   lazy val atomWorkshopUrl: String = s"https://atomworkshop.$domain"
-  lazy val telemetryUrl: String = s"https://telemetry.$domain"
+  lazy val telemetryUrl: String = s"https://user-telemetry.$domain"
 
   private lazy val composerUrls: Set[String] = stage match {
     case Dev => Set(composerUrl) // Composer secondary does not exist in DEV

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -36,6 +36,7 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
 
   lazy val mediaAtomMakerUrl: String = s"https://video.$domain"
   lazy val atomWorkshopUrl: String = s"https://atomworkshop.$domain"
+  lazy val telemetryUrl: String = s"https://telemetry.$domain"
 
   private lazy val composerUrls: Set[String] = stage match {
     case Dev => Set(composerUrl) // Composer secondary does not exist in DEV
@@ -62,7 +63,8 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
   lazy val corsAllowedDomains: Set[String] = composerUrls +
     mediaAtomMakerUrl ++ allowDevServiceToCallWorkflowCode("video") +
     atomWorkshopUrl ++ allowDevServiceToCallWorkflowCode("atomworkshop") +
-    s"https://recipes.$domain" ++ allowDevServiceToCallWorkflowCode("recipes")
+    s"https://recipes.$domain" ++ allowDevServiceToCallWorkflowCode("recipes") +
+    telemetryUrl
 
   lazy val presenceUrl: String = s"wss://presence.$domain/socket"
   lazy val presenceClientLib: String = s"https://presence.$domain/client/1/lib.js"

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -147,7 +147,9 @@ class Application(
         ("atomTypes", config.atomTypes.asJson),
         ("sessionId", Json.fromString(config.sessionId)),
         ("gaId", Json.fromString(config.googleTrackingId)),
-        ("tagManagerUrl",Json.fromString(config.tagManagerUrl))
+        ("tagManagerUrl", Json.fromString(config.tagManagerUrl)),
+        ("stage", Json.fromString(config.stage.toString)),
+        ("telemetryUrl", Json.fromString(config.telemetryUrl))
       )
 
       val hasPinboardPermission = permissions.hasPermission(pinboardPermission, request.user.email)

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "sass-loader": "^8.0.2",
     "style-loader": "^0.13.1",
     "terser-webpack-plugin": "^3.0.2",
-    "typescript": "^4.6.2",
     "ts-loader": "^9.5.1",
+    "typescript": "^4.6.2",
     "url-loader": "^4.1.1",
     "webpack": "5.94.0",
     "webpack-cli": "^5.1.4",
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
+    "@guardian/user-telemetry-client": "^1.1.0",
     "@types/react": "^17.0.76",
     "@types/react-dom": "^17.0.9",
     "angular": "1.5.11",

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -6,10 +6,11 @@ import './atom-workshop-service'
 import './http-session-service';
 import './user';
 import './visibility-service';
+import './telemetry-service';
 
-angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'wfPreferencesService'])
-    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'wfPreferencesService', 'config',
-        function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService, wfMediaAtomMakerService, wfAtomWorkshopService, wfPreferencesService, config) {
+angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'wfPreferencesService', 'wfTelemetryService'])
+    .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'wfPreferencesService', 'config', 'wfTelemetryService',
+        function ($rootScope, $log, wfHttpSessionService, wfDateParser, wfFormatDateTimeFilter, wfFiltersService, wfComposerService, wfMediaAtomMakerService, wfAtomWorkshopService, wfPreferencesService, config, wfTelemetryService) {
 
             const httpRequest = wfHttpSessionService.request;
 
@@ -116,6 +117,8 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                             if (statusOption) {
                                 updatedStub['status'] = statusOption;
                             }
+
+                            wfTelemetryService.sendTelemetryEvent("WORKFLOW_CREATE_IN_COMPOSER_TRIGGERED", { contentId: stub.id })
 
                             if (stub.id) {
                                 return this.updateStub(updatedStub);

--- a/public/lib/telemetry-service.js
+++ b/public/lib/telemetry-service.js
@@ -1,0 +1,27 @@
+import angular from "angular";
+import {UserTelemetryEventSender} from "@guardian/user-telemetry-client"
+
+
+angular
+    .module("wfTelemetryService", [])
+    .factory("wfTelemetryService", [() => {
+
+    class TelemetryService {
+        constructor() {
+            this.telemetrySender = _wfConfig.telemetryUrl ? new UserTelemetryEventSender(_wfConfig.telemetryUrl) : undefined;
+        }
+        sendTelemetryEvent = (type, tags, value = true) =>
+            this.telemetrySender?.addEvent({
+                app: "composer",
+                stage: _wfConfig.stage,
+                eventTime: new Date().toISOString(),
+                type,
+                value,
+                tags,
+            });
+    }
+
+    return new TelemetryService();
+}]);
+
+

--- a/public/lib/telemetry-service.js
+++ b/public/lib/telemetry-service.js
@@ -12,7 +12,7 @@ angular
         }
         sendTelemetryEvent = (type, tags, value = true) =>
             this.telemetrySender?.addEvent({
-                app: "composer",
+                app: "workflow",
                 stage: _wfConfig.stage,
                 eventTime: new Date().toISOString(),
                 type,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,13 @@
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@guardian/user-telemetry-client@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/user-telemetry-client/-/user-telemetry-client-1.1.0.tgz#5805837fa5d6f53db492b7bca6090f534ead7c1c"
+  integrity sha512-3jb0rN/+i2jcvqmDuSs4aSiaVVBuXg3rqjWyT2PSpW+o19zjSUgLzFAZCtZUt95ORuzIKfT4Xqr3c2PvuW8cmw==
+  dependencies:
+    lodash "^4.17.20"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz"
@@ -3607,7 +3614,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
+lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## What does this change?

Adds telemetry service to Workflow, which logs to: https://metrics.gutools.co.uk/d/ae0yg6hy27kzke/workflow-telemetry?orgId=1&var-Stage=CODE.

At a first pass this logs an event when a Composer article is created from the Workflow 'Create new' dropdown. 

In a further pass we can track other details we might want to log (e.g. commissioned length, missing commissioned length reason).

### Testing
This branch has been deployed to [CODE](https://workflow.code.dev-gutools.co.uk/dashboard). Create an article using the dropdown modal. You should see a network request to the user telemetry service. The event will be logged in https://metrics.gutools.co.uk/d/ae0yg6hy27kzke/workflow-telemetry?orgId=1&var-Stage=CODE. 
