### PR TITLE
Fix minor panda update mistakes

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -27,7 +27,7 @@ class AppComponents(context: Context)
   val panDomainRefresher = PanDomainAuthSettingsRefresher(
     domain = config.domain,
     system = config.pandaSystem,
-    S3BucketLoader.forAwsSdkV1(AWS.S3Client, "pan-domain-auth-settings")
+    S3BucketLoader.forAwsSdkV1(AWS.S3Client, config.pandaBucketName)
   )
 
   val permissions: PermissionsProvider =

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -107,7 +107,6 @@ class Config(playConfig: Configuration) extends AwsInstanceTags with Logging {
 
   lazy val pandaSystem: String = "workflow"
   lazy val pandaBucketName: String = "pan-domain-auth-settings"
-  lazy val pandaSettingsFile: String = s"$domain.settings"
 
   lazy val loggingStreamName: Option[String] = playConfig.getOptional[String]("aws.kinesis.logging.streamName")
   lazy val loggingRole: Option[String] = playConfig.getOptional[String]("aws.kinesis.logging.stsRoleToAssume")


### PR DESCRIPTION
## What does this change?

When recently updating panda to v7 in commit ce587649252e83a1ff2b53003e890987c0f238f2 (PR https://github.com/guardian/workflow-frontend/pull/489), I followed the example in https://github.com/guardian/tagmanager/pull/535/files#r1767036487 slightly too closely, replacing the use of the config key with a hard-coded string by mistake.

This PR restores the use of the config key, and removes a config key that that commit removed the only use of.