### PR TITLE
Enable templates for interactive articles

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -105,7 +105,7 @@
                     <select class="section-margin" id="stub_section" name="section" ng-model="stub.section" ng-options="section.name for section in sections" required>
                     </select>
                 </div>
-                <div ng-if="contentName === 'Article'">
+                <div ng-if="['Article', 'Interactive'].includes(contentName)">
                     <label for="stub_template">Template</label>
                     <div ng-if="!loadingTemplates && templates.length === 0">
                         <p class="help-block">Cannot load templates. Try logging into Composer directly.</p>


### PR DESCRIPTION
## What does this change?

We recently added support for templates in interactive articles in Composer: https://github.com/guardian/flexible-content/pull/5404

This adds the equivalent support in Workflow.

## How to test

First, save a template for an interactive article in CODE Composer (details [here](https://github.com/guardian/flexible-content/pull/5404)).

Next, deploy this branch to CODE and visit: https://workflow.code.dev-gutools.co.uk

Create new -> Interactive. Fill out required fields. Note that there is a "Template" dropdown beside Commissioned Length. The dropdown should include the template you created before. Select it and press "Create new". 

## How can we measure success?

Interactive templates are supported in workflow.

## Have we considered potential risks?

Low risk.

## Images

https://github.com/user-attachments/assets/60fbd546-e4c6-42b7-ab89-26c36dd45fe3



