### PR TITLE
length status logic (green if within 50 words, red if >50 words over)

### DIFF
--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -375,6 +375,9 @@
             &-over {
                 color: red;
             }
+            &-alert {
+                color: red;
+            }
         }
     }
 

--- a/public/components/content-list-item/_content-list-item.scss
+++ b/public/components/content-list-item/_content-list-item.scss
@@ -367,13 +367,11 @@
 
     .content-list-item__field--commissionedLength {
         &-status {
-            &-low {
-            }
             &-near {
                 color: green;
             }
             &-over {
-                color: red;
+                color: green;
             }
             &-alert {
                 color: red;

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -369,15 +369,19 @@ function wfGetPriorityStringFilter (priorities) {
 }
 
 function wfCommissionedLengthCtrl ($scope) {
-    $scope.$watch('contentItem.wordCount', function (newVal) {
-        let commLen = $scope.contentItem.commissionedLength;
-        let difference = $scope.contentItem.wordCount / commLen;
+    $scope.$watch('contentItem.wordCount', function (newVal) {   
+        const commLen = $scope.contentItem.commissionedLength;
+        const wordCount = $scope.contentItem.wordCount
+        const difference = wordCount / commLen;
+
         if(!newVal || !commLen || difference < 0.75) {
             $scope.lengthStatus = "low";
         } else if(difference <= 1) {
             $scope.lengthStatus = "near";
-        } else {
+        } else if (wordCount - commLen < 50) {
             $scope.lengthStatus = "over";
+        } else {
+            $scope.lengthStatus = "alert";
         }
     });
 }

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -368,13 +368,32 @@ function wfGetPriorityStringFilter (priorities) {
     };
 }
 
+
+const LENGTH_DESCRIPTIONS = {
+    none: 'unset',
+    low: 'low',
+    near:'near',
+    over: 'over',
+    alert: 'over'
+}
+
+function getCommissionedLengthTitle (lengthStatus) {
+    const description = LENGTH_DESCRIPTIONS[lengthStatus] ?? LENGTH_DESCRIPTIONS.low;
+    if (lengthStatus === 'none') {
+        return `Commissioned word count(not defined)`
+    }
+    return `Commissioned word count(${description} in commparison to web words)`
+}
+
 function wfCommissionedLengthCtrl ($scope) {
     $scope.$watch('contentItem.wordCount', function (newVal) {   
         const commLen = $scope.contentItem.commissionedLength;
         const wordCount = $scope.contentItem.wordCount
         const difference = wordCount / commLen;
 
-        if(!newVal || !commLen || difference < 0.75) {
+        if (!commLen) {
+            $scope.lengthStatus = "none";
+        } else if(!newVal || difference < 0.75) {
             $scope.lengthStatus = "low";
         } else if(difference <= 1) {
             $scope.lengthStatus = "near";
@@ -383,6 +402,7 @@ function wfCommissionedLengthCtrl ($scope) {
         } else {
             $scope.lengthStatus = "alert";
         }
+        $scope.commissionedLengthTitle = getCommissionedLengthTitle($scope.lengthStatus)
     });
 }
 

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -393,7 +393,7 @@ function wfCommissionedLengthCtrl ($scope) {
 
         if (!commLen) {
             $scope.lengthStatus = "none";
-        } else if(!newVal || difference < 0.75) {
+        } else if(!newVal || difference < 0.85) {
             $scope.lengthStatus = "low";
         } else if(difference <= 1) {
             $scope.lengthStatus = "near";

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -1,3 +1,4 @@
+import { getContentLengthCategory, getCommissionedLengthTitle } from "./word-count-helpers.ts";
 
 const OPHAN_PATH = 'https://dashboard.ophan.co.uk/summary?path=/',
     LIVE_PATH = 'http://www.theguardian.com/';
@@ -370,40 +371,11 @@ function wfGetPriorityStringFilter (priorities) {
 }
 
 
-const LENGTH_DESCRIPTIONS = {
-    none: 'unset',
-    low: 'low',
-    near:'near',
-    over: 'over',
-    alert: 'over'
-}
-
-function getCommissionedLengthTitle (lengthStatus) {
-    const description = LENGTH_DESCRIPTIONS[lengthStatus] ?? LENGTH_DESCRIPTIONS.low;
-    if (lengthStatus === 'none') {
-        return `Commissioned word count(not defined)`
-    }
-    return `Commissioned word count(${description} in commparison to web words)`
-}
-
 function wfCommissionedLengthCtrl ($scope) {
-    $scope.$watch('contentItem.wordCount', function (newVal) {   
-        const commLen = $scope.contentItem.commissionedLength;
-        const wordCount = $scope.contentItem.wordCount
-        const difference = wordCount / commLen;
-
-        if (!commLen) {
-            $scope.lengthStatus = "none";
-        } else if(!newVal || difference < 0.85) {
-            $scope.lengthStatus = "low";
-        } else if(difference <= 1) {
-            $scope.lengthStatus = "near";
-        } else if (wordCount - commLen < 50) {
-            $scope.lengthStatus = "over";
-        } else {
-            $scope.lengthStatus = "alert";
-        }
-        $scope.commissionedLengthTitle = getCommissionedLengthTitle($scope.lengthStatus)
+    $scope.$watch('contentItem.wordCount', function (newWordCount) {   
+        const commissionedLength = $scope.contentItem.commissionedLength;
+        $scope.lengthStatus = getContentLengthCategory(commissionedLength, newWordCount);
+        $scope.commissionedLengthTitle = getCommissionedLengthTitle(commissionedLength, newWordCount)
     });
 
     $scope.formatReason = (missingCommissionedLengthReason) => {

--- a/public/components/content-list-item/templates/commissionedLength.html
+++ b/public/components/content-list-item/templates/commissionedLength.html
@@ -1,6 +1,6 @@
 <td class="content-list-item__field--commissionedLength"
     ng-controller="wfCommissionedLengthCtrl"
-    ng-attr-title="{{'Commissioned word count (' + lengthStatus + ' in comparison to web words)'}}">
+    ng-attr-title="{{commissionedLengthTitle}}">
     <span ng-class="'content-list-item__field--commissionedLength-status-'+ lengthStatus"
           ng-show="contentItem.contentType == 'article'">
         {{ contentItem.commissionedLength }}

--- a/public/components/content-list-item/word-count-helpers.ts
+++ b/public/components/content-list-item/word-count-helpers.ts
@@ -1,0 +1,41 @@
+type ContentLengthCategory = 'alert' | 'over' | 'near' | 'low' | 'none';
+
+const getContentLengthCategory = function (
+    commissionedLength: number | undefined | null,
+    wordCount: number | undefined | null,
+): ContentLengthCategory {
+    if (typeof commissionedLength !== 'number' || typeof wordCount !== 'number') {
+        return 'none';
+    }
+    const wordsLeft = commissionedLength - wordCount;
+    if (wordsLeft > 50) {
+        return 'low';
+    }
+    if (wordsLeft <= 50 && wordsLeft >= 0) {
+        return 'near';
+    }
+    if (wordsLeft >= -50) {
+        return 'over';
+    }
+    return 'alert';
+};
+
+function getCommissionedLengthTitle(
+    commissionedLength: number | undefined | null,
+    wordCount: number | undefined | null,
+) {
+    if (typeof commissionedLength !== 'number') {
+        return `Commissioned word count(not defined)`
+    }
+    if (typeof wordCount !== 'number') {
+        return `Commissioned word count`
+    }
+    
+    const wordsLeft = commissionedLength - wordCount;
+    if (wordsLeft <= 0) {
+        return `Commissioned word count(${-wordsLeft.toString()} over web words)`
+    }
+    return `Commissioned word count(${wordsLeft.toString()} below web words)`
+}
+
+export { getContentLengthCategory, getCommissionedLengthTitle };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Changes the highlight color for the commissioned length text in the workflow table : 

when web words is...
 - more than 50 words below commissioned length  = regular black text ("low" status)
 - 50 words or less below commissioned length        = green text ("near" status)
 - 50 words or less above commissioned length        = green text ("over" status)
 - more than 50 words above commissioned length  = red text ("alert" status)

When the missingCommissionLength is displayed, this will be in regular black text.

Uses a function to set the title of the commissioned length cell so it will include the number of words above or below  commissioned length (if numerical value is set)

this is to match the changes in composer  in https://github.com/guardian/flexible-content/pull/5085

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
