### PR TITLE
Remove multi-bylines feature switch

### DIFF
--- a/public/components/feature-switches/feature-switches.js
+++ b/public/components/feature-switches/feature-switches.js
@@ -21,8 +21,6 @@ function wfFeatureSwitchesDirective() {
     };
 }
 
-export const multiBylineFeatureSwitchKey = 'multiByline';
-
 class FeatureSwitches {
     constructor(switches, entries) {
         // this.switches should be a single object with the type { [key]: value }
@@ -41,9 +39,11 @@ class FeatureSwitches {
 }
 
 function wfFeatureSwitchesController ($scope, wfPreferencesService) {
-    const featureSwitchKeys = [multiBylineFeatureSwitchKey];
+    const featureSwitchKeys = [
+        // e.g. 'multiByline'
+    ];
     $scope.readableNames = {
-        [multiBylineFeatureSwitchKey]: 'Multi-byline',
+        // e.g. 'multiByline': 'Multi-byline',
     }
 
     const getDefaultFeatureSwitchValues = () => {

--- a/public/lib/model/special-formats.ts
+++ b/public/lib/model/special-formats.ts
@@ -5,7 +5,7 @@ const specialFormats: SpecialArticleFormat[] = [
     { label: 'Q&A Explainer', value: 'qAndA' },
     { label: 'Timeline', value: 'timeline' },
     { label: 'Mini profiles', value: 'miniProfiles' },
-    { label: 'Multi-byline', value: 'multiByline', behindFeatureSwitch: 'multiByline' },
+    { label: 'Multi-byline', value: 'multiByline' },
 ]
 
 const setDisplayHintForFormat = (stub: Stub): Stub => {


### PR DESCRIPTION
## What does this change?

Remove multi-bylines feature switch in preparation for a roll-out of the new format.

## How to test

You should no longer need to enable a feature switch to see the "Multi-byline" option in the "Create new" dropdown

I have tested this on CODE.

## How can we measure success?

Anyone can create a multi-byline article via workflow

## Have we considered potential risks?

No risks

## Images

<img width="161" alt="Screenshot 2025-02-10 at 11 50 28" src="https://github.com/user-attachments/assets/a3e813f4-0359-4b78-90fc-f8525af2c389" />