### PR TITLE
model display hint, centralise special format definitions

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -52,7 +52,8 @@ case class ExternalData(
                          rightsSyndicationAggregate: Option[Boolean] = None,
                          rightsSubscriptionDatabases: Option[Boolean] = None,
                          rightsDeveloperCommunity: Option[Boolean] = None,
-                         byline: Option[String] = None) {
+                         byline: Option[String] = None,
+                         displayHint: Option[String] = None) {
 }
 
 object ExternalData {

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -13,7 +13,7 @@
             <input type="text" ng-model="formData.importUrl" ng-change="importUrlChanged()" id="import_url" name="import_url" class="form-control" required  wf-focus focus-me="{{ mode === 'import' }}">
         </div>
         <div class="form-horizontal clearfix">
-                <div class="format-dropdown" ng-if="(showFormatDropdown && (stubFormat === 'Standard Article' || stubFormat === 'Key Takeaways' || stubFormat === 'Q&A Explainer' || stubFormat === 'Timeline' || stubFormat === 'Mini profiles' || stubFormat === 'Multi-byline'))">
+                <div class="format-dropdown" ng-if="(showFormatDropdown && stubFormatIsCorrectlyPopulated())">
                 <label for="stub_format">Format</label>
                     <div>
                         <select id="stub_format" name="articleFormat" ng-model="stub.articleFormat" ng-options="f.value as f.name for f in articleFormats"></select>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -17,7 +17,8 @@ import 'lib/prodoffice-service';
 import 'lib/telemetry-service';
 import { punters } from 'components/punters/punters';
 import { generateErrorMessages, doesContentTypeRequireCommissionedLength, useNativeFormFeedback } from '../../lib/stub-form-validation.ts';
-import { getStubArticleFormat, isFormatLabel, setDisplayHintForFormat } from 'lib/model/special-formats.ts';
+import { setDisplayHintForFormat } from 'lib/model/special-formats.ts';
+import { getArticleFormatLabel, isFormatLabel } from 'lib/model/format-helpers.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -32,7 +33,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             (wfContentService.getAtomTypes())[stub.contentType] ?
             "Atom" : (types[stub.contentType] || "News item");
             
-        $scope.stubFormat = getStubArticleFormat(stub.contentType);
+        $scope.stubFormat = getArticleFormatLabel(stub.contentType);
  
         $scope.$watch('stub.articleFormat', (newValue) => {
             $scope.stubFormat = newValue;
@@ -491,7 +492,7 @@ wfStubModal.run([
 
             function createStubData (contentType, sectionName) {
                 return {
-                    articleFormat: getStubArticleFormat(contentType),
+                    articleFormat: getArticleFormatLabel(contentType),
                     contentType: contentType === "atom" ? defaultAtomType : contentType,
                     // Only send through a section if one is found in the prefs
                     section: sectionName === null ? sectionName : sections.filter((section) => section.name === sectionName)[0],

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -17,7 +17,7 @@ import 'lib/prodoffice-service';
 import 'lib/telemetry-service';
 import { punters } from 'components/punters/punters';
 import { generateErrorMessages, doesContentTypeRequireCommissionedLength, useNativeFormFeedback } from '../../lib/stub-form-validation.ts';
-import { getStubArticleFormat, setDisplayHintForFormat } from 'lib/model/special-formats.ts';
+import { getStubArticleFormat, isFormatLabel, setDisplayHintForFormat } from 'lib/model/special-formats.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -46,6 +46,10 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             'import': 'Import Existing Content'
         })[mode];
     });
+
+    $scope.stubFormatIsCorrectlyPopulated = function() {     
+        return isFormatLabel($scope.stubFormat)
+    }
 
     $scope.loadingTemplates = true;
 

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -17,6 +17,7 @@ import 'lib/prodoffice-service';
 import 'lib/telemetry-service';
 import { punters } from 'components/punters/punters';
 import { generateErrorMessages, doesContentTypeRequireCommissionedLength, useNativeFormFeedback } from '../../lib/stub-form-validation.ts';
+import { getStubArticleFormat, setDisplayHintForFormat } from 'lib/model/special-formats.js';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -31,20 +32,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
             (wfContentService.getAtomTypes())[stub.contentType] ?
             "Atom" : (types[stub.contentType] || "News item");
             
-        $scope.stubFormat = ''
-        if (stub.contentType === 'article') {
-            $scope.stubFormat = "Standard Article"
-        } else if (stub.contentType === 'keyTakeaways') {
-            $scope.stubFormat = "Key Takeaways"
-        } else if (stub.contentType === 'qAndA') {
-            $scope.stubFormat = "Q&A Explainer"
-        } else if (stub.contentType === 'timeline') {
-            $scope.stubFormat = "Timeline"
-        } else if (stub.contentType === 'miniProfiles') {
-            $scope.stubFormat = "Mini profiles"
-        } else if (stub.contentType === 'multiByline') {
-            $scope.stubFormat = "Multi-byline"
-        }
+        $scope.stubFormat = getStubArticleFormat(stub.contentType);
+ 
         $scope.$watch('stub.articleFormat', (newValue) => {
             $scope.stubFormat = newValue;
         })
@@ -344,20 +333,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     };
 
     $scope.ok = function (addToComposer, addToAtomEditor) {
-        const stub = {...$scope.stub};
+        const stub = setDisplayHintForFormat ($scope.stub);
         
-        switch (stub.contentType){
-            case 'keyTakeaways':
-            case 'qAndA':
-            case "timeline":
-            case "miniProfiles":
-            case "multiByline":
-                stub.displayHint = stub.contentType
-                break;
-            default:
-                break;
-        }
-
         function createItemPromise() {
             if ($scope.contentName === 'Atom') {
                 stub.contentType = $scope.stub.contentType.toLowerCase();
@@ -509,32 +486,8 @@ wfStubModal.run([
         function setUpPreferredStub (contentType) {
 
             function createStubData (contentType, sectionName) {
-                let chosenArticleFormat = ""
-                switch (contentType) {
-                    case "article":
-                        chosenArticleFormat = "Standard Article"
-                        break;
-                    case "keyTakeaways":
-                        chosenArticleFormat = "Key Takeaways"
-                        break;
-                    case "qAndA":
-                        chosenArticleFormat = "Q&A Explainer"
-                        break;
-                    case "timeline":
-                        chosenArticleFormat = "Timeline"
-                        break;
-                    case "miniProfiles":
-                        chosenArticleFormat = "Mini profiles"
-                        break;
-                    case "multiByline":
-                        chosenArticleFormat = "Multi-byline"
-                        break;
-                    default:
-                        break;
-                }
-
                 return {
-                    articleFormat: chosenArticleFormat,
+                    articleFormat: getStubArticleFormat(contentType),
                     contentType: contentType === "atom" ? defaultAtomType : contentType,
                     // Only send through a section if one is found in the prefs
                     section: sectionName === null ? sectionName : sections.filter((section) => section.name === sectionName)[0],

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -344,7 +344,20 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     };
 
     $scope.ok = function (addToComposer, addToAtomEditor) {
-        const stub = $scope.stub;
+        const stub = {...$scope.stub};
+        
+        switch (stub.contentType){
+            case 'keyTakeaways':
+            case 'qAndA':
+            case "timeline":
+            case "miniProfiles":
+            case "multiByline":
+                stub.displayHint = stub.contentType
+                break;
+            default:
+                break;
+        }
+
         function createItemPromise() {
             if ($scope.contentName === 'Atom') {
                 stub.contentType = $scope.stub.contentType.toLowerCase();

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -17,7 +17,7 @@ import 'lib/prodoffice-service';
 import 'lib/telemetry-service';
 import { punters } from 'components/punters/punters';
 import { generateErrorMessages, doesContentTypeRequireCommissionedLength, useNativeFormFeedback } from '../../lib/stub-form-validation.ts';
-import { getStubArticleFormat, setDisplayHintForFormat } from 'lib/model/special-formats.js';
+import { getStubArticleFormat, setDisplayHintForFormat } from 'lib/model/special-formats.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])

--- a/public/lib/article-format-service.js
+++ b/public/lib/article-format-service.js
@@ -1,27 +1,14 @@
-define(['angular'], function (angular) {
-    'use strict';
+import angular from 'angular';
+import { provideArticleFormatsForDropDown } from './model/format-helpers.ts';
 
-    var articleFormatService = angular.module('articleFormatService', []);
 
-    articleFormatService.factory('articleFormatService',['wfPreferencesService', function (wfPreferencesService) {
-            function getArticleFormats() {
-                const featureSwitches = wfPreferencesService.preferences.featureSwitches;
-
-                const articleFormats =  [
-                    {name: 'Standard Article', value: 'Standard Article'},
-                    {name: 'Key Takeaways', value: 'Key Takeaways'},
-                    {name: 'Q&A Explainer', value: 'Q&A Explainer'},
-                    {name: 'Timeline', value: 'Timeline'},
-                    {name: 'Mini profiles', value: 'Mini profiles'},
-                ]
-                if (featureSwitches && featureSwitches.multiByline){
-                    articleFormats.push({name: 'Multi-byline', value: 'Multi-byline'})
-                }
-                return articleFormats                    
-            };
+angular.module('articleFormatService', [])
+    .factory('articleFormatService', ['wfPreferencesService', function (wfPreferencesService) {
+        function getArticleFormats() {
+            const featureSwitches = wfPreferencesService.preferences?.featureSwitches;
+            return provideArticleFormatsForDropDown(featureSwitches)
+        };
         return {
-                getArticleFormats: getArticleFormats
-            };
-        }]);
-    return articleFormatService;
-});
+            getArticleFormats: getArticleFormats
+        };
+    }]);

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import './telemetry-service';
-import { getFormatFromLabel, contentTypeToComposerContentType } from './model/special-formats';
+import { getFormatFromLabel, contentTypeToComposerContentType } from './model/special-formats.ts';
 
 angular.module('wfComposerService', ['wfTelemetryService'])
     .service('wfComposerService', ['$http', '$q', 'config', '$log', 'wfHttpSessionService', 'wfTelemetryService', wfComposerService]);

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import './telemetry-service';
-import { getFormatFromLabel, contentTypeToComposerContentType } from './model/special-formats.ts';
+import { getSpecialFormatFromLabel, contentTypeToComposerContentType } from './model/special-formats.ts';
 
 angular.module('wfComposerService', ['wfTelemetryService'])
     .service('wfComposerService', ['$http', '$q', 'config', '$log', 'wfHttpSessionService', 'wfTelemetryService', wfComposerService]);
@@ -95,7 +95,7 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
     this.parseComposerData = parseComposerData;
     
     this.create = function createInComposer(type, commissioningDesks, commissionedLength, prodOffice, template, articleFormat, priority, missingCommissionedLengthReason) {
-        var selectedDisplayHint = getFormatFromLabel(articleFormat)?.value;
+        var selectedDisplayHint = getSpecialFormatFromLabel(articleFormat)?.value;
         
         var params = {
             'type': contentTypeToComposerContentType(type),

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import './telemetry-service';
+import { getFormatFromLabel, contentTypeToComposerContentType } from './model/special-formats';
 
 angular.module('wfComposerService', ['wfTelemetryService'])
     .service('wfComposerService', ['$http', '$q', 'config', '$log', 'wfHttpSessionService', 'wfTelemetryService', wfComposerService]);
@@ -92,42 +93,12 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
 
     this.getComposerContent = getComposerContent;
     this.parseComposerData = parseComposerData;
-
-    const getDisplayHint = (articleFormat) => {
-        switch (articleFormat){
-            case "Key Takeaways":
-                return "keyTakeaways"
-            case "Q&A Explainer":
-                return "qAndA"
-            case "Timeline":
-                return "timeline"
-            case "Mini profiles":
-                return "miniProfiles"
-            case "Multi-byline":
-                return "multiByline"
-            default:
-                return undefined
-        }
-    }
     
-    const getType = (type) => {
-        switch (type){
-            case 'keyTakeaways':
-            case 'qAndA':
-            case "timeline":
-            case "miniProfiles":
-            case "multiByline":
-                return "article"
-            default:
-                return type
-        }
-    }
-
     this.create = function createInComposer(type, commissioningDesks, commissionedLength, prodOffice, template, articleFormat, priority, missingCommissionedLengthReason) {
-        var selectedDisplayHint = getDisplayHint(articleFormat);
+        var selectedDisplayHint = getFormatFromLabel(articleFormat)?.value;
         
         var params = {
-            'type': getType(type),
+            'type': contentTypeToComposerContentType(type),
             'tracking': commissioningDesks,
             'productionOffice': prodOffice,
             'displayHint': selectedDisplayHint,
@@ -158,7 +129,7 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
         }
 
         const tags = {
-            contentType: getType(type),
+            contentType: contentTypeToComposerContentType(type),
             productionOffice: prodOffice,
             priority: getPriorityName(priority),
         }

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -6,6 +6,7 @@ import './atom-workshop-service'
 import './http-session-service';
 import './user';
 import './visibility-service';
+import { provideFormats } from './model/format-helpers.ts'
 
 angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'wfPreferencesService'])
     .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'wfPreferencesService', 'config',
@@ -15,37 +16,12 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
 
             class ContentService {
 
-                provideFormats(featureSwitches){
-                    const articleFormats = {
-                        "article": "Article",
-                        "keyTakeaways": "Key Takeaways",
-                        "qAndA": "Q&A Explainer",
-                        "timeline": "Timeline",
-                        "miniProfiles": "Mini profiles"
-                    }
-
-                    if (featureSwitches && featureSwitches.multiByline){
-                        articleFormats.multiByline = "Multi-byline"
-                    }
-
-                    const nonArticleFormats = {
-                        "liveblog": "Live blog",
-                        "gallery": "Gallery",
-                        "interactive": "Interactive",
-                        "picture": "Picture",
-                        "audio": "Audio",
-                        "atom": "Video/Atom"
-                    }
-                    // Assembling the object this way preserves the existing order in the UI
-                    return Promise.resolve({...articleFormats, ...nonArticleFormats}); 
-                }
-
                 getTypes() {
                     return wfPreferencesService.getPreference('featureSwitches')
-                    .then((featureSwitches) => {
-                        return this.provideFormats(featureSwitches)
-                    })
-                    .catch((err) => {return this.provideFormats()})
+                        .then((featureSwitches) => {
+                            return provideFormats(featureSwitches)
+                        })
+                        .catch((err) => { return provideFormats() })
                 }
 
                 /* what types of stub should be treated as atoms? */
@@ -363,7 +339,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
 
                 const localSearch = this._paramsProvider()
                 this.currentSearch = localSearch
-                
+
                 return wfContentService.get(localSearch)
                     .then((cb) => {
                         const localSearchIsStale = localSearch !== this.currentSearch

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -284,6 +284,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                         'hasPrintInfo': modelParams['hasPrintInfo'] || null,
                         'hasMainMedia': modelParams['hasMainMedia'] || null,
                         'rights': modelParams['rights'] || null,
+                        'display-hint': modelParams["display-hint"],
                     };
 
                     return params;
@@ -362,7 +363,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
 
                 const localSearch = this._paramsProvider()
                 this.currentSearch = localSearch
-
+                
                 return wfContentService.get(localSearch)
                     .then((cb) => {
                         const localSearchIsStale = localSearch !== this.currentSearch

--- a/public/lib/filters-service.js
+++ b/public/lib/filters-service.js
@@ -200,7 +200,8 @@ angular.module('wfFiltersService', ['wfDateService', 'wfTrustedHtml'])
                         'editorId'       : params['editorId'],
                         'hasPrintInfo'   : params['hasPrintInfo'],
                         'hasMainMedia'   : params['hasMainMedia'],
-                        'hasAnyRights'   : params['rights']
+                        'hasAnyRights'   : params['rights'],
+                        'display-hint'   : params['display-hint'],
                     };
 
                     $rootScope.currentlySelectedStatusFilters = self.transformStatusList(self.filters['status']);

--- a/public/lib/model/format-helpers.ts
+++ b/public/lib/model/format-helpers.ts
@@ -1,6 +1,8 @@
-import { specialFormats, STANDARD_ARTICLE_FORMAT_LABEL } from './special-formats'
+import { specialFormats } from './special-formats'
 import { ContentType } from './stub'
 
+const STANDARD_ARTICLE_FORMAT_LABEL = "Standard Article";
+const STANDARD_ARTICLE_FORMAT_SHORT_LABEL = "Article";
 
 const nonArticleFormats = {
     "liveblog": "Live blog",
@@ -11,9 +13,13 @@ const nonArticleFormats = {
     "atom": "Video/Atom"
 }
 
+/**
+ * Returns an object mapping ContentType to user facings labels, excluding any
+ * special formats that that behind a feature switch in the 'off' state.
+ */
 const provideFormats = (featureSwitches?: Record<string, boolean>): Partial<Record<ContentType, string>> => {
     const articleFormats: Record<string, string> = {
-        "article": "Article",
+        "article": STANDARD_ARTICLE_FORMAT_SHORT_LABEL,
     }
 
     specialFormats.forEach(format => {
@@ -52,7 +58,27 @@ const provideArticleFormatsForDropDown = (featureSwitches?: Record<string, boole
     return list.map(label => ({ name: label, value: label }))
 }
 
+/**
+ * returns "Standard Article" for normal articles, the label for special article formats
+ * or empty string for non-article content types
+ */
+const getArticleFormatLabel = (contentType: ContentType): string => {
+    const maybeMatchingFormat = specialFormats.find(format => format.value === contentType)
+    if (maybeMatchingFormat) {
+        return maybeMatchingFormat.label
+    }
+    if (contentType === 'article') {
+        return STANDARD_ARTICLE_FORMAT_LABEL
+    }
+    return ''
+}
+
+/**
+ * true if the value is the label of a special format or the "Standard Article" label
+ */
+const isFormatLabel = (value: string): boolean => {
+    return value === STANDARD_ARTICLE_FORMAT_LABEL || specialFormats.some(format => format.label === value)
+}
 
 
-
-export { provideFormats, provideArticleFormatsForDropDown }
+export { provideFormats, provideArticleFormatsForDropDown, getArticleFormatLabel, isFormatLabel }

--- a/public/lib/model/format-helpers.ts
+++ b/public/lib/model/format-helpers.ts
@@ -1,0 +1,58 @@
+import { specialFormats, STANDARD_ARTICLE_FORMAT_LABEL } from './special-formats'
+import { ContentType } from './stub'
+
+
+const nonArticleFormats = {
+    "liveblog": "Live blog",
+    "gallery": "Gallery",
+    "interactive": "Interactive",
+    "picture": "Picture",
+    "audio": "Audio",
+    "atom": "Video/Atom"
+}
+
+const provideFormats = (featureSwitches?: Record<string, boolean>): Partial<Record<ContentType, string>> => {
+    const articleFormats: Record<string, string> = {
+        "article": "Article",
+    }
+
+    specialFormats.forEach(format => {
+        if (format.behindFeatureSwitch) {
+            if (featureSwitches?.[format.behindFeatureSwitch]) {
+                articleFormats[format.value] = format.label
+            }
+        } else {
+            articleFormats[format.value] = format.label
+        }
+    })
+
+
+    // Assembling the object this way preserves the existing order in the UI
+    return { ...articleFormats, ...nonArticleFormats };
+}
+
+/**
+ * Returns a list of objects describing the available article formats 
+ * that can be used to as a model for a select input in an angular template
+ */
+const provideArticleFormatsForDropDown = (featureSwitches?: Record<string, boolean>): { name: string; value: string }[] => {
+
+    const list = [STANDARD_ARTICLE_FORMAT_LABEL]
+
+    specialFormats.forEach(format => {
+        if (format.behindFeatureSwitch) {
+            if (featureSwitches && featureSwitches[format.behindFeatureSwitch]) {
+                list.push(format.label)
+            }
+        } else {
+            list.push(format.label)
+        }
+    })
+
+    return list.map(label => ({ name: label, value: label }))
+}
+
+
+
+
+export { provideFormats, provideArticleFormatsForDropDown }

--- a/public/lib/model/special-formats.ts
+++ b/public/lib/model/special-formats.ts
@@ -1,13 +1,13 @@
 import { ComposerContentType, ContentType, SpecialArticleFormat, Stub } from "./stub";
 
-const STANDARD_ARTICLE_FORMAT_LABEL = "Standard Article"; 
+const STANDARD_ARTICLE_FORMAT_LABEL = "Standard Article";
 
 const specialFormats: SpecialArticleFormat[] = [
-    { label: 'Key Takeaways', value: 'keyTakeaways', iconId: 'keyTakeaways' },
-    { label: 'Q&A Explainer', value: 'qAndA', iconId: 'qAndA' },
-    { label: 'Timeline', value: 'timeline', iconId: 'timeline' },
-    { label: 'Mini profiles', value: 'miniProfiles', iconId: 'miniProfiles' },
-    { label: 'Multi-byline', value: 'multiByline', iconId: 'multiByline', hidden: true },
+    { label: 'Key Takeaways', value: 'keyTakeaways' },
+    { label: 'Q&A Explainer', value: 'qAndA' },
+    { label: 'Timeline', value: 'timeline' },
+    { label: 'Mini profiles', value: 'miniProfiles' },
+    { label: 'Multi-byline', value: 'multiByline', behindFeatureSwitch: 'multiByline' },
 ]
 
 const setDisplayHintForFormat = (stub: Stub): Stub => {
@@ -22,7 +22,7 @@ const setDisplayHintForFormat = (stub: Stub): Stub => {
  * return "Standard Article" for normal articles, the label for special article formats
  * or empty string for non-article stubs
  */
-const getStubArticleFormat = (contentType:ContentType): string => {
+const getStubArticleFormat = (contentType: ContentType): string => {
     const maybeMatchingFormat = specialFormats.find(format => format.value === contentType)
     if (maybeMatchingFormat) {
         return maybeMatchingFormat.label
@@ -33,7 +33,7 @@ const getStubArticleFormat = (contentType:ContentType): string => {
     return ''
 }
 
-const isFormatLabel = (value:string):boolean => {
+const isFormatLabel = (value: string): boolean => {
     return value === STANDARD_ARTICLE_FORMAT_LABEL || specialFormats.some(format => format.label === value)
 }
 
@@ -55,4 +55,4 @@ const contentTypeToComposerContentType = (type: ContentType): ComposerContentTyp
     }
 }
 
-export { specialFormats, setDisplayHintForFormat, getSpecialFormatFromLabel, contentTypeToComposerContentType, getStubArticleFormat, isFormatLabel }
+export { STANDARD_ARTICLE_FORMAT_LABEL, specialFormats, setDisplayHintForFormat, getSpecialFormatFromLabel, contentTypeToComposerContentType, getStubArticleFormat, isFormatLabel }

--- a/public/lib/model/special-formats.ts
+++ b/public/lib/model/special-formats.ts
@@ -1,0 +1,52 @@
+import { ComposerContentType, ContentType, SpecialArticleFormat, Stub } from "./stub";
+
+const specialFormats: SpecialArticleFormat[] = [
+    { label: 'Key Takeaways', value: 'keyTakeaways', iconId: 'keyTakeaways' },
+    { label: 'Q&A Explainer', value: 'qAndA', iconId: 'qAndA' },
+    { label: 'Timeline', value: 'timeline', iconId: 'timeline' },
+    { label: 'Mini profiles', value: 'miniProfiles', iconId: 'miniProfiles' },
+    { label: 'Multi-byline', value: 'multiByline', iconId: 'multiByline', hidden: true },
+]
+
+const setDisplayHintForFormat = (stub: Stub): Stub => {
+    const maybeMatchingFormat = specialFormats.find(format => format.value === stub.contentType)
+    if (maybeMatchingFormat) {
+        stub.displayHint = maybeMatchingFormat.value
+    }
+    return stub
+}
+
+/**
+ * return "Standard Article" for normal articles, the label for special article formats
+ * or empty string for non-article stubs
+ */
+const getStubArticleFormat = (contentType:ContentType): string => {
+    const maybeMatchingFormat = specialFormats.find(format => format.value === contentType)
+    if (maybeMatchingFormat) {
+        return maybeMatchingFormat.label
+    }
+    if (contentType === 'article') {
+        return "Standard Article"
+    }
+    return ''
+}
+
+const getFormatFromLabel = (label: string): SpecialArticleFormat | undefined =>
+    specialFormats.find(format => format.label === label)
+
+const contentTypeToComposerContentType = (type: ContentType): ComposerContentType => {
+    switch (type) {
+        case "article":
+        case "liveblog":
+        case "gallery":
+        case "interactive":
+        case "picture":
+        case "video":
+        case "audio":
+            return type;
+        default:
+            return 'article'
+    }
+}
+
+export { specialFormats, setDisplayHintForFormat, getFormatFromLabel, contentTypeToComposerContentType, getStubArticleFormat }

--- a/public/lib/model/special-formats.ts
+++ b/public/lib/model/special-formats.ts
@@ -1,5 +1,7 @@
 import { ComposerContentType, ContentType, SpecialArticleFormat, Stub } from "./stub";
 
+const STANDARD_ARTICLE_FORMAT_LABEL = "Standard Article"; 
+
 const specialFormats: SpecialArticleFormat[] = [
     { label: 'Key Takeaways', value: 'keyTakeaways', iconId: 'keyTakeaways' },
     { label: 'Q&A Explainer', value: 'qAndA', iconId: 'qAndA' },
@@ -26,12 +28,16 @@ const getStubArticleFormat = (contentType:ContentType): string => {
         return maybeMatchingFormat.label
     }
     if (contentType === 'article') {
-        return "Standard Article"
+        return STANDARD_ARTICLE_FORMAT_LABEL
     }
     return ''
 }
 
-const getFormatFromLabel = (label: string): SpecialArticleFormat | undefined =>
+const isFormatLabel = (value:string):boolean => {
+    return value === STANDARD_ARTICLE_FORMAT_LABEL || specialFormats.some(format => format.label === value)
+}
+
+const getSpecialFormatFromLabel = (label: string): SpecialArticleFormat | undefined =>
     specialFormats.find(format => format.label === label)
 
 const contentTypeToComposerContentType = (type: ContentType): ComposerContentType => {
@@ -49,4 +55,4 @@ const contentTypeToComposerContentType = (type: ContentType): ComposerContentTyp
     }
 }
 
-export { specialFormats, setDisplayHintForFormat, getFormatFromLabel, contentTypeToComposerContentType, getStubArticleFormat }
+export { specialFormats, setDisplayHintForFormat, getSpecialFormatFromLabel, contentTypeToComposerContentType, getStubArticleFormat, isFormatLabel }

--- a/public/lib/model/special-formats.ts
+++ b/public/lib/model/special-formats.ts
@@ -1,7 +1,5 @@
 import { ComposerContentType, ContentType, SpecialArticleFormat, Stub } from "./stub";
 
-const STANDARD_ARTICLE_FORMAT_LABEL = "Standard Article";
-
 const specialFormats: SpecialArticleFormat[] = [
     { label: 'Key Takeaways', value: 'keyTakeaways' },
     { label: 'Q&A Explainer', value: 'qAndA' },
@@ -16,25 +14,6 @@ const setDisplayHintForFormat = (stub: Stub): Stub => {
         stub.displayHint = maybeMatchingFormat.value
     }
     return stub
-}
-
-/**
- * return "Standard Article" for normal articles, the label for special article formats
- * or empty string for non-article stubs
- */
-const getStubArticleFormat = (contentType: ContentType): string => {
-    const maybeMatchingFormat = specialFormats.find(format => format.value === contentType)
-    if (maybeMatchingFormat) {
-        return maybeMatchingFormat.label
-    }
-    if (contentType === 'article') {
-        return STANDARD_ARTICLE_FORMAT_LABEL
-    }
-    return ''
-}
-
-const isFormatLabel = (value: string): boolean => {
-    return value === STANDARD_ARTICLE_FORMAT_LABEL || specialFormats.some(format => format.label === value)
 }
 
 const getSpecialFormatFromLabel = (label: string): SpecialArticleFormat | undefined =>
@@ -55,4 +34,4 @@ const contentTypeToComposerContentType = (type: ContentType): ComposerContentTyp
     }
 }
 
-export { STANDARD_ARTICLE_FORMAT_LABEL, specialFormats, setDisplayHintForFormat, getSpecialFormatFromLabel, contentTypeToComposerContentType, getStubArticleFormat, isFormatLabel }
+export { specialFormats, setDisplayHintForFormat, getSpecialFormatFromLabel, contentTypeToComposerContentType }

--- a/public/lib/model/stub.ts
+++ b/public/lib/model/stub.ts
@@ -1,4 +1,4 @@
-export type ContentType =
+export type ComposerContentType =
   | "article"
   | "liveblog"
   | "gallery"
@@ -6,11 +6,15 @@ export type ContentType =
   | "picture"
   | "video"
   | "audio"
+
+export type SpecialFormatContentType =
   | "keyTakeaways"
   | "qAndA"
   | "timeline"
   | "miniProfiles"
   | "multiByline";
+
+export type ContentType = ComposerContentType | SpecialFormatContentType;
 
 type FlagValue = "NA" | "REQUIRED" | "COMPLETE";
 
@@ -27,4 +31,11 @@ export type Stub = {
   note?: string;
   displayHint?: string;
 };
+
+export type SpecialArticleFormat = {
+  label: string,
+  value: SpecialFormatContentType,
+  iconId: string,
+  hidden?: boolean,
+}
 

--- a/public/lib/model/stub.ts
+++ b/public/lib/model/stub.ts
@@ -25,5 +25,6 @@ export type Stub = {
   priority?: number;
   prodOffice?: string;
   note?: string;
+  displayHint?: string;
 };
 

--- a/public/lib/model/stub.ts
+++ b/public/lib/model/stub.ts
@@ -35,7 +35,6 @@ export type Stub = {
 export type SpecialArticleFormat = {
   label: string,
   value: SpecialFormatContentType,
-  iconId: string,
-  hidden?: boolean,
+  behindFeatureSwitch?: string,
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

 - Adds the "displayHint" property to the `Stub` model so that it can be posted to the backend when creating new stubs for articles with special formats - see https://github.com/guardian/workflow/pull/1130 for the backend & DB changes to support the new property.
- Creates a ts type `SpecialArticleFormat` and a central list of the current formats available. Uses this list to create a collection of helpers to replace the code that was using hard coded values for the names or values of the formats - this should allow us to more easily add new formats in future



## How to test

### DisplayHint property
 - Run this branch and the workflow project on https://github.com/guardian/workflow/pull/1130 locally.
 - Create a new miniProfile article in workflow from the "create new" button
 - Create a new timeline article in workflow from the "create new" button
 - (create some normal articles if you don't already have some in your DB)
 - manual set the display hint filter by navigating to  https://workflow.local.dev-gutools.co.uk/dashboard?display-hint=miniProfiles
 - after it has loaded, the list of content should only contain your new miniProfile (note - if you have existing miniProfile pieces in your DB, these will not show as the displayHint was not populated when they were created)
 - navigate to https://workflow.local.dev-gutools.co.uk/dashboard?display-hint=timeline and the list loaded should only contain your new timline article

### special format list
 - Run this branch locally
 - comment out on of the formats in public/lib/model/special-formats.ts, or set its `behindFeatureSwitch` property 
 - the format should be removed from the UI everywhere the formats appear (eg "create new" drop down, stub form) but the others should work as before
 - add a new item to the list (an include its `value` in the `SpecialFormatContentType` type ), reload the page
 - your new format should appear in the UI alongside the real once


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
