### PR TITLE
read article format and display hint when importing from composer

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -14,9 +14,9 @@
         </div>
         <div class="form-horizontal clearfix">
                 <div class="format-dropdown" ng-if="(showFormatDropdown && stubFormatIsCorrectlyPopulated())">
-                <label for="stub_format">Format</label>
+                    <label for="stub_format">Format</label>
                     <div>
-                        <select id="stub_format" name="articleFormat" ng-model="stub.articleFormat" ng-options="f.value as f.name for f in articleFormats"></select>
+                        <select ng-disabled="mode === 'import'" id="stub_format" name="articleFormat" ng-model="stub.articleFormat" ng-options="f.value as f.name for f in articleFormats"></select>
                     </div>
                 </div>
             <div class="form-group col-xs-8">

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import './telemetry-service';
-import { getSpecialFormatFromLabel, contentTypeToComposerContentType } from './model/special-formats.ts';
+import { getSpecialFormatFromLabel, contentTypeToComposerContentType, specialFormats } from './model/special-formats.ts';
 
 angular.module('wfComposerService', ['wfTelemetryService'])
     .service('wfComposerService', ['$http', '$q', 'config', '$log', 'wfHttpSessionService', 'wfTelemetryService', wfComposerService]);
@@ -47,6 +47,10 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
     const composerParseMap = {
         composerId: (d) => d.id,
         contentType: (d) => d.type,
+        articleFormat: (d) => {
+            const displayHint = deepSearch(d, ['preview', 'data', 'settings', 'displayHint', 'data'])
+            return specialFormats.find(f => f.value === displayHint)?.label
+        },
         headline: (d) => deepSearch(d, ['preview', 'data', 'fields', 'headline', 'data']) || undefined,
         published: (d) => d.published,
         timePublished: (d) => new Date(deepSearch(d, ['contentChangeDetails', 'data', 'published', 'date']) || undefined),
@@ -61,7 +65,8 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
         lastModified: (d) => new Date(deepSearch(d, ['contentChangeDetails', 'data', 'lastModified', 'date']) || undefined),
         lastModifiedBy: (d) => deepSearch(d, ['contentChangeDetails', 'data', 'lastModified', 'user', 'firstName']) + ' ' + deepSearch(d, ['contentChangeDetails', 'data', 'lastModified', 'user', 'lastName']),
         commissionedLength: (d) => deepSearch(d, ['preview', 'data', 'fields', 'commissionedLength', 'data']) || undefined,
-        missingCommissionedLengthReason: (d) => deepSearch(d, ['preview', 'data', 'fields', 'missingCommissionedLengthReason', 'data']) || undefined
+        missingCommissionedLengthReason: (d) => deepSearch(d, ['preview', 'data', 'fields', 'missingCommissionedLengthReason', 'data']) || undefined,
+        displayHint: (d) => deepSearch(d, ['preview', 'data', 'settings', 'displayHint', 'data']) || undefined,
     };
 
 


### PR DESCRIPTION
## What does this change?

The "import content" feature (bottom of the "create new" menu) allows Composer pieces to be tracked by providing the composer URL. Workflow-frontend fetches the data, and parses it in to a Content Stub.

This PR updates that feature to map the content's "displayHint" setting to the `stub.displayHint` also to the `stub.articleFormat` (the label of the special format, if any, corresponding to the displayHint)

Having a corrected populated `articleFormat` results in the "article format" dropdown being rendered on the Stub Modal - as we don't want to value to be changed on an existing composer article, the dropdown is disabled if the modal is in "import" mode.


## How to test

 - Create a special format article in composer (do not track in workflow)
 - In workflow, open the "import content" modal from the "create new" menu
 - paste the composer URL to your article into the URL field
 - the disabled "article format" dropdown should show on the form
 - on completing the required fields and clicking 'submit' the display hint should be persisted in the new Workflow Stub (this can be verified by checking the "data-display-hint" attribute on the table cell with the content type icon

If you repeat the process with a normal article or other content type (eg gallery), the piece should import as normal.

## How can we measure success?

Workflow will be aware of the display hint of any pieces imported from Composer - this will support the move to allowing filtering and displaying special format types.

## Have we considered potential risks?

Should be safe.

## Images

<img width="627" alt="Screenshot 2025-02-05 at 10 27 58" src="https://github.com/user-attachments/assets/21ef1ce3-ace6-45a5-a786-fa1bad662254" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
