### PR TITLE
Pass priority to Composer endpoint for downstream telemetry 

### DIFF
--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -111,7 +111,7 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService) {
         }
     }
 
-    this.create = function createInComposer(type, commissioningDesks, commissionedLength, prodOffice, template, articleFormat) {
+    this.create = function createInComposer(type, commissioningDesks, commissionedLength, prodOffice, template, articleFormat, priority) {
         var selectedDisplayHint = getDisplayHint(articleFormat);
         
         var params = {
@@ -119,7 +119,8 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService) {
             'tracking': commissioningDesks,
             'productionOffice': prodOffice,
             'displayHint': selectedDisplayHint,
-            'originatingSystem': 'workflow'
+            'originatingSystem': 'workflow',
+            'priority': priority
         };
 
         if(commissionedLength) params['initialCommissionedLength'] = commissionedLength;

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -110,7 +110,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                  * Also will create the stub if it doesn't have an id.
                  */
                 createInComposer(stub, statusOption) {
-                    return wfComposerService.create(stub.contentType, stub.commissioningDesks, stub.commissionedLength, stub.prodOffice, stub.template, stub.articleFormat)
+                    return wfComposerService.create(stub.contentType, stub.commissioningDesks, stub.commissionedLength, stub.prodOffice, stub.template, stub.articleFormat, stub.priority)
                         .then((response) => wfComposerService.parseComposerData(response, stub))
                         .then((updatedStub) => {
 


### PR DESCRIPTION
## What does this change?

Pass priority to Composer create endpoint so we can log telemetry downstream (see https://github.com/guardian/flexible-content/pull/4997).

The idea behind this is to track if users clicking 'Breaking News' (due to be released in #467) correlate with high priority articles.

### How to test
Creating an article through the Workflow dashboard should post the priority as a parameter to the Composer create endpoint.

If deployed alongside https://github.com/guardian/flexible-content/pull/4997, the priority field should appear in Grafana. You can see an example in this [Grafana dashboard](https://metrics.gutools.co.uk/d/de18bodvm1e68c/composer-article-creation?orgId=1).