### PR TITLE
Update pan-domain-authentication to latest version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     "joda-time" % "joda-time" % "2.14.0"
   )
 
-  val pandaVersion = "19.0.0-PREVIEW.updatebcprov-jdk18on-184.2026-04-28T1547.ddfc6716"
+  val pandaVersion = "19.0.0"
 
   val authDependencies = Seq(
     "com.gu" %% "pan-domain-auth-play_3-0" % pandaVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     "joda-time" % "joda-time" % "2.14.0"
   )
 
-  val pandaVersion = "12.0.0"
+  val pandaVersion = "19.0.0-PREVIEW.updatebcprov-jdk18on-184.2026-04-28T1547.ddfc6716"
 
   val authDependencies = Seq(
     "com.gu" %% "pan-domain-auth-play_3-0" % pandaVersion,


### PR DESCRIPTION
## What does this change?

The latest version of pan-domain-authentication ([release currently underway](https://github.com/guardian/pan-domain-authentication/actions/runs/25160066139)) contains [a fix for a high-severity vulnerability in bouncycastle](https://github.com/guardian/pan-domain-authentication/pull/257). 

## How has this change been tested?

I [tested the pan-domain-authentication fix branch locally](https://github.com/guardian/pan-domain-authentication/pull/257#issuecomment-4351611267) by updating the dependency here and running this app and workflow locally, and the app was able to successfully log me in via oauth after I deleted my cookie.