### PR TITLE
Update production office in Composer

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -320,6 +320,23 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
                 updateField("plannedNewspaperPageNumber", pageNumber, $scope.contentItem.plannedNewspaperPageNumber)
             }
 
+            $scope.updateOffice = (office) => {
+                // preview
+                wfComposerService.updateSetting(
+                    $scope.contentItem.composerId,
+                    "productionOffice",
+                    office,
+                )
+
+                // live
+                wfComposerService.updateSetting(
+                    $scope.contentItem.composerId,
+                    "productionOffice",
+                    office,
+                    true
+                )
+            };
+
             /**
              * Update the deadline manually using value from datepicker
              */

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -20,6 +20,16 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
         }
     }
 
+    function composerUpdateSettingUrl(settingName, contentId) {
+        function liveOrPreview(isPreview) {
+            return `${composerContentFetch}${contentId}/${isPreview ? "preview" : "live"}/settings/${settingName}`
+        }
+        return {
+            preview: liveOrPreview(true),
+            live:    liveOrPreview(false)
+        }
+    }
+
     // budget composer url parser - just gets the portion after the last '/'
     function parseComposerId(url) {
         return url.substring(url.lastIndexOf('/') + 1);
@@ -177,6 +187,18 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
 
     this.updateField = function (composerId, fieldName, value, live = false) {
         let urls = composerUpdateFieldUrl(fieldName, composerId);
+        let url = live ? urls.live : urls.preview;
+        let req = {
+            method: 'PUT',
+            url: url,
+            data: `"${value}"`,
+            withCredentials: true
+        };
+        return request(req);
+    };
+
+    this.updateSetting = function (composerId, settingName, value, live = false) {
+        let urls = composerUpdateSettingUrl(settingName, composerId);
         let url = live ? urls.live : urls.preview;
         let req = {
             method: 'PUT',


### PR DESCRIPTION
For a while now, changing the Production Office in Workflow would only update the stub in the Workflow DB.

This PR updates the Production Office field in Composer as well - using the settings endpoint (as Production Office is a setting, not a field).

### To test
In either local or CODE workflow, find the Management tab of an article and change the Production Office setting.

You should see two PUT network requests to the Production Office setting endpoint in Composer (one for preview, another for live).

The article in Composer CODE should update with the new value of Production Office. You can see this in three places:
(1) the Management tab
(2) the API debug endpoint - here you can see both draft and live settings
(3) the 'Track in Workflow' section of the sidebar (this reads from the Workflow DB)

Before this PR, only (3) would update, leading to confusion.