### PR TITLE
change dropdown order to match design

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
-    "@guardian/stand": "^0.0.47",
+    "@guardian/stand": "^0.0.50",
     "@guardian/user-telemetry-client": "1.2.1",
     "@types/react": "^17.0.76",
     "@types/react-dom": "^17.0.9",

--- a/public/lib/model/intended-audience.ts
+++ b/public/lib/model/intended-audience.ts
@@ -2,9 +2,9 @@ import { Stub } from "./stub";
 import { LimitedTag } from "./tags";
 
 type IntendedAudienceOptionValue =
-  | "domestic-for-domestic"
-  | "domestic-for-global"
   | "global"
+  | "domestic-for-global"
+  | "domestic-for-domestic"
   | "don-t-know"
   | null;
 
@@ -20,20 +20,20 @@ export const intendedAudienceOptions: {
     value: null,
   },
   {
-    displayName: "Don't know",
-    value: "don-t-know",
-  },
-  {
-    displayName: "Domestic for Domestic",
-    value: "domestic-for-domestic",
+    displayName: "Global",
+    value: "global",
   },
   {
     displayName: "Domestic for Global",
     value: "domestic-for-global",
   },
   {
-    displayName: "Global",
-    value: "global",
+    displayName: "Domestic for Domestic",
+    value: "domestic-for-domestic",
+  },
+  {
+    displayName: "Don't know",
+    value: "don-t-know",
   },
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1217,10 +1217,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/stand@^0.0.47":
-  version "0.0.47"
-  resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.47.tgz#a4d0de4de9cec4c7ed15d921262abef51170aa2f"
-  integrity sha512-mBwgHqWi1L9F+lVZWcqKCCRwe/LLwzu46UM+S6Q9eNdlRtCqk/NhwZ31OawuNnie0sR5fL4rdloZfnxNDEtVtQ==
+"@guardian/stand@^0.0.50":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@guardian/stand/-/stand-0.0.50.tgz#2bef626b4742e26b953b5d4aa8867bbf65f47832"
+  integrity sha512-Ngilr3LbIKP5/Q7U7jZ0uejyMAQ1jHrd4SY7/AcaKHljISmvUreYejXm7h234LSmRLf/EbDYjmhmd0DLmEbuvQ==
 
 "@guardian/user-telemetry-client@1.2.1":
   version "1.2.1"


### PR DESCRIPTION
## What does this change?

Change the order that the drop-down options for intended audience appear to match the figma design:

<img width="664" height="472" alt="Screenshot 2026-06-15 at 12 31 35" src="https://github.com/user-attachments/assets/0d27017c-4a43-4e2a-b75d-ae4550d34b70" />


TODO - updates stand to new version: https://github.com/guardian/stand/pull/137/changes

## How has this change been tested?

ran locally, order on the select input has changes

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
