### PR TITLE
Update to io.netty:netty-handler:4.1.135.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,6 @@ val buildInfo = Seq(
       "gitCommitId" -> env.getOrElse("GITHUB_SHA", "Unknown"),
 )
 
-
-
 val commonSettings = Seq(
   scalaVersion := scalaVersionNumber,
   ThisBuild / scalaVersion := scalaVersionNumber,

--- a/common-lib/src/test/scala/lib/Response.scala
+++ b/common-lib/src/test/scala/lib/Response.scala
@@ -1,13 +1,13 @@
 package com.gu.workflow.test
 
-import org.apache.http.client.methods.{CloseableHttpResponse}
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
 import scala.io.Source
 
 
 class Response(val response: CloseableHttpResponse) {
   lazy val body = Source.fromInputStream(response.getEntity.getContent).getLines().mkString("")
-  lazy val responseCode = response.getStatusLine.getStatusCode
-  lazy val responseMessage = response.getStatusLine.getReasonPhrase
+  lazy val responseCode = response.getCode()
+  lazy val responseMessage = response.getReasonPhrase()
 
   def header(name: String) = response.getFirstHeader(name).getValue
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val awsVersion: String = "2.44.7"
+  val awsVersion: String = "2.46.13"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1" % "test"
 
   val awsDependencies = Seq(
@@ -16,7 +16,7 @@ object Dependencies {
     "joda-time" % "joda-time" % "2.14.0"
   )
 
-  val pandaVersion = "19.0.0"
+  val pandaVersion = "20.0.0"
 
   val authDependencies = Seq(
     "com.gu" %% "pan-domain-auth-play_3-0" % pandaVersion,
@@ -49,7 +49,7 @@ object Dependencies {
     "org.bouncycastle" % "bcprov-jdk18on" % "1.84"
   )
 
-  val permissionsClientVersion = "5.0.0"
+  val permissionsClientVersion = "7.0.0"
 
   val permissionsDependencies = Seq(
     "com.gu" %% "editorial-permissions-client" % permissionsClientVersion


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Fixes for:

https://github.com/guardian/workflow-frontend/security/dependabot/278
https://github.com/guardian/workflow-frontend/security/dependabot/279
https://github.com/guardian/workflow-frontend/security/dependabot/285

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

Tested by running workflow locally and checking that nothing seems obviously broken

Also ran `sbt "whatDependsOn io.netty netty-handler"` which confims we're using the patched version `io.netty:netty-handler:4.1.135.Final`

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Vulnerabilities 📉

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Small risk of breaking functionality, so do a smoke test