### PR TITLE
Send telemetry when content is imported from Composer

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -64,7 +64,7 @@
                             type="button"
                             ng-click="
                                 resetMissingCommissionedLengthReason();
-                                sendTelemetry(commissionedLengthSuggestion);
+                                sendTelemetryForSuggestion(commissionedLengthSuggestion);
                             "
                         >
                             {{ commissionedLengthSuggestion }}
@@ -75,7 +75,7 @@
                             btn-radio="'BreakingNews'"
                             ng-click="
                                 resetCommissionedLength();
-                                sendTelemetry(0, 'BreakingNews');
+                                sendTelemetryForSuggestion(0, 'BreakingNews');
                                 setPriorityToVeryUrgent(2)
                             "
                             type="button"
@@ -192,7 +192,15 @@
 
     <div class="modal-footer" ng-if="mode === 'import'" ng-hide="actionInProgress">
         <button type="button" class="btn btn-default pull-left" data-dismiss="modal" ng-click="cancel()">Cancel</button>
-        <button type="submit" class="btn btn-primary" id="testing-import-from-composer" ng-click="ok()" ng-disabled="stubForm.$invalid || !validImport">
+        <button
+                type="submit"
+                class="btn btn-primary"
+                id="testing-import-from-composer"
+                ng-click="
+                    ok();
+                    sendTelemetryForImport();
+                "
+                ng-disabled="stubForm.$invalid || !validImport">
             Import <span ng-show="importHandler">from {{importHandler.name}}</span>
         </button>
     </div>

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -76,7 +76,7 @@
                             ng-click="
                                 resetCommissionedLength();
                                 sendTelemetryForSuggestion(0, 'BreakingNews');
-                                setPriorityToVeryUrgent(2)
+                                setPriorityToVeryUrgent();
                             "
                             type="button"
                         >

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -198,7 +198,7 @@
                 id="testing-import-from-composer"
                 ng-click="
                     ok();
-                    sendTelemetryForImport();
+                    sendTelemetryForImport(contentName);
                 "
                 ng-disabled="stubForm.$invalid || !validImport">
             Import <span ng-show="importHandler">from {{importHandler.name}}</span>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -298,7 +298,10 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         }
     }
 
-    $scope.sendTelemetryForImport = () => {
+    $scope.sendTelemetryForImport = (contentName) => {
+        if(contentName === 'Atom') {
+            return;
+        }
         const tags = {
             contentId: stub.composerId,
             productionOffice: stub.prodOffice,

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -281,7 +281,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         1200,
     ]
 
-    $scope.sendTelemetry = (value, missingCommissionedLengthReason = null) => {
+    $scope.sendTelemetryForSuggestion = (value, missingCommissionedLengthReason = null) => {
         const commissioningDesk = $scope.cdesks.find(desk  => desk.id.toString() === stub.commissioningDesks)?.externalName;
         const tags = {
             contentId: stub.id,
@@ -289,11 +289,29 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             commissioningDesk
         }
         if (missingCommissionedLengthReason) tags['missingCommissionedLengthReason'] = missingCommissionedLengthReason;
-        wfTelemetryService.sendTelemetryEvent(
-            "WORKFLOW_COMMISSIONED_LENGTH_SUGGESTION_PRESSED",
-            tags,
-            value
-        )
+        if(wfTelemetryService !== null && wfTelemetryService !== undefined) {
+            wfTelemetryService.sendTelemetryEvent(
+                "WORKFLOW_COMMISSIONED_LENGTH_SUGGESTION_PRESSED",
+                tags,
+                value
+            )
+        }
+    }
+
+    $scope.sendTelemetryForImport = () => {
+        const tags = {
+            contentId: stub.composerId,
+            productionOffice: stub.prodOffice,
+            commissioningDesk: stub.section?.name,
+            commissionedLength: stub.commissionedLength
+        }
+        if(wfTelemetryService !== null && wfTelemetryService !== undefined) {
+            wfTelemetryService.sendTelemetryEvent(
+                "WORKFLOW_CONTENT_IMPORTED_FROM_COMPOSER",
+                tags,
+                true
+            )
+        }
     }
 
     $scope.setPriorityToVeryUrgent = () => {

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -306,7 +306,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             contentId: stub.composerId,
             productionOffice: stub.prodOffice,
             commissioningDesk: stub.section?.name,
-            commissionedLength: stub.commissionedLength
+            commissionedLength: stub.commissionedLength,
+            contentType: stub.contentType
         }
         if(wfTelemetryService !== null && wfTelemetryService !== undefined) {
             wfTelemetryService.sendTelemetryEvent(


### PR DESCRIPTION
## What does this change?

We have recently made commissioned length mandatory in Workflow and when tracking in Workflow from Composer. However there is another way into Workflow, the `Import Content` method, and I'm curious how many use it, to see if this is another loophole worth closing. 

This PR adds some telemetry to find that data out.

### Testing

Find the `Import content` option in the `Create new` dropdown. Does clicking import send any network requests off to the telemetry service? Are the headers correct? Does it surface in Grafana?

<img width="202" alt="image" src="https://github.com/user-attachments/assets/7a96870f-8988-4ceb-a415-290090dcc1d2" />

<img width="647" alt="image" src="https://github.com/user-attachments/assets/793093a4-1f3c-47d3-8031-c26c8327128d" />
