### PR TITLE
Remove asg migration parameter from riffraff

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -4,7 +4,6 @@ deployments:
   workflow-frontend:
     type: autoscaling
     parameters:
-      asgMigrationInProgress: true
     dependencies: [workflow-frontend-ami-update]
   workflow-frontend-ami-update:
     type: ami-cloudformation-parameter


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We are going to remove the old infrastructure of Workflow frontend in guardian/editorial-tools-platform#898 and so we should remove the `asgMigrationInProcess` option from riffraff configuration.