### PR TITLE
Provide fallback for intended audience when tag manager is unavailable

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -61,7 +61,7 @@
                             </label>
                             <i class="content-list-head__heading-icon--tooltip" wf-icon="tooltip" title="TBC"></i>
                         </div>
-
+                      <div ng-if="allAudienceTagsAreAvailable">
                         <select 
                             id="stub_intended_audience" 
                             required 
@@ -69,10 +69,9 @@
                             ng-model="formData.audienceOption" 
                             ng-options="audienceOption.value as audienceOption.displayName for audienceOption in audienceOptions"
                         ></select>
-
+                      </div>
                         <div ng-if="!allAudienceTagsAreAvailable">
-                            <div>Selecting Intended Audience</div>
-                            <div>is temporarily unavailable</div>
+                            <div>Selecting Intended Audience is temporarily unavailable</div>
                         </div>
                     </div>
                 </section>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -19,7 +19,12 @@ import { punters } from 'components/punters/punters';
 import { generateErrorMessages, doesContentTypeRequireCommissionedLength, useNativeFormFeedback } from '../../lib/stub-form-validation.ts';
 import { setDisplayHintForFormat } from 'lib/model/special-formats.ts';
 import { getArticleFormatLabel, isFormatLabel } from 'lib/model/format-helpers.ts';
-import { intendedAudienceOptions, getIntendedAudienceFromOptionValue, areAllExpectedTagsAvailable } from 'lib/model/intended-audience.ts';
+import {
+  intendedAudienceOptions,
+  getIntendedAudienceFromOptionValue,
+  areAllExpectedTagsAvailable,
+  offlineDefault,
+} from 'lib/model/intended-audience.ts';
 
 const wfStubModal = angular.module('wfStubModal', [
     'ui.bootstrap', 'articleFormatService', 'legalStatesService', 'pictureDeskStatesService', 'wfComposerService', 'wfContentService', 'wfDateTimePicker', 'wfProdOfficeService', 'wfFiltersService', 'wfCapiAtomService', 'wfTelemetryService'])
@@ -96,9 +101,17 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     $scope.audienceOptions = intendedAudienceOptions;
     $scope.allAudienceTagsAreAvailable = areAllExpectedTagsAvailable(_wfConfig.audienceTags)
 
-    $scope.formData = {
-        audienceOption: intendedAudienceOptions[0].value,
-    };
+    if ($scope.allAudienceTagsAreAvailable) {
+      $scope.formData = {
+          audienceOption: intendedAudienceOptions[0].value,
+      };
+    } else {
+      // if audience tags are unavailable we assume tag manager is offline, hide the drop-down
+      // menu and provide a default value. The value can be updated subsequently in Composer.
+      $scope.formData = {
+        audienceOption: offlineDefault.value,
+      };
+    }
     $scope.disabled = !!stub.composerId;
     $scope.sections = getSectionsList(sections);
     $scope.templates = [];

--- a/public/lib/model/intended-audience.ts
+++ b/public/lib/model/intended-audience.ts
@@ -11,6 +11,11 @@ type IntendedAudienceOptionValue =
 type AudienceTagSlug = "global" | "uk" | "au" | "us";
 const expectedAudienceSlugs = ["global", "uk", "au", "us"];
 
+export const offlineDefault = {
+  displayName: "Don't know",
+  value: "don-t-know" as IntendedAudienceOptionValue,
+}
+
 export const intendedAudienceOptions: {
   displayName: string;
   value: IntendedAudienceOptionValue;
@@ -31,10 +36,7 @@ export const intendedAudienceOptions: {
     displayName: "Domestic for Domestic",
     value: "domestic-for-domestic",
   },
-  {
-    displayName: "Don't know",
-    value: "don-t-know",
-  },
+  offlineDefault,
 ];
 
 const tagMatchesSlug = (slug: string) => (tag: LimitedTag) =>


### PR DESCRIPTION
## What does this change?
This pr replaces the intended audience drop-down with a 'service unavailable' message and defaults the form to select 'don't know' as the intended audience option when tag manager has not returned the expected audience tags. This ensures tag manager being unavailable does not prevent people from creating content in workflow.

## How has this change been tested?
I found the easiest way to test this was to run the application locally and change the tag manager url value in config https://github.com/guardian/workflow-frontend/blob/9670a11e4f89289abe6316889ab2678fbe328228/app/config/Config.scala#L77

The domain defaults to `local.dev-gutools.co.uk`, which will be unavailable by default unless you're running tag manager on your machine. Changing the domain to point to CODE should then return the expected tag values.

## How can we measure success?
The app is more resilient. One service going down does not prevent people from doing their work.

## Have we considered potential risks?
If the tags were to change from the intendedAudienceOptions defined in `intended-audience.ts`, it's possible that the service will always show as unavailable.

## Images

| Tag manager available    | Tag manager unavailable |
| -------- | ------- |
| <img width="594" height="743" alt="Screenshot 2026-06-25 at 11 10 46" src="https://github.com/user-attachments/assets/c155d1a0-3034-4181-ba13-ef513bfa1c75" />  | <img width="594" height="808" alt="Screenshot 2026-06-25 at 11 09 35" src="https://github.com/user-attachments/assets/0065b5cf-bab9-42bc-aaea-78ca76d7ddf2" />    |

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
