### PR TITLE
length status logic

### DIFF
--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -375,6 +375,9 @@
             &-over {
                 color: red;
             }
+            &-alert {
+                color: red;
+            }
         }
     }
 

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -369,15 +369,19 @@ function wfGetPriorityStringFilter (priorities) {
 }
 
 function wfCommissionedLengthCtrl ($scope) {
-    $scope.$watch('contentItem.wordCount', function (newVal) {
-        let commLen = $scope.contentItem.commissionedLength;
-        let difference = $scope.contentItem.wordCount / commLen;
+    $scope.$watch('contentItem.wordCount', function (newVal) {   
+        const commLen = $scope.contentItem.commissionedLength;
+        const wordCount = $scope.contentItem.wordCount
+        const difference = wordCount / commLen;
+
         if(!newVal || !commLen || difference < 0.75) {
             $scope.lengthStatus = "low";
         } else if(difference <= 1) {
             $scope.lengthStatus = "near";
-        } else {
+        } else if (wordCount - commLen < 50) {
             $scope.lengthStatus = "over";
+        } else {
+            $scope.lengthStatus = "alert";
         }
     });
 }

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -368,13 +368,32 @@ function wfGetPriorityStringFilter (priorities) {
     };
 }
 
+
+const LENGTH_DESCRIPTIONS = {
+    none: 'unset',
+    low: 'low',
+    near:'near',
+    over: 'over',
+    alert: 'over'
+}
+
+function getCommissionedLengthTitle (lengthStatus) {
+    const description = LENGTH_DESCRIPTIONS[lengthStatus] ?? LENGTH_DESCRIPTIONS.low;
+    if (lengthStatus === 'none') {
+        return `Commissioned word count(not defined)`
+    }
+    return `Commissioned word count(${description} in commparison to web words)`
+}
+
 function wfCommissionedLengthCtrl ($scope) {
     $scope.$watch('contentItem.wordCount', function (newVal) {   
         const commLen = $scope.contentItem.commissionedLength;
         const wordCount = $scope.contentItem.wordCount
         const difference = wordCount / commLen;
 
-        if(!newVal || !commLen || difference < 0.75) {
+        if (!commLen) {
+            $scope.lengthStatus = "none";
+        } else if(!newVal || difference < 0.75) {
             $scope.lengthStatus = "low";
         } else if(difference <= 1) {
             $scope.lengthStatus = "near";
@@ -383,6 +402,7 @@ function wfCommissionedLengthCtrl ($scope) {
         } else {
             $scope.lengthStatus = "alert";
         }
+        $scope.commissionedLengthTitle = getCommissionedLengthTitle($scope.lengthStatus)
     });
 }
 

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -393,7 +393,7 @@ function wfCommissionedLengthCtrl ($scope) {
 
         if (!commLen) {
             $scope.lengthStatus = "none";
-        } else if(!newVal || difference < 0.75) {
+        } else if(!newVal || difference < 0.85) {
             $scope.lengthStatus = "low";
         } else if(difference <= 1) {
             $scope.lengthStatus = "near";

--- a/public/components/content-list-item/templates/commissionedLength.html
+++ b/public/components/content-list-item/templates/commissionedLength.html
@@ -1,6 +1,6 @@
 <td class="content-list-item__field--commissionedLength"
     ng-controller="wfCommissionedLengthCtrl"
-    ng-attr-title="{{'Commissioned word count (' + lengthStatus + ' in comparison to web words)'}}">
+    ng-attr-title="{{commissionedLengthTitle}}">
     <span ng-class="'content-list-item__field--commissionedLength-status-'+ lengthStatus"
           ng-show="contentItem.contentType == 'article'">
         {{ contentItem.commissionedLength }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the logic for categorising the 'lengthStatus' of content (ie whether the word count is over or under the commissioned length) to match the categories used in composer since https://github.com/guardian/flexible-content/pull/4955. As such, the 'categories' are now:

|new state| range| old state would be|
|---|---|---|
|"none"|  no commissioned length defined| "low"|
|"low"|  word count less than 85% of the commissioned length| "low" (near at 75%+) |
|"near"| word count less than 85% - 100% of the commissioned length| "near"|
|"over"| word count less than 50 words over| "over"|
|"alert"|word count over by 50 words+| "over"|

**TO DO - we don't have conformation on the visual style for the "over" and "alert" states - currently, the text is in red for both as currently is on main for 'over'** 

Also adds a function to define the element title for the counts, so that the "none" status can have appropriate text (on a subsequent PR, we should be able to include the `missingCommissionedLengthReason` here

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Categories of lenght match with composer

## Have we considered potential risks?

This is just a display change - but will need to be communicated to avoid confusing staff used to the old ranges

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
