### PR TITLE
Update scala version to 2.13.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.sys.env
 
 Test / parallelExecution := false
 
-val scalaVersionNumber = "2.13.12"
+val scalaVersionNumber = "2.13.16"
 
 val buildInfo = Seq(
   buildInfoPackage := "build",


### PR DESCRIPTION
This app is currently using Scala 2.13.12, which [is now nearly two years old](https://www.scala-lang.org/download/2.13.12.html). This commit updates the scala version to 2.13.16.

(I noticed this and decided to change it because my editor integration metals recently started complaining about this version.)

I think we should be ok to rely on CI plus a successful CODE deploy for testing this PR: I would expect scala version changes to cause compilation errors or total failure of the app, not more subtle bugs.