### PR TITLE
Fix error: [ngModel:numfmt] Expected `N` to be a number

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -68,6 +68,7 @@
                       class="form-control"
                       name="commissionedLength"
                       type="number"
+                      string-to-number
                       ng-model="stub.commissionedLength"
                       placeholder="Choose a custom commissioned length"
                   />

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -518,7 +518,7 @@ wfStubModal.run([
                 return '' + value;
             });
             ngModel.$formatters.push(function(value) {
-                return parseFloat(value, 10);
+                return parseFloat(value);
             });
         }
     };

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -500,7 +500,7 @@ wfStubModal.run([
                     mode: () => mode
                 }
             });
-        };
+        }
     }]).directive('wfFocus', ['$timeout', function($timeout){
       return {
           restrict: "A",
@@ -510,4 +510,17 @@ wfStubModal.run([
               }
           }
       };
-    }]);
+    }]).directive('stringToNumber', function() {
+    return {
+        require: 'ngModel',
+        link: function(scope, element, attrs, ngModel) {
+            ngModel.$parsers.push(function(value) {
+                return '' + value;
+            });
+            ngModel.$formatters.push(function(value) {
+                return parseFloat(value, 10);
+            });
+        }
+    };
+});
+


### PR DESCRIPTION
## What does this change?
Angular struggles to deal with inputs of type number. See https://code.angularjs.org/1.4.8/docs/error/ngModel/numfmt?p0=1234567890 for more.

## How to test
Submit the 'Create new' form in Workflow, with a commissioned length set. You should see no error in the console.