### PR TITLE
Add tracking tags to external data model

### DIFF
--- a/common-lib/src/main/scala/models/Stub.scala
+++ b/common-lib/src/main/scala/models/Stub.scala
@@ -54,6 +54,7 @@ case class ExternalData(
                          rightsDeveloperCommunity: Option[Boolean] = None,
                          byline: Option[String] = None,
                          displayHint: Option[String] = None,
+                         trackingTags: Option[List[String]] = None,
                          intendedAudience: Option[String] = None) {
 }
 


### PR DESCRIPTION
## What does this change?

Updates the stub ExternalData model to include the new `trackingTags` field introduced by https://github.com/guardian/workflow/pull/1481