### PR TITLE
default column config to empty array

### DIFF
--- a/public/lib/column-service.js
+++ b/public/lib/column-service.js
@@ -23,7 +23,7 @@ angular.module('wfColumnService', [])
                     self.contentItemTemplate;
 
                     self.preferencePromise = wfPreferencesService.getAllPreferences().then(function resolve(preferencesData) {
-                        var { columnConfiguration, featureSwitches = getDefaultFeatureSwitchValues() } = preferencesData;
+                        var { columnConfiguration = [], featureSwitches = getDefaultFeatureSwitchValues() } = preferencesData;
                         if (typeof columnConfiguration[0] !== "string") {
                             return reject();
                         } else {


### PR DESCRIPTION
## What does this change?

fixes a bug introduced in https://github.com/guardian/workflow-frontend/pull/577/changes#diff-bee766ca2ca169da5b57cc9612d5940159cf9a6fb175b48d327e7ab061bc370dR27

Sets a default value to the columnConfiguration preference - this is expected to be an array of string, but for new users who have not run the app before or toggled any columns, the value will be `undefined`.

## How has this change been tested?

Have run locally and the preferences will still load - but don't have a quick way to test with new empty preferences set

## How can we measure success?

resolves bug - new users can access workflow

