### PR TITLE
Fix setting the book section and publication date

### DIFF
--- a/public/components/content-list-drawer/content-list-drawer.html
+++ b/public/components/content-list-drawer/content-list-drawer.html
@@ -414,7 +414,7 @@
                                 </button>
                                 <div class="editable--edit editable--inline autocomplete" ng-show="showBookTagPicker">
                                     <input class="text-input fullwidth"
-                                        ng-model="$parent.bookSectionQuery"
+                                        ng-model="bookSectionQuery"
                                         placeholder="Enter a book section…"
                                         name="bookSection"
                                         autocomplete="off"
@@ -463,7 +463,7 @@
                                         <div
                                         wf-date-time-picker
                                         wf-update-on="enter"
-                                        ng-model="$parent.currentPublicationDatePickerValue"
+                                        ng-model="currentPublicationDatePickerValue"
                                         wf-on-cancel="publicationDateTimeEdit = false; revertPlannedPublicationDate()"
                                         wf-cancel-on="blur"
                                         wf-on-submit="updatePlannedPublicationDate(); publicationDateTimeEdit = false;"

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -339,7 +339,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             };
 
             $scope.updatePlannedPublicationDate = function () {
-                updateField("plannedNewspaperPublicationDate", wfFormatDateTime($scope.currentPublicationDatePickerValue,'YYYY-MM-DD'));
+                updateField("plannedNewspaperPublicationDate", wfFormatDateTime($scope.$parent.currentPublicationDatePickerValue,'YYYY-MM-DD'));
             };
 
             $scope.updateCommissionedLength = function (newValue) {
@@ -437,7 +437,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             });
 
             $scope.setBookSections = function () {
-                var results = wfTagApiService.searchTags($scope.bookSectionQuery, 'newspaper book section');
+                var results = wfTagApiService.searchTags($scope.$parent.bookSectionQuery, 'newspaper book section');
                 results.then(function (response) {
                 const tags = (response && response.data) || []
                     return tags.map(function (tag) {

--- a/public/components/content-list-drawer/content-list-drawer.js
+++ b/public/components/content-list-drawer/content-list-drawer.js
@@ -339,7 +339,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             };
 
             $scope.updatePlannedPublicationDate = function () {
-                updateField("plannedNewspaperPublicationDate", wfFormatDateTime($scope.$parent.currentPublicationDatePickerValue,'YYYY-MM-DD'));
+                updateField("plannedNewspaperPublicationDate", wfFormatDateTime($scope.currentPublicationDatePickerValue,'YYYY-MM-DD'));
             };
 
             $scope.updateCommissionedLength = function (newValue) {
@@ -437,7 +437,7 @@ export function wfContentListDrawer($rootScope, config, $timeout, $window, conte
             });
 
             $scope.setBookSections = function () {
-                var results = wfTagApiService.searchTags($scope.$parent.bookSectionQuery, 'newspaper book section');
+                var results = wfTagApiService.searchTags($scope.bookSectionQuery, 'newspaper book section');
                 results.then(function (response) {
                 const tags = (response && response.data) || []
                     return tags.map(function (tag) {


### PR DESCRIPTION
## What does this change?

Fixes the methods in "contentListDrawerController" for setting the book publication date and selecting a book section tag from the "management" tab of the content drawer.

In both cases, the bug was that controller method was trying to access the property from it's own $scope, but the values are actually held on $scope.$parent for the controls that have them methods attached.

## How has this change been tested?

running locally, you can now open the draw for a piece of content without a book section and:
 - type into the section input and get the autocomplete suggestions from the tag search, choose a tag to confirm
 - into a date and successfully submit the value

when on main:
 - the input will not respond as the method never fetches a list of tags (since the query string is not being accessed)
 - submitting a date will do nothing in the UI and show an error in the console (undefined value used instead of the date input.) 

## How can we measure success?

Fixes  broken interactions

## Have we considered potential risks?

Should be safe - was previously broken

## Images

<img width="336" height="438" alt="Screenshot 2026-04-13 at 15 34 20" src="https://github.com/user-attachments/assets/051f740c-8114-48ce-aaf8-c8f49fbb44da" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
