### PR TITLE
Fix tag typing (stick to strings)

### DIFF
--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -148,12 +148,12 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
 
         const tags = {
             contentType: getType(type),
-            displayHint: selectedDisplayHint,
-            commissionedLength,
             productionOffice: prodOffice,
-            commissioningDesk: commissioningDeskExternalName,
             priority: getPriorityName(priority),
         }
+        if(selectedDisplayHint) tags.displayHint = selectedDisplayHint;
+        if(commissionedLength) tags.commissionedLength = commissionedLength.toString();
+        if(commissioningDeskExternalName) tags.commissioningDesk = commissioningDeskExternalName;
         if(missingCommissionedLengthReason) tags.missingCommissionedLengthReason = missingCommissionedLengthReason;
         wfTelemetryService.sendTelemetryEvent("WORKFLOW_CREATE_IN_COMPOSER_TRIGGERED", tags);
 

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -151,10 +151,10 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
             productionOffice: prodOffice,
             priority: getPriorityName(priority),
         }
-        if(selectedDisplayHint) tags.displayHint = selectedDisplayHint;
-        if(commissionedLength) tags.commissionedLength = commissionedLength.toString();
-        if(commissioningDeskExternalName) tags.commissioningDesk = commissioningDeskExternalName;
-        if(missingCommissionedLengthReason) tags.missingCommissionedLengthReason = missingCommissionedLengthReason;
+        if(selectedDisplayHint !== null && selectedDisplayHint !== undefined) tags.displayHint = selectedDisplayHint;
+        if(commissionedLength !== null && commissionedLength !== undefined) tags.commissionedLength = commissionedLength.toString();
+        if(commissioningDeskExternalName !== null && commissioningDeskExternalName !== undefined) tags.commissioningDesk = commissioningDeskExternalName;
+        if(missingCommissionedLengthReason !== null && missingCommissionedLengthReason !== undefined) tags.missingCommissionedLengthReason = missingCommissionedLengthReason;
         wfTelemetryService.sendTelemetryEvent("WORKFLOW_CREATE_IN_COMPOSER_TRIGGERED", tags);
 
         return request({


### PR DESCRIPTION
## What does this change?

Telemetry events aren't being sent for this button. We are receiving errors in the console (in the network response):
```
{
    "status": "error",
    "message": "Incorrect event format",
    "data": [
        {
            "keyword": "type",
            "dataPath": "[1].tags['commissionedLength']",
            "schemaPath": "#/definitions/IUserTelemetryEvent/properties/tags/additionalProperties/type",
            "params": {
                "type": "string,number,boolean"
            },
            "message": "should be string,number,boolean"
        }
    ]
}
```

The commissionedLength is currently sometimes a number, sometimes null. Let's only add it as an event tag if it's defined, and make it a string to make sure that isn't the issue.

For the other tags, let's do the same - add them optionally if we sometimes expect them to be non-null.

Another version of this PR is filtering the tags for the non-empty values, if we want to do it that way. 

### Testing
I have deployed to CODE. The errors have resolved and the events are sending as expected.
