### PR TITLE
Set priority to Very Urgent when Breaking News is pressed

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -76,6 +76,7 @@
                             ng-click="
                                 resetCommissionedLength();
                                 sendTelemetry(0, 'BreakingNews');
+                                setPriorityToVeryUrgent(2)
                             "
                             type="button"
                         >

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -123,9 +123,9 @@
 
                     <div>
                         <div class="btn-group">
-                            <label class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="0">Normal</label>
-                            <label class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="1"><i class="stubModal__icon" wf-icon="priority-urgent"></i> Urgent</label>
-                            <label class="btn btn-default btn-sm" ng-model="stub.priority" btn-radio="2"><i class="stubModal__icon" wf-icon="priority-very-urgent"></i> Very Urgent</label>
+                            <button class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="0">Normal</button>
+                            <button class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="1"><i class="stubModal__icon" wf-icon="priority-urgent"></i> Urgent</button>
+                            <button class="btn btn-default btn-sm" ng-model="stub.priority" btn-radio="2"><i class="stubModal__icon" wf-icon="priority-very-urgent"></i> Very Urgent</button>
                         </div>
                     </div>
                 </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -123,8 +123,8 @@
 
                     <div>
                         <div class="btn-group">
-                            <label class="btn btn-default btn-sm" ng-model="stub.priority" btn-radio="0">Normal</label>
-                            <label class="btn btn-default btn-sm" ng-model="stub.priority" btn-radio="1"><i class="stubModal__icon" wf-icon="priority-urgent"></i> Urgent</label>
+                            <label class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="0">Normal</label>
+                            <label class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="1"><i class="stubModal__icon" wf-icon="priority-urgent"></i> Urgent</label>
                             <label class="btn btn-default btn-sm" ng-model="stub.priority" btn-radio="2"><i class="stubModal__icon" wf-icon="priority-very-urgent"></i> Very Urgent</label>
                         </div>
                     </div>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -294,6 +294,10 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         )
     }
 
+    $scope.setPriorityToVeryUrgent = () => {
+        $scope.stub.priority = 2;
+    }
+
     $scope.submit = function (form) {
         if (form.$invalid) {
             useNativeFormFeedback($scope.stub)


### PR DESCRIPTION
## What does this change?

We recently made commissioned length mandatory and added an opt-out 'Breaking News' button. We found that a lot of users were clicking Breaking News while their piece was only 'Normal' priority. This seemed suspicious. It turned out though that a lot of people don't click 'Very Urgent' priority when their piece is Breaking News. Instead they shout to a sub nearby if they need eyes on it.

However, we know there are definitely people 'misusing' the button, as it were, by looking at the commissioning desks who are using it. We think setting the priority to Very Urgent will discourage users from misusing this button, as it will draw attention to their piece in Workflow.

Having chatted to a few editors on news and sport they think that setting the priority to Very Urgent when it's Breaking News can only be a good thing (even if they will keep using their own system of speaking to each other in the office).

So this is mainly here as a deterrent but it also has the nice side effect of showing genuinely breaking news pieces as very urgent priority which they should be.

There is a second deterrent in the form of #476 (surface the term 'Breaking News' in the Workflow UI).

### Risks
We care here about users who are genuinely using the Breaking News button for its intended purpose. If enough of them complain we can easily roll back.