### PR TITLE
Fix casing issue with intended audience signifier

### DIFF
--- a/public/react/IntendedAudienceWrapper.tsx
+++ b/public/react/IntendedAudienceWrapper.tsx
@@ -17,7 +17,7 @@ const getSourceAndTarget = (intendedAudience?: string) => {
   // stub.externalData.trackingTags (Option[List[String]], array of tag paths)
 
   return mapTagsToSourceAndTarget(
-    intendedAudience
+    intendedAudience.toLowerCase()
       .split(",")
       .map((slug) => ({ path: `tracking/audience/${slug}` })),
   );


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds logic to transform the casing of the `intendedAudience` field to lower case before attempting to create "tags" which are passed into `mapTagsToSourceAndTarget()`. I don't quite understand why it's upper case because the PUT requests setting this field from Composer sends a lower case value. But I suppose we can figure this out later (and we eventually want to move away from using this field).

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

It has not! I currently cannot develop locally or using CODE, hopefully that won't be the case for much longer...

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Fixing the appearance of workflow for users testing the intended audience functionality.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Risks should be minimal

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
