### PR TITLE
WIP: Enable strict mode

### DIFF
--- a/public/react/react2angular.tsx
+++ b/public/react/react2angular.tsx
@@ -18,7 +18,7 @@ import { render, unmountComponentAtNode } from 'react-dom'
  *   const AngularComponent = react2angular(ReactComponent, ['foo'])
  *   ```
  */
-export function react2angular<Props>(
+export function react2angular<Props extends Map<string, any>>(
     Class: React.ComponentType<Props>,
     bindingNames: (keyof Props)[],
     injectNames: string[] = []

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "noImplicitAny": true,
+        "strict": true,
         "module": "commonjs",
         "target": "es2017",
         "jsx": "react-jsx",


### PR DESCRIPTION
## What does this change?

The TypeScript docs [recommend enabling strict mode](https://www.typescriptlang.org/docs/handbook/2/basic-types.html#strictness) for extra type checks (e.g. null checks), so this PR enables it.

Turning it on causes only one error to appear (🎉), which this PR also fixes by adding a type bound to the props parameter in react2angular.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
