### PR TITLE
add a link to a help doc on the tooltips for intended audience

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -59,7 +59,9 @@
                                 <span>Intended audience</span>
                                 <span>*</span>
                             </label>
-                            <i class="content-list-head__heading-icon--tooltip" wf-icon="tooltip" title="TBC"></i>
+                            <a title="{{ intendedAudienceTooltip.text }}" href="{{ intendedAudienceTooltip.docUrl }}" target="_blank">
+                                <i class="content-list-head__heading-icon--tooltip" wf-icon="tooltip"></i>
+                            </a>
                         </div>
 
                         <select 

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -19,7 +19,7 @@ import { punters } from 'components/punters/punters';
 import { generateErrorMessages, doesContentTypeRequireCommissionedLength, useNativeFormFeedback } from '../../lib/stub-form-validation.ts';
 import { setDisplayHintForFormat } from 'lib/model/special-formats.ts';
 import { getArticleFormatLabel, isFormatLabel } from 'lib/model/format-helpers.ts';
-import { intendedAudienceOptions, getIntendedAudienceFromOptionValue, areAllExpectedTagsAvailable } from 'lib/model/intended-audience.ts';
+import { intendedAudienceOptions, getIntendedAudienceFromOptionValue, areAllExpectedTagsAvailable, intendedAudienceTooltip } from 'lib/model/intended-audience.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -286,6 +286,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
         900,
         1200,
     ]
+
+    $scope.intendedAudienceTooltip = intendedAudienceTooltip
 
     $scope.sendTelemetryForSuggestion = (value, missingCommissionedLengthReason = null) => {
         const commissioningDesk = $scope.cdesks.find(desk  => desk.id.toString() === stub.commissioningDesks)?.externalName;

--- a/public/lib/column-defaults.js
+++ b/public/lib/column-defaults.js
@@ -30,6 +30,7 @@ import needsPictureDeskTemplate      from "components/content-list-item/template
 import statusInPrintTemplate         from "components/content-list-item/templates/statusInPrint.html";
 import lastModifiedInPrintByTemplate from "components/content-list-item/templates/lastModifiedInPrintBy.html";
 import contentRightsTemplate         from "components/content-list-item/templates/rights.html";
+import { intendedAudienceTooltip } from "./model/intended-audience.ts";
 
 /**
  * This array represents the default ordering and display of the content-list-item columns for workflow.
@@ -85,11 +86,12 @@ const createCustomHeadlineLabelHtml = () => {
     `;
 };
 
-const intendedAudienceHelpText = "TBC" // TO DO - get text for tooltip
-const createCustomIntendedAudienceLabelHtml = (tooltipText) => {
+const createCustomIntendedAudienceLabelHtml = () => {
     return `
-        <span>Intended Audience</span> 
-        <i class="content-list-head__heading-icon--tooltip" wf-icon="tooltip" title="${tooltipText}"></i>
+        <span>Intended Audience</span>
+        <a href="${intendedAudienceTooltip.docUrl}" target="_blank" title="${intendedAudienceTooltip.text}"> 
+            <i class="content-list-head__heading-icon--tooltip" wf-icon="tooltip"></i>
+        </a>
     `
 }
 
@@ -289,7 +291,7 @@ const columnDefaults = [{
 },{
     name: 'intended-audience',
     prettyName: 'Intended Audience',
-    labelHTML: createCustomIntendedAudienceLabelHtml(intendedAudienceHelpText),
+    labelHTML: createCustomIntendedAudienceLabelHtml(),
     colspan: 1,
     title: '',
     templateUrl: templateRoot + 'intended-audience.html',

--- a/public/lib/model/intended-audience.ts
+++ b/public/lib/model/intended-audience.ts
@@ -108,3 +108,9 @@ export const findMatchingAudienceTags = (
 
   return tags;
 };
+
+export const intendedAudienceTooltip = {
+  text: "find out more about Intended audience",
+  docUrl:
+    "https://docs.google.com/document/d/1_NMKSsWq5cGUNGr2JcDmwkGxXK82thTUp0xzt5BkjTQ/edit?tab=t.0#heading=h.lbvu212ng3qf",
+};


### PR DESCRIPTION
## What does this change?


The tooltip for intended audience on the create article form and column header now have the title "find out more about Intended audience" and link to this help doc:
https://docs.google.com/document/d/1_NMKSsWq5cGUNGr2JcDmwkGxXK82thTUp0xzt5BkjTQ/edit?tab=t.0#heading=h.lbvu212ng3qf


## How has this change been tested?

Ran locally

## How can we measure success?

users can access the document, which includes  the link to the [feedback form](https://docs.google.com/forms/d/e/1FAIpQLSfByWMwKdsGZuRmLj9ex0Gl-MMedcCpAclrZvxSBIcl7JfzXA/viewform?usp=dialog)

## Have we considered potential risks?

Just a mark-up change, should be safe

## Images

<img width="642" height="442" alt="Screenshot 2026-06-23 at 11 56 49" src="https://github.com/user-attachments/assets/3ea4a5cc-cfb6-4121-a801-b3e3abb7f035" />
<img width="642" height="442" alt="Screenshot 2026-06-23 at 11 56 22" src="https://github.com/user-attachments/assets/93b1e4d5-2b0e-47ad-92da-ccc18936ef54" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
