### PR TITLE
Update AMI recipe to use Ubuntu 22

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       amiTags:
         AmigoStage: PROD
-        Recipe: editorial-tools-focal-java11-ARM-WITH-cdk-base
+        Recipe: editorial-tools-jammy-java11
         BuiltBy: amigo
       cloudFormationStackName: Workflow-Frontend
       prependStackToCloudFormationStackName: false


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Ubuntu 20.04 (focal) will [stop receiving security updates on 31st May 2025](https://ubuntu.com/about/release-cycle).

Previously the service uses the AMI recipe `editorial-tools-focal-java11-ARM-WITH-cdk-base` which is based on Ubuntu 20.  The pull request updates the riffraff configuration of the service to AMI recipe `editorial-tools-jammy-java11` that changes the base image of the old recipe to Ubuntu 22 (Jammy).

## How to test

I did smoke test on CODE, creating an article in Workflow frontend and making changes to some of its attributes.

## How can we measure success?

Workflow frontend works properly on the new AMI image, and the amiable tool shows that the AMI images with Ubuntu 22 is being used by workflow frontend.

## Have we considered potential risks?

The risk should be fairly low because we only changed the OS on which Workflow frontend is running and our application does not rely on OS-specific features / system calls directly. 