### PR TITLE
Adds low priority options to create article form

### DIFF
--- a/public/components/icons/_icons.scss
+++ b/public/components/icons/_icons.scss
@@ -30,7 +30,7 @@
 
         &--priority-low,
         &--priority-very-low {
-            transform: rotate(180deg);
+            transform: rotate(180deg) translateY(2px);
         }
 
         &--priority-low {

--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -118,24 +118,26 @@
             </div>
             <div wf-date-time-picker label="Production deadline" help-text="true" ng-model="stub.due"></div>
             <div class="form-horizontal clearfix">
-                <div class="form-group col-xs-8">
+                <div class="form-group col-xs-9">
                     <label for="stub_priority">Priority</label>
 
                     <div>
                         <div class="btn-group">
+                            <button class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="-2"><i class="stubModal__icon" wf-icon="priority-very-low"></i> Very Low</button>
+                            <button class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="-1"><i class="stubModal__icon" wf-icon="priority-low"></i> Low</button>
                             <button class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="0">Normal</button>
                             <button class="btn btn-default btn-sm" ng-model="stub.priority" ng-disabled="stub.missingCommissionedLengthReason === 'BreakingNews'" btn-radio="1"><i class="stubModal__icon" wf-icon="priority-urgent"></i> Urgent</button>
                             <button class="btn btn-default btn-sm" ng-model="stub.priority" btn-radio="2"><i class="stubModal__icon" wf-icon="priority-very-urgent"></i> Very Urgent</button>
                         </div>
                     </div>
                 </div>
-                <div class="form-group col-xs-5 pull-right">
+                <div class="form-group col-xs-4 pull-right">
                     <label for="stub_legal">Legal</label>
                     <div>
                         <select id="stub_legal" name="needsLegal" ng-model="stub.needsLegal" ng-options="ls.value as ls.name for ls in legalStates"></select>
                     </div>
                 </div>
-                <div class="form-group col-xs-5 pull-right">
+                <div class="form-group col-xs-4 pull-right">
                     <label for="stub_picture_desk">Picture Desk</label>
                     <div>
                         <select id="stub_picture_desk" name="needsPictureDesk" ng-model="stub.needsPictureDesk" ng-options="pds.value as pds.name for pds in pictureDeskStates"></select>
@@ -143,11 +145,11 @@
                 </div>
             </div>
             <div class="form-horizontal clearfix">
-                <div class="form-group col-xs-8">
+                <div class="form-group col-xs-9">
                     <label for="stub_note">Note</label>
                     <input type="text" ng-model="stub.note" id="stub_note" name="note" value="" class="form-control" maxlength="500">
                 </div>
-                <div class="form-group col-xs-5 pull-right">
+                <div class="form-group col-xs-4 pull-right">
                     <label>Production Office</label>
                     <div>
                         <select ng-model="stub.prodOffice"

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -122,6 +122,10 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
 
         const getPriorityName = (priority) => {
             switch (priority){
+                case -2:
+                    return 'Very Low'
+                case -1:
+                    return 'Low'
                 case 0:
                     return 'Normal'
                 case 1:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Addressing https://github.com/guardian/workflow-frontend/issues/515, this PR adds "Very Low" and "Low" priority form options when creating a new stub in Workflow:

| Before | After |
|--------|--------|
| <img width="824" alt="image" src="https://github.com/user-attachments/assets/26cd8d3c-b819-436b-b93c-c063b58c8f74" /> | <img width="824" alt="image" src="https://github.com/user-attachments/assets/a07c07d0-4419-4473-9fa4-6f849effb592" /> | 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable by creating stubs in Workflow with various priority levels, all levels should work as expected!

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users can easily create Very Low and Low priority stubs. 