### PR TITLE
make intended audience optional

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -57,7 +57,6 @@
                         <div class="label-and-icon">
                             <label for="stub_intended_audience">
                                 <span>Intended audience</span>
-                                <span>*</span>
                             </label>
                             <a title="{{ intendedAudienceTooltip.text }}" href="{{ intendedAudienceTooltip.docUrl }}" target="_blank">
                                 <i class="content-list-head__heading-icon--tooltip" wf-icon="tooltip"></i>
@@ -66,7 +65,6 @@
                       <div ng-if="allAudienceTagsAreAvailable">
                         <select 
                             id="stub_intended_audience" 
-                            required 
                             name="intended_audience" 
                             ng-model="formData.audienceOption" 
                             ng-options="audienceOption.value as audienceOption.displayName for audienceOption in audienceOptions"

--- a/public/lib/model/intended-audience.ts
+++ b/public/lib/model/intended-audience.ts
@@ -6,24 +6,23 @@ type IntendedAudienceOptionValue =
   | "domestic-for-global"
   | "domestic-for-domestic"
   | "don-t-know"
-  | null;
-
-type AudienceTagSlug = "global" | "uk" | "au" | "us";
-const expectedAudienceSlugs = ["global", "uk", "au", "us"];
-
-export const offlineDefault = {
-  displayName: "Don't know",
-  value: "don-t-know" as IntendedAudienceOptionValue,
-}
-
+  | null; 
+  
+  type AudienceTagSlug = "global" | "uk" | "au" | "us";
+  const expectedAudienceSlugs = ["global", "uk", "au", "us"];
+  
+  export const offlineDefault = {
+    displayName: "Not set",
+    value: "don-t-know" as IntendedAudienceOptionValue,
+  }
+  
+// If choosing an option is made mandatory, the intendedAudienceOptions should start with a default null option 
+// so the user would have to explictly choose "Don't know" rather than it being the default.
 export const intendedAudienceOptions: {
   displayName: string;
   value: IntendedAudienceOptionValue;
 }[] = [
-  {
-    displayName: "",
-    value: null,
-  },
+  offlineDefault,
   {
     displayName: "Global",
     value: "global",
@@ -36,7 +35,6 @@ export const intendedAudienceOptions: {
     displayName: "Domestic for Domestic",
     value: "domestic-for-domestic",
   },
-  offlineDefault,
 ];
 
 const tagMatchesSlug = (slug: string) => (tag: LimitedTag) =>


### PR DESCRIPTION
## What does this change?

Makes the Intended Audience optional in the stub form, defaulting the drop-down to the "don't know" option (re-labeled as "Not set".)

The aim is to have the field optional until it is more familiar, and later to  require users to explictly set an option (even if that is "Don't Know")


## How has this change been tested?

Ran locally - was able to create a stub an open in Composer without interacting with the dropdown


## How can we measure success?

less user friction for new field.

## Have we considered potential risks?

Still behind feature switch, jsut a frontend change.

## Images

<img width="607" height="754" alt="Screenshot 2026-06-29 at 10 15 15" src="https://github.com/user-attachments/assets/db94b24e-accf-4610-aace-5f757df01622" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
