### PR TITLE
Track commissioned length when importing from Composer

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -41,7 +41,7 @@
                     </select>
                 </div>
             </div>
-            <div class="form-group pull-left col-xs-8" ng-if="mode !== 'import' && contentName !== 'Atom'">
+            <div class="form-group pull-left col-xs-8" ng-if="contentName !== 'Atom'">
                 <label for="stub_cdesk">Commissioning info</label>
                 <div ng-if="cdesks.length > 0">
                     <select class="commissioning-desk-margin" id="stub_cdesk" name="cdesk" ng-model="stub.commissioningDesks" ng-options="cdesk.id.toString() as cdesk.externalName for cdesk in cdesks"></select>
@@ -198,6 +198,7 @@
                 id="testing-import-from-composer"
                 ng-click="
                     ok();
+                    updateCommissionedLengthInComposer(stubForm.commissionedLength);
                     sendTelemetryForImport(contentName);
                 "
                 ng-disabled="stubForm.$invalid || !validImport">

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -343,6 +343,28 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         }
     };
 
+    $scope.updateCommissionedLengthInComposer = function() {
+        const commissionedLength = $scope.stub.commissionedLength;
+        const missingCommissionedLengthReason = $scope.stub.missingCommissionedLengthReason;
+
+        // one request for preview, one for live
+        if(commissionedLength === null) {
+            wfComposerService.deleteField(stub.composerId, 'commissionedLength');
+            wfComposerService.deleteField(stub.composerId, 'commissionedLength', true);
+        } else {
+            wfComposerService.updateField(stub.composerId, 'commissionedLength', commissionedLength);
+            wfComposerService.updateField(stub.composerId, 'commissionedLength', commissionedLength, true);
+        }
+
+        if(missingCommissionedLengthReason === null) {
+            wfComposerService.deleteField(stub.composerId, 'missingCommissionedLengthReason');
+            wfComposerService.deleteField(stub.composerId, 'missingCommissionedLengthReason', true);
+        } else {
+            wfComposerService.updateField(stub.composerId, 'missingCommissionedLengthReason', missingCommissionedLengthReason);
+            wfComposerService.updateField(stub.composerId, 'missingCommissionedLengthReason', missingCommissionedLengthReason, true);
+        }
+    }
+
     $scope.ok = function (addToComposer, addToAtomEditor) {
         const stub = $scope.stub;
         function createItemPromise() {


### PR DESCRIPTION
## What does this change?

In #467 we made Commissioned Length mandatory when creating articles in Workflow. In [#5081](https://github.com/guardian/flexible-content/pull/5081), we made Commissioned Length mandatory when tracking articles in Workflow from Composer.

This has increased compliance for articles which originate in Workflow and Composer to ~85%. The remaining 15% are a mix of articles which are published without ever being tracked in Workflow, and articles which are _imported_ into Workflow from the Workflow menu:
![image](https://github.com/user-attachments/assets/68d292f1-a299-4d77-8818-0793bf459fd2)




## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
