### PR TITLE
Add type guard for value expected to be a string

### DIFF
--- a/public/layouts/dashboard/dashboard-toolbar.js
+++ b/public/layouts/dashboard/dashboard-toolbar.js
@@ -29,7 +29,10 @@ angular.module('wfDashboardToolbar', ['wfFiltersService', 'wfDateService', 'wfPr
 
         function buildSelectedSections () {
             var sectionsString = wfFiltersService.get('section');
-            var sectionsStringArray = sectionsString ? sectionsString.split(',') : [];
+            var sectionsStringArray =
+                (typeof sectionsString === "string")
+                ? sectionsString.split(',')
+                : [];
             return sections.filter((el) => sectionsStringArray.indexOf(el.name) !== -1);
         }
 


### PR DESCRIPTION
## What does this change?

[A recent error in Sentry](https://the-guardian.sentry.io/issues/6362818459/?alert_rule_id=56564&alert_timestamp=1741252090194&alert_type=email&notification_uuid=58661c31-1ebe-47a1-927e-d679b91117f9&project=33134&referrer=alert_email) appears to indicate that sectionsString here is truthy but not a string. Since the code seems to expect it to be a string, this PR adds a type guard to make sure we only use the value if it is a string.

It seems this value comes from the request URL, though I’m not 100% sure how. I’m also not sure how it came to be a non-string value.