### PR TITLE
Disable Create button from being clicked (not just styling!)

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -175,7 +175,8 @@
             </button>
             <button
                 type="button"
-                class="btn btn-primary" 
+                class="btn btn-primary"
+                ng-disabled="disabled || stubForm.$invalid || warningMessages.length > 0"
                 ng-class="{ 'disabled': disabled || stubForm.$invalid || warningMessages.length > 0 }"
                 id="testing-create-in-composer" 
                 ng-click="submit(stubForm)" 


### PR DESCRIPTION
If you create an article in workflow and set the commissioned length to 0, you receive a warning and the create button appears disabled, but you can still click the disabled button to create an article.

This PR should fix that.