### PR TITLE
Use tracking tags to display intended audience

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -207,8 +207,7 @@ angular.module('workflow',
         'title',
     ]))
     .component('intendedAudienceSignifier', react2angular(IntendedAudienceWrapper,[
-        'intendedAudience',
-        'productionOffice', 
+        'trackingTags',
     ]))
     .run(['$document', '$rootScope', function ($document, $rootScope) {
         $document.on('keydown', function(event) {

--- a/public/components/content-list-item/content-list-item.js
+++ b/public/components/content-list-item/content-list-item.js
@@ -202,7 +202,7 @@ function wfContentItemParser(config, wfFormatDateTime, statusLabels, sections) {
             this.statusInPrint = item.statusInPrint;
             this.lastModifiedInPrintBy = item.lastModifiedInPrintBy;
             
-            this.intendedAudience = item.intendedAudience;
+            this.trackingTags = item.trackingTags;
 
             // These are derived values used for display purposes.
             const {

--- a/public/components/content-list-item/templates/intended-audience.html
+++ b/public/components/content-list-item/templates/intended-audience.html
@@ -2,6 +2,6 @@
   class="content-list-item__field--intended-audience"
 >
   <intended-audience-signifier
-    intended-audience="contentItem.intendedAudience"
+    tracking-tags="contentItem.trackingTags"
   ></intended-audience-signifier>
 </td>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -19,7 +19,11 @@ import { punters } from 'components/punters/punters';
 import { generateErrorMessages, doesContentTypeRequireCommissionedLength, useNativeFormFeedback } from '../../lib/stub-form-validation.ts';
 import { setDisplayHintForFormat } from 'lib/model/special-formats.ts';
 import { getArticleFormatLabel, isFormatLabel } from 'lib/model/format-helpers.ts';
-import { intendedAudienceOptions, getIntendedAudienceFromOptionValue, areAllExpectedTagsAvailable } from 'lib/model/intended-audience.ts';
+import {
+    intendedAudienceOptions,
+    areAllExpectedTagsAvailable,
+    getTrackingTagsFromAudienceOption,
+} from 'lib/model/intended-audience.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -363,10 +367,9 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     }
 
     $scope.ok = function (addToComposer, addToAtomEditor) {
-        const stub = setDisplayHintForFormat ($scope.stub);
+        const stub = setDisplayHintForFormat($scope.stub);
 
-        // stub.intendedAudience is not rendered on the form, so does not need to be evaluated until submitting
-        stub.intendedAudience = getIntendedAudienceFromOptionValue($scope.formData.audienceOption, $scope.stub);
+        stub.trackingTags = getTrackingTagsFromAudienceOption($scope.stub, $scope.formData.audienceOption, _wfConfig.audienceTags);
 
         function createItemPromise() {
             if ($scope.contentName === 'Atom') {

--- a/public/lib/composer-service.js
+++ b/public/lib/composer-service.js
@@ -67,6 +67,10 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
         commissionedLength: (d) => deepSearch(d, ['preview', 'data', 'fields', 'commissionedLength', 'data']) || undefined,
         missingCommissionedLengthReason: (d) => deepSearch(d, ['preview', 'data', 'fields', 'missingCommissionedLengthReason', 'data']) || undefined,
         displayHint: (d) => deepSearch(d, ['preview', 'data', 'settings', 'displayHint', 'data']) || undefined,
+        trackingTags: (d) => {
+            const trackingTags = deepSearch(d, ['preview', 'data', 'taxonomy', 'tracking', 'data']) || undefined
+            return trackingTags?.map(tag => tag.path);
+        },
     };
 
 
@@ -125,11 +129,11 @@ function wfComposerService($http, $q, config, $log, wfHttpSessionService, wfTele
         audienceTags
     ) {
         var selectedDisplayHint = getListElementFormatFromLabel(articleFormat)?.value;
-        var trackingTagIds = [commissioningDeskTag?.id, audienceTags.map(tag=>tag.id)].filter(Boolean).join(",")
+        var trackingTagIDs = [commissioningDeskTag?.id].concat(audienceTags.map(tag => tag.id)).filter(Boolean).join(",");
 
         var params = {
             'type': contentTypeToComposerContentType(type),
-            'tracking': trackingTagIds,
+            'tracking': trackingTagIDs,
             'productionOffice': prodOffice,
             'displayHint': selectedDisplayHint,
             'originatingSystem': 'workflow'

--- a/public/lib/content-service.js
+++ b/public/lib/content-service.js
@@ -7,7 +7,7 @@ import './http-session-service';
 import './user';
 import './visibility-service';
 import { provideFormats } from './model/format-helpers.ts'
-import { findMatchingAudienceTags } from './model/intended-audience.ts'
+import { findTagsByPath } from './model/intended-audience.ts'
 
 angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService', 'wfDateService', 'wfFiltersService', 'wfUser', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'wfPreferencesService'])
     .factory('wfContentService', ['$rootScope', '$log', 'wfHttpSessionService', 'wfDateParser', 'wfFormatDateTimeFilter', 'wfFiltersService', 'wfComposerService', 'wfMediaAtomMakerService', 'wfAtomWorkshopService', 'wfPreferencesService', 'config',
@@ -98,7 +98,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                  */
                 createInComposer(stub, statusOption) {
 
-                    const audienceTags = findMatchingAudienceTags(stub.intendedAudience, _wfConfig.audienceTags);
+                    const audienceTags = findTagsByPath(stub.trackingTags, _wfConfig.audienceTags);
                     const commissioningDeskTag = this.getCommissioningDeskTagFromStub(stub);
 
                     return wfComposerService.create(
@@ -109,7 +109,7 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                             stub.template, 
                             stub.articleFormat, 
                             stub.priority, 
-                            stub.missingCommissionedLengthReason, 
+                            stub.missingCommissionedLengthReason,
                             audienceTags,
                         )
                         .then((response) => wfComposerService.parseComposerData(response, stub))
@@ -128,7 +128,6 @@ angular.module('wfContentService', ['wfHttpSessionService', 'wfVisibilityService
                                 }
                                 $log.info(JSON.stringify(data))
                             }
-
 
                             if (statusOption) {
                                 updatedStub['status'] = statusOption;

--- a/public/lib/model/intended-audience.ts
+++ b/public/lib/model/intended-audience.ts
@@ -108,3 +108,17 @@ export const findMatchingAudienceTags = (
 
   return tags;
 };
+
+export const getTrackingTagsFromAudienceOption = (
+  stub: Stub,
+  optionValue: IntendedAudienceOptionValue,
+  audienceTags: LimitedTag[],
+): string[] => {
+  const intendedAudience = getIntendedAudienceFromOptionValue(optionValue, stub);
+  return findMatchingAudienceTags(intendedAudience, audienceTags)
+    .map(tag => tag.path)
+    .filter(path => path !== undefined);
+}
+
+export const findTagsByPath = (paths: string[], audienceTags: LimitedTag[]): LimitedTag[] =>
+  audienceTags.filter(tag => tag.path && paths.includes(tag.path));

--- a/public/react/IntendedAudienceWrapper.tsx
+++ b/public/react/IntendedAudienceWrapper.tsx
@@ -5,28 +5,23 @@ import {
 import React from "react";
 
 type Props = {
-  intendedAudience?: string;
+  trackingTags?: string[];
 };
 
-const getSourceAndTarget = (intendedAudience?: string) => {
-  if (!intendedAudience) {
+const getSourceAndTarget = (trackingTags?: string[]) => {
+  if (!trackingTags) {
     return undefined;
   }
 
-  // We intend to deprecate the stub.externalData.intendedAudience (Option[String], comma separated tag slugs) and use
-  // stub.externalData.trackingTags (Option[List[String]], array of tag paths)
-
   return mapTagsToSourceAndTarget(
-    intendedAudience.toLowerCase()
-      .split(",")
-      .map((slug) => ({ path: `tracking/audience/${slug}` })),
+    trackingTags.map((path) => ({ path })),
   );
 };
 
 export const IntendedAudienceWrapper: React.FunctionComponent<Props> = ({
-  intendedAudience,
+  trackingTags,
 }: Props) => {
-  const sourceAndTarget = getSourceAndTarget(intendedAudience);
+  const sourceAndTarget = getSourceAndTarget(trackingTags);
   if (!sourceAndTarget) {
     return null; // do not render the "Don't know" signifier in the table
   }


### PR DESCRIPTION
## What does this change?
This pr follows on from https://github.com/guardian/workflow/pull/1481, to use audience tracking tags to set and display the intended audience.

## How has this change been tested?
This has been deployed to CODE and tested by switching on the intended audience feature switch and setting the intended audience in Workflow and in Composer and seeing the values match and update in both tools.

## How can we measure success?
The display of the intended audience indicator should be as before, but it should resolve a bug where the intended audience indicator in Workflow was falling out of sync with Composer.