### PR TITLE
add more logging to help debug production office issue

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -160,7 +160,10 @@ class Api(
       ApiResponseFt[Long](for {
         json <- readJsonFromRequestResponse(request.body)
         prodOffice <- extractDataResponse[String](json)
-        id <- stubsApi.putStubProdOffice(stubId, prodOffice)
+        id <- {
+          logger.info(s"Put request received to update to prodOffice on stub $stubId - new value = $prodOffice")
+          stubsApi.putStubProdOffice(stubId, prodOffice)
+        }
       } yield id
     )}
   }

--- a/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
@@ -9,6 +9,7 @@ import models.api._
 import models.{ContentItemIds, Flag, Stub}
 import org.joda.time.{DateTime, LocalDate}
 import play.api.libs.ws.WSClient
+import play.api.Logging
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -16,7 +17,7 @@ import scala.concurrent.Future
 class StubAPI(
   override val apiRoot: String,
   override val ws: WSClient
-) extends ApiUtils with WSUtils {
+) extends ApiUtils with WSUtils with Logging {
 
   def createStub(body: Json): ApiResponseFt[ContentUpdate] =
     for {
@@ -90,9 +91,15 @@ class StubAPI(
 
   def putStubProdOffice(id: Long, status: String): ApiResponseFt[Long] =
     for {
-      res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$id/prodOffice", status.asJson))
+      res <- {
+        logger.info(s"Sending put request to update to prodOffice on stub $id - new value = $status")
+        ApiResponseFt.Async.Right(putRequest(s"stubs/$id/prodOffice", status.asJson))
+      }
       json <- parseBody(res.body)
-      item <- extractDataResponse[Long](json)
+      item <- {
+        logger.info(s"Respond to request to update to prodOffice on stub $id - new value = $status:\n $json")
+        extractDataResponse[Long](json)
+      }
     } yield item
 
   def putStubTrashed(id: Long, trashed: Boolean): ApiResponseFt[Long] =


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

see https://github.com/guardian/workflow/pull/1131

To help investigate bug reports, add extra logging to track when requests to change the production office are made and hopefully determine when/if they fails

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
