### PR TITLE
Fix sbt dependency graph workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -1,19 +1,28 @@
-name: Update Dependency Graph for SBT
+name: Update Dependency Graph for sbt
 on:
   push:
     branches:
       - main
-  workflow_dispatch: 
+  workflow_dispatch:
 jobs:
   dependency-graph:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Install Java
+        id: java
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
+        with:
+          distribution: corretto
+          java-version: 17
+      - name: Install sbt
+        id: sbt
+        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
       - name: Submit dependencies
         id: submit
-        uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
+        uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
       - name: Log snapshot for user validation
         id: validate
         run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq


### PR DESCRIPTION
## What does this change?

At the moment, this workflow is [failing on main](https://github.com/guardian/workflow-frontend/actions/runs/12430359668/job/34705650369) because it doesn’t explicitly install sbt, and github has updated the ubuntu-latest tag to the 24.04 runners which don’t include sbt by default.

To fix this, this commit updates the workflow by copying the version from https://github.com/guardian/fastly-cache-purger/pull/88, which PR was produced by a newer version of the gu-dependency-graph-integrator bot and includes an explicit installation of sbt (and updates to some action versions).

## How to test

To test this, we could modify the workflow to be triggered by this branch and confirm it runs successfully. Alternatively, we could just merge and see if it fixes it: since it's currently broken I don't think merging could make things any worse, and I'm confident this fixes the problem.

## How can we measure success?

The dependency graph in github will be up to date, and the build on main will be marked as completely successful in the github UI.