### PR TITLE
Bumps CI OS version to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
 
         permissions:
             # Allow GitHub to request an OIDC JWT ID token, for exchange with AWS Security Token Service (STS)


### PR DESCRIPTION
As described: 
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/154c1f79-95f0-4937-b2c7-c645180eea3f" />
