### PR TITLE
Update @guardian/user-telemetry-client to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
-    "@guardian/user-telemetry-client": "^1.1.0",
+    "@guardian/user-telemetry-client": "1.2.1",
     "@types/react": "^17.0.76",
     "@types/react-dom": "^17.0.9",
     "angular": "1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,10 +1222,10 @@
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/user-telemetry-client@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/user-telemetry-client/-/user-telemetry-client-1.1.0.tgz#5805837fa5d6f53db492b7bca6090f534ead7c1c"
-  integrity sha512-3jb0rN/+i2jcvqmDuSs4aSiaVVBuXg3rqjWyT2PSpW+o19zjSUgLzFAZCtZUt95ORuzIKfT4Xqr3c2PvuW8cmw==
+"@guardian/user-telemetry-client@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/user-telemetry-client/-/user-telemetry-client-1.2.1.tgz#f6c255860e5dcf061fa937481c404709424423ae"
+  integrity sha512-ftzaEFggp5avQetNmMjBTewL6TtLWperfDgt01Ho2KfZaK9SsjT6GyHTUpbamCW0WDWfY6ThiQX1ovnt7uRhgA==
   dependencies:
     lodash "^4.17.20"
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

I don't think there are any actual changes in behaviour since v1.1.0, and the adjustment to use a lockfile in the upstream project won't add any appreciable extra security here as we were already using one in this project, just seems like a good idea to keep the dependency up to date.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Not sure. There are very few usages of `sendTelemetryEvent()` in this project it seems. I will figure out the steps required to send `WORKFLOW_COMMISSIONED_LENGTH_SUGGESTION_PRESSED` and then put reproduction steps here.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

User telemetry continuing to work

## Visual testing

Changes to the [Flexible Frontend](../flexible-frontend/README.md) project should be tested visually using Chromatic. Add the `run_chromatic` label to pull requests to trigger a visual test run.

### Visual Testing Required?

- [ ] Yes
- [x] No
