### PR TITLE
Enable ASG migration in progress option in riffraff

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -4,6 +4,7 @@ deployments:
   workflow-frontend:
     type: autoscaling
     parameters:
+      asgMigrationInProgress: true
     dependencies: [workflow-frontend-ami-update]
   workflow-frontend-ami-update:
     type: ami-cloudformation-parameter


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Enables a riff-raff option to deploy the app to two ASGs. We are currently migration from the legacy VPC to a new VPC with private/public subnets and we set up a ASG in the new VPC in https://github.com/guardian/editorial-tools-platform/pull/879 for workflow-frontend so we expect there to be 2 ASGs.

