### PR TITLE
Change code owner to Workflow and Collaboration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @guardian/digital-cms
+* @guardian/workflow-and-collaboration


### PR DESCRIPTION
## What does this change?

Since the recent reorganisation, I believe Workflow and Collaboration (the team I am on) should be the code owner for this repository. This PR makes it so.

## How to test

- confirm that github has flagged the file as valid
- check after merging that code-owner review requests are for [Workflow and Collaboration](https://github.com/orgs/guardian/teams/workflow-and-collaboration)