### PR TITLE
hide deprecated tags

### DIFF
--- a/public/lib/tag-api-service.js
+++ b/public/lib/tag-api-service.js
@@ -44,12 +44,6 @@ function tagApiService($http, $q) {
     return getTag(id)
   }
 
-  function getPublications() {
-    return tags({
-      type: "publication",
-      limit: 50,
-    })
-  }
 
   function searchTags(query, types, subType) {
     if (query) {
@@ -74,8 +68,6 @@ function tagApiService($http, $q) {
     }
   }
 
-  this.getPublication = getPublications;
   this.searchTags = searchTags;
-  this.getTag = getTag;
   this.getHyperTag = getHyperTag;
 }

--- a/public/lib/tag-api-service.js
+++ b/public/lib/tag-api-service.js
@@ -45,7 +45,7 @@ function tagApiService($http, $q) {
   }
 
 
-  function searchTags(query, types, subType) {
+  function searchTags(query, types, subType, includeDeprecated) {
     if (query) {
       var wildcardQuery = query.replace(/^\\/, "*"); // using '\' as a wildcard character is a hangover from R2
 
@@ -60,6 +60,10 @@ function tagApiService($http, $q) {
 
       if (subType) {
         params.subType = subType;
+      }
+
+      if (!includeDeprecated) {
+        params.deprecated = "false"
       }
 
       return tags(params);


### PR DESCRIPTION

## What does this change?

The `searchTags` method of the tagManager service will now exclude deprecated tags by default. This should be a no-op in production there are no deprecated Tags in the PROD tag DB (the UI does not expose the new property yet).

The only usage of the tagManager to search for tags is to set the print location book section tag.

## How has this change been tested?

Ran tagmanager locally on https://github.com/guardian/tagmanager/pull/637 and marked the "Obs: 100 Great British Woods and Forests (nbs)" tag (https://tagmanager.local.dev-gutools.co.uk/hyper/tags/43543) as deprecated.

Opened the management tab of content drawer for an article and type "obs" into the Print location / book section search input. 

On this branch,  "Obs: 100 Great British Woods and Forests (nbs)" tag was no longer included in the results, but is included on main.


## How can we measure success?

We will be able to deprecate historical book sections (like the observer related ones) so users only see the relevant options.

## Have we considered potential risks?

This PR doesn't add a UI option for allowing the user to see deprecated tag, but that is unllikely to be required as workflow is not typcally used for historical content. If necessary, Composer could be used to restore deprecated section tags.

## Images

<img width="667" height="624" alt="Screenshot 2026-04-15 at 16 40 52" src="https://github.com/user-attachments/assets/73f651be-ec51-49fc-bbb8-cc326a664c8e" />

