### PR TITLE
update Stand, replace IntendedAudienceSignifier prop logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sass": "^1.77.8",
     "sass-loader": "^8.0.2",
     "style-loader": "^0.13.1",
-    "terser-webpack-plugin": "^3.0.2",
+    "terser-webpack-plugin": "^5.6.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.0.0",
     "url-loader": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "style-loader": "^0.13.1",
     "terser-webpack-plugin": "^3.0.2",
     "ts-loader": "^9.5.1",
-    "typescript": "^4.6.2",
+    "typescript": "^5.0.0",
     "url-loader": "^4.1.1",
     "webpack": "5.94.0",
     "webpack-cli": "^5.1.4",
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
-    "@guardian/stand": "^0.0.37",
+    "@guardian/stand": "^0.0.42",
     "@guardian/user-telemetry-client": "1.2.1",
     "@types/react": "^17.0.76",
     "@types/react-dom": "^17.0.9",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
-    "@guardian/stand": "^0.0.42",
+    "@guardian/stand": "^0.0.47",
     "@guardian/user-telemetry-client": "1.2.1",
     "@types/react": "^17.0.76",
     "@types/react-dom": "^17.0.9",

--- a/public/components/content-list-item/templates/intended-audience.html
+++ b/public/components/content-list-item/templates/intended-audience.html
@@ -2,8 +2,7 @@
   class="content-list-item__field--intended-audience"
   title="Intended Audience: {{ contentItem.intendedAudience || 'none' }}"
 >
-  <intended-audience-signifier 
-   production-office="contentItem.office"
-   intended-audience="contentItem.intendedAudience"
+  <intended-audience-signifier
+    intended-audience="contentItem.intendedAudience"
   ></intended-audience-signifier>
 </td>

--- a/public/components/content-list-item/templates/intended-audience.html
+++ b/public/components/content-list-item/templates/intended-audience.html
@@ -1,6 +1,5 @@
 <td
   class="content-list-item__field--intended-audience"
-  title="Intended Audience: {{ contentItem.intendedAudience || 'none' }}"
 >
   <intended-audience-signifier
     intended-audience="contentItem.intendedAudience"

--- a/public/lib/model/intended-audience.ts
+++ b/public/lib/model/intended-audience.ts
@@ -11,9 +11,6 @@ type IntendedAudienceOptionValue =
 type AudienceTagSlug = "global" | "uk" | "au" | "us";
 const expectedAudienceSlugs = ["global", "uk", "au", "us"];
 
-export const isAudienceTagSlug = (text: string) =>
-  expectedAudienceSlugs.includes(text);
-
 export const intendedAudienceOptions: {
   displayName: string;
   value: IntendedAudienceOptionValue;

--- a/public/react/IntendedAudienceWrapper.tsx
+++ b/public/react/IntendedAudienceWrapper.tsx
@@ -1,68 +1,64 @@
 import {
   IntendedAudienceSignifier,
   type IntendedAudienceSignifierProps,
-} from "@guardian/stand/intendedAudienceSignifier";
+} from "@guardian/stand/IntendedAudienceSignifier";
 import React from "react";
 import { isAudienceTagSlug } from "../lib/model/intended-audience";
 
 type Props = {
   intendedAudience?: string;
-  productionOffice?: string;
 };
 
-const parseProductionOfficeToSource = (
-  source?: string,
-): IntendedAudienceSignifierProps["source"] => {
-  if (!source) {
-    return "UK";
-  }
-  switch (source?.toUpperCase()) {
-    case "US":
-      return "US";
-    case "AU":
-    case "AUS":
-      return "AUS";
-    case "UK":
-    default:
-      return "UK";
-  }
-};
+type DomesticRegion = "UK" | "US" | "AUS";
 
-const slugsToSource = (
+const getHasGlobal = (audienceTagTokens: string[]): boolean =>
+  audienceTagTokens.includes("global");
+
+const getDomesticRegion = (
   audienceTagTokens: string[],
-): IntendedAudienceSignifierProps["source"] => {
+): DomesticRegion | undefined => {
   if (audienceTagTokens.includes("au")) {
     return "AUS";
   }
   if (audienceTagTokens.includes("us")) {
     return "US";
   }
-  return "UK";
+  if (audienceTagTokens.includes("uk")) {
+    return "UK";
+  }
+  return undefined;
 };
 
-const slugsToIntendedAudience = (
-  audienceTagTokens: string[],
-): IntendedAudienceSignifierProps["intendedAudience"] => {
-  if (audienceTagTokens.length === 0) {
-    return "Don't know";
+const slugsToSource = (
+  hasGlobal: boolean,
+  domesticRegion: DomesticRegion | undefined,
+): IntendedAudienceSignifierProps["source"] => {
+  if (domesticRegion) {
+    return domesticRegion;
   }
-  if (audienceTagTokens.includes("global")) {
-    return audienceTagTokens.length === 1 ? "Global" : "Domestic For Global";
+  return hasGlobal ? "global" : undefined;
+};
+
+const slugsToTarget = (
+  hasGlobal: boolean,
+  domesticRegion: DomesticRegion | undefined,
+): IntendedAudienceSignifierProps["target"] => {
+  if (hasGlobal) {
+    return "global";
   }
-  return "Domestic for Domestic";
+  return domesticRegion;
 };
 
 const deriveProps = (
   stubIntendedAudience: string | undefined,
-  productionOffice: string | undefined,
 ): {
   source: IntendedAudienceSignifierProps["source"];
-  intendedAudience: IntendedAudienceSignifierProps["intendedAudience"];
+  target: IntendedAudienceSignifierProps["target"];
 } => {
   if (!stubIntendedAudience) {
     return {
-      source: parseProductionOfficeToSource(productionOffice),
-      intendedAudience: "Don't know",
+      source: undefined,
+      target: undefined,
     };
   }
 
@@ -70,30 +66,25 @@ const deriveProps = (
     .split(",")
     .filter(isAudienceTagSlug);
 
+  const hasGlobal = getHasGlobal(audienceTagSlugs);
+  const domesticRegion = getDomesticRegion(audienceTagSlugs);
+
   return {
-    source: slugsToSource(audienceTagSlugs),
-    intendedAudience: slugsToIntendedAudience(audienceTagSlugs),
+    source: slugsToSource(hasGlobal, domesticRegion),
+    target: slugsToTarget(hasGlobal, domesticRegion),
   };
 };
 
 export const IntendedAudienceWrapper: React.FunctionComponent<Props> = ({
   intendedAudience: stubIntendedAudience,
-  productionOffice,
 }: Props) => {
-  const { intendedAudience, source } = deriveProps(
-    stubIntendedAudience,
-    productionOffice,
-  );
+  const { target, source } = deriveProps(stubIntendedAudience);
 
   return (
     <IntendedAudienceSignifier
-      intendedAudience={intendedAudience}
+      target={target}
       source={source}
       theme={{
-        svg: {
-          width: "16px",
-          height: "12px",
-        },
         typography: {
           font: "normal 460 12px GuardianAgateSans1Web",
         },

--- a/public/react/IntendedAudienceWrapper.tsx
+++ b/public/react/IntendedAudienceWrapper.tsx
@@ -1,94 +1,41 @@
 import {
   IntendedAudienceSignifier,
+  mapTagsToSourceAndTarget,
   type IntendedAudienceSignifierProps,
 } from "@guardian/stand/IntendedAudienceSignifier";
 import React from "react";
-import { isAudienceTagSlug } from "../lib/model/intended-audience";
 
 type Props = {
   intendedAudience?: string;
 };
 
-type DomesticRegion = "UK" | "US" | "AUS";
-
-const getHasGlobal = (audienceTagTokens: string[]): boolean =>
-  audienceTagTokens.includes("global");
-
-const getDomesticRegion = (
-  audienceTagTokens: string[],
-): DomesticRegion | undefined => {
-  if (audienceTagTokens.includes("au")) {
-    return "AUS";
-  }
-  if (audienceTagTokens.includes("us")) {
-    return "US";
-  }
-  if (audienceTagTokens.includes("uk")) {
-    return "UK";
-  }
-  return undefined;
-};
-
-const slugsToSource = (
-  hasGlobal: boolean,
-  domesticRegion: DomesticRegion | undefined,
-): IntendedAudienceSignifierProps["source"] => {
-  if (domesticRegion) {
-    return domesticRegion;
-  }
-  return hasGlobal ? "global" : undefined;
-};
-
-const slugsToTarget = (
-  hasGlobal: boolean,
-  domesticRegion: DomesticRegion | undefined,
-): IntendedAudienceSignifierProps["target"] => {
-  if (hasGlobal) {
-    return "global";
-  }
-  return domesticRegion;
-};
-
-const deriveProps = (
-  stubIntendedAudience: string | undefined,
-): {
-  source: IntendedAudienceSignifierProps["source"];
-  target: IntendedAudienceSignifierProps["target"];
-} => {
-  if (!stubIntendedAudience) {
-    return {
-      source: undefined,
-      target: undefined,
-    };
+const getSourceAndTarget = (intendedAudience?: string) => {
+  if (!intendedAudience) {
+    return undefined;
   }
 
-  const audienceTagSlugs = stubIntendedAudience
-    .split(",")
-    .filter(isAudienceTagSlug);
+  // We intend to deprecate the stub.externalData.intendedAudience (Option[String], comma separated tag slugs) and use
+  // stub.externalData.trackingTags (Option[List[String]], array of tag paths)
 
-  const hasGlobal = getHasGlobal(audienceTagSlugs);
-  const domesticRegion = getDomesticRegion(audienceTagSlugs);
-
-  return {
-    source: slugsToSource(hasGlobal, domesticRegion),
-    target: slugsToTarget(hasGlobal, domesticRegion),
-  };
+  return mapTagsToSourceAndTarget(
+    intendedAudience
+      .split(",")
+      .map((slug) => ({ path: `tracking/audience/${slug}` })),
+  );
 };
 
 export const IntendedAudienceWrapper: React.FunctionComponent<Props> = ({
-  intendedAudience: stubIntendedAudience,
+  intendedAudience,
 }: Props) => {
-  const { target, source } = deriveProps(stubIntendedAudience);
+  const sourceAndTarget = getSourceAndTarget(intendedAudience);
+  if (!sourceAndTarget) {
+    return null; // do not render the "Don't know" signifier in the table
+  }
 
   return (
     <IntendedAudienceSignifier
-      target={target}
-      source={source}
-      theme={{
-        typography: {
-          font: "normal 460 12px GuardianAgateSans1Web",
-        },
-      }}
+      target={sourceAndTarget.target}
+      source={sourceAndTarget.source}
     />
   );
 };

--- a/public/react/IntendedAudienceWrapper.tsx
+++ b/public/react/IntendedAudienceWrapper.tsx
@@ -1,7 +1,6 @@
 import {
   IntendedAudienceSignifier,
-  mapTagsToSourceAndTarget,
-  type IntendedAudienceSignifierProps,
+  mapTagsToSourceAndTarget
 } from "@guardian/stand/IntendedAudienceSignifier";
 import React from "react";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1217,11 +1217,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gar/promisify@^1.0.1":
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
-  integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
-
 "@guardian/stand@^0.0.47":
   version "0.0.47"
   resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.47.tgz#a4d0de4de9cec4c7ed15d921262abef51170aa2f"
@@ -1311,22 +1306,6 @@
   integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
   dependencies:
     eslint-scope "5.1.1"
-
-"@npmcli/fs@^1.0.0":
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz"
-  integrity sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==
-  dependencies:
-    "@gar/promisify" "^1.0.1"
-    semver "^7.3.5"
-
-"@npmcli/move-file@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz"
-  integrity sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==
-  dependencies:
-    mkdirp "^1.0.4"
-    rimraf "^3.0.2"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1617,6 +1596,11 @@ acorn@^7.4.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+acorn@^8.15.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+
 acorn@^8.7.1:
   version "8.12.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
@@ -1633,14 +1617,6 @@ agent-base@^7.0.2, agent-base@^7.1.0:
   integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
   dependencies:
     debug "^4.3.4"
-
-aggregate-error@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  dependencies:
-    clean-stack "^2.0.0"
-    indent-string "^4.0.0"
 
 ajv-formats@^2.1.1:
   version "2.1.1"
@@ -1984,30 +1960,6 @@ bytes@3.1.2:
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-cacache@^15.0.5:
-  version "15.3.0"
-  resolved "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz"
-  integrity sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
-  dependencies:
-    "@npmcli/fs" "^1.0.0"
-    "@npmcli/move-file" "^1.0.1"
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    glob "^7.1.4"
-    infer-owner "^1.0.4"
-    lru-cache "^6.0.0"
-    minipass "^3.1.1"
-    minipass-collect "^1.0.2"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.2"
-    mkdirp "^1.0.3"
-    p-map "^4.0.0"
-    promise-inflight "^1.0.1"
-    rimraf "^3.0.2"
-    ssri "^8.0.1"
-    tar "^6.0.2"
-    unique-filename "^1.1.1"
-
 call-bind@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz"
@@ -2106,11 +2058,6 @@ chokidar@^4.0.1:
   dependencies:
     readdirp "^4.0.1"
 
-chownr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
-  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
-
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz"
@@ -2122,11 +2069,6 @@ clean-css@^4.2.3:
   integrity sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==
   dependencies:
     source-map "~0.6.0"
-
-clean-stack@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -2962,13 +2904,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz"
-  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
-  dependencies:
-    minipass "^3.0.0"
-
 fs-monkey@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.6.tgz#8ead082953e88d992cf3ff844faa907b26756da2"
@@ -3044,7 +2979,7 @@ glob@^10.4.5:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.1.7, glob@^7.2.0:
+glob@^7.1.3, glob@^7.1.7, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -3266,16 +3201,6 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
-
-infer-owner@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz"
-  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -3385,15 +3310,6 @@ jackspeak@^3.1.2:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
-
-jest-worker@^26.2.1:
-  version "26.6.2"
-  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz"
-  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
-  dependencies:
-    "@types/node" "*"
-    merge-stream "^2.0.0"
-    supports-color "^7.0.0"
 
 jest-worker@^27.4.5:
   version "27.5.1"
@@ -3756,13 +3672,6 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
-
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz"
@@ -3854,51 +3763,10 @@ minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minipass-collect@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz"
-  integrity sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
-  dependencies:
-    minipass "^3.0.0"
-
-minipass-flush@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz"
-  integrity sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
-  dependencies:
-    minipass "^3.0.0"
-
-minipass-pipeline@^1.2.2:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz"
-  integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
-  dependencies:
-    minipass "^3.0.0"
-
-minipass@^3.0.0, minipass@^3.1.1:
-  version "3.3.6"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz"
-  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
-  dependencies:
-    yallist "^4.0.0"
-
-minipass@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz"
-  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
-
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
-
-minizlib@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz"
-  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
-  dependencies:
-    minipass "^3.0.0"
-    yallist "^4.0.0"
 
 mkdirp@^0.5.5:
   version "0.5.6"
@@ -3906,11 +3774,6 @@ mkdirp@^0.5.5:
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
-
-mkdirp@^1.0.3, mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^11.7.5:
   version "11.7.5"
@@ -4111,13 +3974,6 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-map@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz"
-  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
-  dependencies:
-    aggregate-error "^3.0.0"
-
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
@@ -4297,11 +4153,6 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
-promise-inflight@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz"
-  integrity sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==
 
 psl@^1.1.33:
   version "1.9.0"
@@ -4547,7 +4398,7 @@ scheduler@^0.20.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-utils@^2.6.1, schema-utils@^2.6.5, schema-utils@^2.6.6:
+schema-utils@^2.6.1, schema-utils@^2.6.5:
   version "2.7.1"
   resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz"
   integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
@@ -4575,6 +4426,16 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
 
+schema-utils@^4.3.0:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.3.tgz#5b1850912fa31df90716963d45d9121fdfc09f46"
+  integrity sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.9.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.1.0"
+
 semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
@@ -4595,7 +4456,7 @@ semver@^7.3.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
-serialize-javascript@7.0.4, serialize-javascript@^4.0.0, serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
+serialize-javascript@7.0.4, serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.4.tgz#c517735bd5b7631dd1fc191ee19cbb713ff8e05c"
   integrity sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==
@@ -4744,13 +4605,6 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-ssri@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz"
-  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
-  dependencies:
-    minipass "^3.1.1"
-
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
@@ -4859,7 +4713,7 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -4899,33 +4753,6 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-tar@^6.0.2:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
-  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
-  dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^5.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
-
-terser-webpack-plugin@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-3.1.0.tgz"
-  integrity sha512-cjdZte66fYkZ65rQ2oJfrdCAkkhJA7YLYk5eGOcGCSGlq0ieZupRdjedSQXYknMPo2IveQL+tPdrxUkERENCFA==
-  dependencies:
-    cacache "^15.0.5"
-    find-cache-dir "^3.3.1"
-    jest-worker "^26.2.1"
-    p-limit "^3.0.2"
-    schema-utils "^2.6.6"
-    serialize-javascript "^4.0.0"
-    source-map "^0.6.1"
-    terser "^4.8.0"
-    webpack-sources "^1.4.3"
-
 terser-webpack-plugin@^5.3.10:
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
@@ -4937,7 +4764,17 @@ terser-webpack-plugin@^5.3.10:
     serialize-javascript "^6.0.1"
     terser "^5.26.0"
 
-terser@^4.6.3, terser@^4.8.0:
+terser-webpack-plugin@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz#47bc41bd8b8fab8383b62ec763b7394829097e7b"
+  integrity sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jest-worker "^27.4.5"
+    schema-utils "^4.3.0"
+    terser "^5.31.1"
+
+terser@^4.6.3:
   version "4.8.1"
   resolved "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz"
   integrity sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==
@@ -4953,6 +4790,16 @@ terser@^5.26.0:
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
+terser@^5.31.1:
+  version "5.48.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.48.0.tgz#8b391171cfbb7ac4a88f9f04ba1cfabc54f643db"
+  integrity sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.15.0"
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
@@ -5098,20 +4945,6 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
-
-unique-filename@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz"
-  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
-  dependencies:
-    unique-slug "^2.0.0"
-
-unique-slug@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz"
-  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
-  dependencies:
-    imurmurhash "^0.1.4"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -5260,14 +5093,6 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     flat "^5.0.2"
     wildcard "^2.0.0"
-
-webpack-sources@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz"
-  integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
-  dependencies:
-    source-list-map "^2.0.0"
-    source-map "~0.6.1"
 
 webpack-sources@^2.2.0:
   version "2.3.1"
@@ -5419,11 +5244,6 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0:
   version "1.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,10 +1222,10 @@
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/stand@^0.0.37":
-  version "0.0.37"
-  resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.37.tgz#db61a14bb1793d92a776de844e7f58826a92b680"
-  integrity sha512-wSbYrHZQ/Zs3CvDspBIQj0u2rt4SoKyxTvK+YVFVaGpSoK0kNacg0EbV9RVrpLVXm370iYnVhH1nBULhMvbYQg==
+"@guardian/stand@^0.0.42":
+  version "0.0.42"
+  resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.42.tgz#957036ac397c96ce5faf35badc6e19b2f9088efc"
+  integrity sha512-ZYXGTf0F4lY50vGgWDAn5h8i2VdJYfR0UampvCKfM0ws27I+ueuRiGm7jmDpH4Ddcv7zh1TcrPd89sUsuO7yTA==
 
 "@guardian/user-telemetry-client@1.2.1":
   version "1.2.1"
@@ -5056,10 +5056,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@^4.6.2:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.0.0:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 ua-parser-js@0.7.33:
   version "0.7.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,10 +1222,10 @@
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/stand@^0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.42.tgz#957036ac397c96ce5faf35badc6e19b2f9088efc"
-  integrity sha512-ZYXGTf0F4lY50vGgWDAn5h8i2VdJYfR0UampvCKfM0ws27I+ueuRiGm7jmDpH4Ddcv7zh1TcrPd89sUsuO7yTA==
+"@guardian/stand@^0.0.47":
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.47.tgz#a4d0de4de9cec4c7ed15d921262abef51170aa2f"
+  integrity sha512-mBwgHqWi1L9F+lVZWcqKCCRwe/LLwzu46UM+S6Q9eNdlRtCqk/NhwZ31OawuNnie0sR5fL4rdloZfnxNDEtVtQ==
 
 "@guardian/user-telemetry-client@1.2.1":
   version "1.2.1"


### PR DESCRIPTION
## What does this change?

Updates the version of Stand used in workflow frontend and uses the `mapTagsToSourceAndTarget` function for deriving the props for the `IntendeAudienceSignifier`.

The new logic now parses the "intendedAudience" string value of the stub.externalData, which represents a list of audience tag slugs (eg "uk", "global", "us,global") to the `source` and `target` props which determines the icons displayed, eg :

| stub.externalData.intendedAudience | source | target|
|-----------|---|---|
"uk".           | UK|UK
"global".     |global|global 
"us,global" |US|global|

The stub table will no longer display the "Don't know" signifier if the audience is not defined.

## How has this change been tested?

Ran locally with the feature switch on and created some new stubs to check the display logic

## How can we measure success?

Keeps the implementations of the component in step.

When we transition to using the array of tracking tags instead of the `stub.externalData.intendedAudience` string , it should be relatively easy to adapt the logic for deriving the props.

## Have we considered potential risks?

Just a display change, should be safe.

