### PR TITLE
Update panda to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,12 @@ jobs:
     build:
         runs-on: ubuntu-20.04
 
-        permissions: # required by aws-actions/configure-aws-credentials
+        permissions:
+            # Allow GitHub to request an OIDC JWT ID token, for exchange with AWS Security Token Service (STS)
+            # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#updating-your-github-actions-workflow
             id-token: write
             contents: read
+            pull-requests: write
 
         steps:
             # Seed the build number with last number from TeamCity.
@@ -29,12 +32,6 @@ jobs:
                   distribution: "corretto"
                   java-version: "11"
                   cache: "sbt"
-
-            - name: AWS Auth
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                  role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-                  aws-region: eu-west-1
 
             - name: Install Node
               uses: actions/setup-node@v3
@@ -54,9 +51,11 @@ jobs:
               run: |
                   sbt clean compile test Debian/packageBin
 
-            - uses: guardian/actions-riff-raff@v2
+            - uses: guardian/actions-riff-raff@v4
               with:
                   projectName: Editorial Tools::Workflow::Workflow Frontend
+                  roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+                  githubToken: ${{ secrets.GITHUB_TOKEN }}
                   buildNumber: ${{ env.BUILD_NUMBER }}
                   configPath: conf/riff-raff.yaml
                   contentDirectories: |

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,4 +1,4 @@
-import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, S3BucketLoader}
 import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
 import com.gu.workflow.api.{DesksAPI, SectionDeskMappingsAPI, SectionsAPI, StubAPI}
 import com.gu.workflow.lib.TagService
@@ -24,12 +24,10 @@ class AppComponents(context: Context)
 
   val config = new Config(context.initialConfiguration)
 
-  val panDomainRefresher = new PanDomainAuthSettingsRefresher(
+  val panDomainRefresher = PanDomainAuthSettingsRefresher(
     domain = config.domain,
     system = config.pandaSystem,
-    bucketName = config.pandaBucketName,
-    settingsFileKey = config.pandaSettingsFile,
-    s3Client = AWS.S3Client
+    S3BucketLoader.forAwsSdkV1(AWS.S3Client, "pan-domain-auth-settings")
   )
 
   val permissions: PermissionsProvider =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,10 +12,12 @@ object Dependencies {
     "com.gu" %% "content-api-client-aws" % "0.7"
   )
 
+  val pandaVersion = "7.0.0"
+
   val authDependencies = Seq(
-    "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % pandaVersion,
     "com.gu" %% "hmac-headers" % "2.0.0",
-    "com.gu" %% "panda-hmac-play_3-0" % "4.0.0"
+    "com.gu" %% "panda-hmac-play_3-0" % pandaVersion
   )
 
   val testDependencies = Seq(


### PR DESCRIPTION
## What does this change?

This PR updates the dependencies on [panda](https://github.com/guardian/pan-domain-authentication) to 7.0.0, following the instructions in https://github.com/guardian/pan-domain-authentication/issues/160.

I also took the opportunity to update the use of actions-riff-raff to v4 in https://github.com/guardian/workflow-frontend/pull/489/commits/9ef3deaa99a33c19948bd1de8424db76f6a30629.

## How to test

To test, I [deployed this PR to CODE](https://riffraff.gutools.co.uk/deployment/view/54ec3f48-738e-4acf-a3ac-94f12cf45959), and then confirmed that I can still visit https://workflow.code.dev-gutools.co.uk/dashboard. I also tried clearing my cookies and watching the network tab to make sure the oauth redirects happened and worked, which they did. Finally, I tried accessing the page from a private tab (where I wasn’t signed into my google account) and saw a prompt from google to log in.

Is there anything else I should check?