### PR TITLE
send AUS to composer for production office, not AU

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -321,18 +321,21 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             }
 
             $scope.updateOffice = (office) => {
+                // because the australian prodOffice is 'AUS' in composer and 'AU' in workflow                
+                const composerOffice = office.toUpperCase() === 'AU' ? 'AUS' : office;
+
                 // preview
                 wfComposerService.updateSetting(
                     $scope.contentItem.composerId,
                     "productionOffice",
-                    office,
+                    composerOffice,
                 )
 
                 // live
                 wfComposerService.updateSetting(
                     $scope.contentItem.composerId,
                     "productionOffice",
-                    office,
+                    composerOffice,
                     true
                 )
             };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

Composer uses ‘AUS’ as the production office code for Australia. Workflow uses ‘AU’. When updating Workflow, composer will convert ‘AUS' to ‘AU’, but when composer updates Workflow frontend, it will set the value in  composer to 'AU’.

This causes the the dropdown in the production office panel in Composer to show the wrong initial value (defaults to 'UK' as the first option in the select input)

## What does this change?

changes the `updateOffice` function to convert "AU" to "AUS" before using the value to update Composer.

## How to test

open an article in Workflow, and change the production office to 'AU'. Open the article in Composer 
- the API output should confirm that the "productionOffice" setting is 'AUS'
- the dropdown in the management panel should display 'AUS' (not UK as it would if the "productionOffice" setting was 'AU'

## How can we measure success?

Composer articles will have the expected values after being updated via Workflow

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
