### PR TITLE
Surface missingCommissionedLengthReason field

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -179,10 +179,21 @@ class Api(
     APIAuthAction.async { request =>
       ApiResponseFt[Long](for {
         json <- readJsonFromRequestResponse(request.body)
-        status <- extractDataResponse[Option[Int]](json)
-        id <- stubsApi.updateContentCommissionedLength(stubId, status)
+        commissionedLength <- extractDataResponse[Option[Int]](json)
+        id <- stubsApi.updateContentCommissionedLength(stubId, commissionedLength)
       } yield id
       )}
+  }
+
+  def putStubMissingCommissionedLengthReason(stubId: Long) = {
+    APIAuthAction.async { request =>
+      ApiResponseFt[Long](for {
+        json <- readJsonFromRequestResponse(request.body)
+        missingCommissionedLengthReason <- extractDataResponse[Option[String]](json)
+        id <- stubsApi.updateContentMissingCommissionedLengthReason(stubId, missingCommissionedLengthReason)
+      } yield id
+      )
+    }
   }
 
   def putStubStatusByComposerId(composerId: String) = {

--- a/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
@@ -200,6 +200,13 @@ class StubAPI(
       item <- extractDataResponse[Long](json)
     } yield item
 
+  def updateContentMissingCommissionedLengthReason(stubId: Long, missingCommissionedLengthReason: Option[String]): ApiResponseFt[Long] =
+    for {
+      res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$stubId/missingCommissionedLengthReason", missingCommissionedLengthReason.asJson))
+      json <- parseBody(res.body)
+      item <- extractDataResponse[Long](json)
+    } yield item
+
   def updateContentStatusByComposerId(composerId: String, status: String): ApiResponseFt[String] =
     for {
       res <- ApiResponseFt.Async.Right(putRequest(s"content/$composerId/status", status.asJson))

--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -38,6 +38,7 @@ case class ExternalData(
                          hasMainMedia: Option[Boolean] = None,
                          commentable: Option[Boolean] = None,
                          commissionedLength: Option[Int] = None,
+                         missingCommissionedLengthReason: Option[String] = None,
                          actualPublicationId: Option[Long] = None,
                          actualBookId: Option[Long] = None,
                          actualBookSectionId: Option[Long] = None,

--- a/conf/routes
+++ b/conf/routes
@@ -49,6 +49,8 @@ PUT            /api/stubs/:stubId/plannedBookSectionId     controllers.Api.putSt
 PUT            /api/stubs/:stubId/plannedNewspaperPageNumber          controllers.Api.putStubPlannedNewspaperPageNumber(stubId: Long)
 PUT            /api/stubs/:stubId/plannedNewspaperPublicationDate     controllers.Api.putStubPlannedNewspaperPublicationDate(stubId: Long)
 PUT            /api/stubs/:stubId/rightsReviewed           controllers.Api.putStubRightsReviewed(stubId: Long)
+PUT            /api/stubs/:stubId/commissionedLength       controllers.Api.putStubCommissionedLength(stubId: Long)
+PUT            /api/stubs/:stubId/missingCommissionedLengthReason controllers.Api.putStubMissingCommissionedLengthReason(stubId: Long)
 DELETE         /api/stubs/:stubId                          controllers.Api.deleteStub(stubId: Long)
 
 GET            /api/statuses                               controllers.Api.statusus

--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -140,7 +140,7 @@
                             wf-editable-input-type="number"
                             ng-model="contentItem.commissionedLength"
                             wf-editable-on-update="updateCommissionedLength(newValue)"
-                            wf-editable-maxlength="5">{{contentItem.commissionedLength || "Add" }}
+                            wf-editable-maxlength="5">{{contentItem.commissionedLength || formatReason(contentItem.missingCommissionedLengthReason) || "Add" }}
                             </wf-editable>
                         </li>
                         <li class="drawer__item">

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -332,23 +332,20 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             };
 
             $scope.updateCommissionedLength = function (newValue) {
-              updateField("commissionedLength", newValue);
-              if (newValue === "") {
-                return wfComposerService.deleteField(
-                  $scope.contentItem.composerId,
-                  "commissionedLength"
-                );
-              } else if ($scope.contentItem.missingCommissionedLengthReason !== null) {
+              // Don't allow commissioned length to be unset
+              if(newValue === "") return;
+              if ($scope.contentItem.missingCommissionedLengthReason !== null && $scope.contentItem.missingCommissionedLengthReason !== undefined) {
+                  updateField("missingCommissionedLengthReason", null);
                   wfComposerService.deleteField(
                       $scope.contentItem.composerId,
                       "missingCommissionedLengthReason"
                   );
               }
-
-              return wfComposerService.updateField(
-                $scope.contentItem.composerId,
-                "commissionedLength",
-                newValue
+              updateField("commissionedLength", newValue);
+              wfComposerService.updateField(
+                  $scope.contentItem.composerId,
+                  "commissionedLength",
+                  newValue
               );
             };
 

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -346,6 +346,14 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
               );
             };
 
+            $scope.formatReason = (missingCommissionedLengthReason) => {
+                const reasons = {
+                    "BreakingNews": "Breaking News",
+                }
+
+                return reasons[missingCommissionedLengthReason] || missingCommissionedLengthReason;
+            }
+
             /**
              * Revert deadline to previous state
              */

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -338,7 +338,13 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
                   $scope.contentItem.composerId,
                   "commissionedLength"
                 );
+              } else if ($scope.contentItem.missingCommissionedLengthReason !== null) {
+                  wfComposerService.deleteField(
+                      $scope.contentItem.composerId,
+                      "missingCommissionedLengthReason"
+                  );
               }
+
               return wfComposerService.updateField(
                 $scope.contentItem.composerId,
                 "commissionedLength",

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -335,17 +335,35 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
               // Don't allow commissioned length to be unset
               if(newValue === "") return;
               if ($scope.contentItem.missingCommissionedLengthReason !== null && $scope.contentItem.missingCommissionedLengthReason !== undefined) {
+                  // workflow stub
                   updateField("missingCommissionedLengthReason", null);
+                  // composer preview
                   wfComposerService.deleteField(
                       $scope.contentItem.composerId,
-                      "missingCommissionedLengthReason"
+                      "missingCommissionedLengthReason",
+                      false
+                  );
+                  // composer live
+                  wfComposerService.deleteField(
+                      $scope.contentItem.composerId,
+                      "missingCommissionedLengthReason",
+                      true
                   );
               }
+              // workflow stub
               updateField("commissionedLength", newValue);
+              // composer preview
               wfComposerService.updateField(
                   $scope.contentItem.composerId,
                   "commissionedLength",
                   newValue
+              );
+              // composer live
+              wfComposerService.updateField(
+                  $scope.contentItem.composerId,
+                  "commissionedLength",
+                  newValue,
+                  true
               );
             };
 

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -101,6 +101,7 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
             this.wordCount = item.wordCount;
             this.printWordCount = item.printWordCount;
             this.commissionedLength = item.commissionedLength;
+            this.missingCommissionedLengthReason = item.missingCommissionedLengthReason;
 
             this.headline = item.headline;
             this.standfirst = stripHtml(item.standfirst);
@@ -380,6 +381,14 @@ function wfCommissionedLengthCtrl ($scope) {
             $scope.lengthStatus = "over";
         }
     });
+
+    $scope.formatReason = (missingCommissionedLengthReason) => {
+        const reasons = {
+            "BreakingNews": "Breaking News",
+        }
+
+        return reasons[missingCommissionedLengthReason] || missingCommissionedLengthReason;
+    }
 }
 
 export { wfContentListItem, wfContentItemParser, wfContentItemUpdateActionDirective, wfGetPriorityStringFilter, wfCommissionedLengthCtrl };

--- a/public/components/content-list-item/templates/commissionedLength.html
+++ b/public/components/content-list-item/templates/commissionedLength.html
@@ -3,6 +3,6 @@
     ng-attr-title="{{'Commissioned word count (' + lengthStatus + ' in comparison to web words)'}}">
     <span ng-class="'content-list-item__field--commissionedLength-status-'+ lengthStatus"
           ng-show="contentItem.contentType == 'article'">
-        {{ contentItem.commissionedLength }}
+        {{ contentItem.commissionedLength || formatReason(contentItem.missingCommissionedLengthReason) }}
     </span>
 </td>

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -312,6 +312,17 @@ const columnDefaults = [{
     isSortable: true,
     sortField: ['statusInPrint']
 },{
+    name: 'commissionedLength',
+    prettyName: 'Commissioned Length',
+    labelHTML: 'Commissioned Length',
+    colspan: 1,
+    title: '',
+    templateUrl: templateRoot + 'commissionedLength.html',
+    template: commissionedLengthTemplate,
+    active: true,
+    isSortable: true,
+    sortField: ['missingCommissionedLengthReason', 'commissionedLength']
+},{
     name: 'wordcount',
     prettyName: 'Web wordcount',
     labelHTML: 'Web words',
@@ -347,17 +358,6 @@ const columnDefaults = [{
     isSortable: true,
     defaultSortOrder: ['asc', 'desc', 'asc'],
     sortField: ['printLocationBookSection', 'printLocationPublicationDate', 'printLocationPageNumber']
-},{
-    name: 'commissionedLength',
-    prettyName: 'Commissioned Length',
-    labelHTML: 'Commissioned Length',
-    colspan: 1,
-    title: '',
-    templateUrl: templateRoot + 'commissionedLength.html',
-    template: commissionedLengthTemplate,
-    active: true,
-    isSortable: true,
-    sortField: ['missingCommissionedLengthReason', 'commissionedLength']
 },{
     name: 'links',
     prettyName: 'Open in...',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -356,7 +356,8 @@ const columnDefaults = [{
     templateUrl: templateRoot + 'commissionedLength.html',
     template: commissionedLengthTemplate,
     active: true,
-    isSortable: true
+    isSortable: true,
+    sortField: ['missingCommissionedLengthReason', 'commissionedLength']
 },{
     name: 'links',
     prettyName: 'Open in...',

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -350,7 +350,7 @@ const columnDefaults = [{
 },{
     name: 'commissionedLength',
     prettyName: 'Commissioned Length',
-    labelHTML: 'Commission',
+    labelHTML: 'Commissioned Length',
     colspan: 1,
     title: '',
     templateUrl: templateRoot + 'commissionedLength.html',

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -49,7 +49,8 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
         revision: (d) => deepSearch(d, ['contentChangeDetails', 'data', 'revision']),
         lastModified: (d) => new Date(deepSearch(d, ['contentChangeDetails', 'data', 'lastModified', 'date']) || undefined),
         lastModifiedBy: (d) => deepSearch(d, ['contentChangeDetails', 'data', 'lastModified', 'user', 'firstName']) + ' ' + deepSearch(d, ['contentChangeDetails', 'data', 'lastModified', 'user', 'lastName']),
-        commissionedLength: (d) => deepSearch(d, ['preview', 'data', 'fields', 'commissionedLength', 'data']) || undefined
+        commissionedLength: (d) => deepSearch(d, ['preview', 'data', 'fields', 'commissionedLength', 'data']) || undefined,
+        missingCommissionedLengthReason: (d) => deepSearch(d, ['preview', 'data', 'fields', 'missingCommissionedLengthReason', 'data']) || undefined
     };
 
 


### PR DESCRIPTION
We recently made commissioned length mandatory in Workflow and gave a way for users to opt out by clicking the Breaking News button. 

This PR surfaces this choice in the Workflow UI (in the `Commissioned Length` column, renamed from the vague - if shorter - `Commission`).

### To test
Run locally or deploy to CODE alongside https://github.com/guardian/workflow/pull/1123 and https://github.com/guardian/flexible-content/pull/5070.