### PR TITLE
Add the tools audit tracking pixel to Workflow

### DIFF
--- a/app/views/layout.scala.html
+++ b/app/views/layout.scala.html
@@ -32,6 +32,17 @@
 
 @content
 
+<!-- Tracking pixel for telemetry -->
+<script>
+  const domainMatch = /^.*\.(?<environment>local|code)\.dev-gutools\.co\.uk$|^.*\.gutools\.co\.uk$/
+    .exec(location.hostname);
+  if (domainMatch) {
+    const stage = (domainMatch.groups?.environment || "PROD");
+    const telemetryUrl = stage === "PROD" ? "user-telemetry.gutools.co.uk" : `user-telemetry.${stage}.dev-gutools.co.uk`;
+    new Image().src = `https://${telemetryUrl}/guardian-tool-accessed?app=workflow&stage=${stage.toUpperCase()}&path=${window.location.pathname}`;
+  }
+</script>
+
 <!-- build-commit-id: @build.BuildInfo.gitCommitId -->
 
 </body>

--- a/app/views/layout.scala.html
+++ b/app/views/layout.scala.html
@@ -33,15 +33,7 @@
 @content
 
 <!-- Tracking pixel for telemetry -->
-<script>
-  const domainMatch = /^.*\.(?<environment>local|code)\.dev-gutools\.co\.uk$|^.*\.gutools\.co\.uk$/
-    .exec(location.hostname);
-  if (domainMatch) {
-    const stage = (domainMatch.groups?.environment || "PROD");
-    const telemetryUrl = stage === "PROD" ? "user-telemetry.gutools.co.uk" : `user-telemetry.${stage}.dev-gutools.co.uk`;
-    new Image().src = `https://${telemetryUrl}/guardian-tool-accessed?app=workflow&stage=${stage.toUpperCase()}&path=${window.location.pathname}`;
-  }
-</script>
+<script src="@routes.Assets.versioned("tracking-pixel.js")"></script>
 
 <!-- build-commit-id: @build.BuildInfo.gitCommitId -->
 

--- a/public/tracking-pixel.js
+++ b/public/tracking-pixel.js
@@ -1,0 +1,7 @@
+const domainMatch = /^.*\.(?<environment>local|code)\.dev-gutools\.co\.uk$|^.*\.gutools\.co\.uk$/
+    .exec(location.hostname);
+if (domainMatch) {
+    const stage = (domainMatch.groups?.environment || "PROD");
+    const telemetryUrl = stage === "PROD" ? "user-telemetry.gutools.co.uk" : `user-telemetry.${stage}.dev-gutools.co.uk`;
+    new Image().src = `https://${telemetryUrl}/guardian-tool-accessed?app=workflow&stage=${stage.toUpperCase()}&path=${window.location.pathname}`;
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adds the [User Telemetry tracking pixel ](https://github.com/guardian/editorial-tools-user-telemetry-service?tab=readme-ov-file#user-telemetry-client), to audit the use of the Workflow frontend.  Results will be visible in the [tools audit dashboard](https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit?orgId=1&var-domain=workflow.gutools.co.uk&var-path=All&var-interval=1d&var-chosen_apps=All&from=now-30d&to=now).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable locally and in CODE. Navigating to different pages should result in outgoing image requests to user-telemetry URLs.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We are able to audit the use of the Workflow tool.
