### PR TITLE
display hint put endpoint

### DIFF
--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -165,6 +165,18 @@ class Api(
     )}
   }
 
+  def putStubDisplayHint(stubId: Long) = {
+    def getDisplayHintOpt(input: String): Option[String] = if(input.length > 0) Some(input) else None
+    APIAuthAction.async { request =>
+      ApiResponseFt[Long](for {
+        json <- readJsonFromRequestResponse(request.body)
+        displayHint <- extractDataResponse[String](json)
+        displayHintOpt = getDisplayHintOpt(displayHint)
+        id <- stubsApi.putStubDisplayHint(stubId, displayHintOpt)
+      } yield id
+    )}
+  }
+
   def putStubStatus(stubId: Long) = {
     APIAuthAction.async { request =>
       ApiResponseFt[Long](for {

--- a/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
+++ b/common-lib/src/main/scala/com/gu/workflow/api/StubAPI.scala
@@ -95,6 +95,13 @@ class StubAPI(
       item <- extractDataResponse[Long](json)
     } yield item
 
+  def putStubDisplayHint(id: Long, displayHint: Option[String]): ApiResponseFt[Long] =
+    for {
+      res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$id/displayHint", displayHint.asJson))
+      json <- parseBody(res.body)
+      item <- extractDataResponse[Long](json)
+    } yield item
+
   def putStubTrashed(id: Long, trashed: Boolean): ApiResponseFt[Long] =
     for {
       res <- ApiResponseFt.Async.Right(putRequest(s"stubs/$id/updateTrashed", trashed.asJson))

--- a/conf/routes
+++ b/conf/routes
@@ -33,6 +33,7 @@ POST           /api/stubs                                  controllers.Api.creat
 PUT            /api/stubs/:stubId                          controllers.Api.putStub(stubId: Long)
 PUT            /api/stubs/:stubId/assignee                 controllers.Api.putStubAssignee(stubId: Long)
 PUT            /api/stubs/:stubId/assigneeEmail            controllers.Api.putStubAssigneeEmail(stubId: Long)
+PUT            /api/stubs/:stubId/displayHint              controllers.Api.putStubDisplayHint(stubId: Long)
 PUT            /api/stubs/:stubId/dueDate                  controllers.Api.putStubDueDate(stubId: Long)
 PUT            /api/stubs/:stubId/note                     controllers.Api.putStubNote(stubId: Long)
 PUT            /api/stubs/:stubId/needsLegal               controllers.Api.putStubLegalStatus(stubId: Long)

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -125,9 +125,7 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
 
             this.contentType = item.contentType;
             this.contentTypeTitle = toTitleCase(item.contentType);
-            this.contentTypeAndDisplayHintTitle = item.displayHint 
-                ? `${toTitleCase(item.contentType)}(${toTitleCase(item.displayHint)})` 
-                : toTitleCase(item.contentType)
+            this.displayHintDescription = item.displayHint ?? 'No Display Hint';
             this.office = item.prodOffice;
             this.officeTitle = getFullOfficeString(item.prodOffice);
 

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -125,6 +125,9 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
 
             this.contentType = item.contentType;
             this.contentTypeTitle = toTitleCase(item.contentType);
+            this.contentTypeAndDisplayHintTitle = item.displayHint 
+                ? `${toTitleCase(item.contentType)}(${toTitleCase(item.displayHint)})` 
+                : toTitleCase(item.contentType)
             this.office = item.prodOffice;
             this.officeTitle = getFullOfficeString(item.prodOffice);
 

--- a/public/components/content-list-item/templates/content-type.html
+++ b/public/components/content-list-item/templates/content-type.html
@@ -1,3 +1,3 @@
-<td class="content-list-item__field--content-type" title="{{ contentItem.contentTypeTitle }}">
+<td class="content-list-item__field--content-type" title="{{ contentItem.contentTypeAndDisplayHintTitle }}">
     <i class="content-list-item__icon--content-type" wf-icon="{{ contentItem.contentType }}"/>
 </td>

--- a/public/components/content-list-item/templates/content-type.html
+++ b/public/components/content-list-item/templates/content-type.html
@@ -1,3 +1,3 @@
-<td class="content-list-item__field--content-type" title="{{ contentItem.contentTypeAndDisplayHintTitle }}">
+<td class="content-list-item__field--content-type" title="{{ contentItem.contentTypeTitle }}" data-display-hint="{{ contentItem.displayHintDescription }}">
     <i class="content-list-item__icon--content-type" wf-icon="{{ contentItem.contentType }}"/>
 </td>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new PUT endpoint for the recently added displayHint property.

adds the value of the display hint as a data attribute on the table cell displaying the content-type icon. This is to verify that thee value is set for debugging only. We will not be read to use the property in a user-visible way (EG by using an icon matching the article special formats, or indicating a piece flagged as "immersive") until it is being populated for all new Stubs the existing Stubs have been backfilled to include the display hints of the composer piece.

corresponding change in Workflow : https://github.com/guardian/workflow/pull/1132 

## How to test

This PR won't have an effect until an application can call the new end point. We can defer merging this PR until a composer Branch is available to test it with.

## How can we measure success?

It will be possible to PUT changes to the display hint from Composer, using the control in the "advanced" tab - once Composer has been updated to make the PUT request to workflow as a side effect of changing it in composer

## Have we considered potential risks?

Should be safe - the end point follows an existing pattern.

