### PR TITLE
remove feature switch and references to it

### DIFF
--- a/public/components/stub-modal/stub-modal.html
+++ b/public/components/stub-modal/stub-modal.html
@@ -53,7 +53,7 @@
                             <p>Selecting commissioning info is temporarily unavailable</p>
                         </div>
                     </div>
-                    <div ng-if="isIntendedAudienceEnabled">
+                    <div>
                         <div class="label-and-icon">
                             <label for="stub_intended_audience">
                                 <span>Intended audience</span>

--- a/public/components/stub-modal/stub-modal.js
+++ b/public/components/stub-modal/stub-modal.js
@@ -44,11 +44,7 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
  
         $scope.$watch('stub.articleFormat', (newValue) => {
             $scope.stubFormat = newValue;
-        })
-
-        wfPreferencesService.getPreference('featureSwitches').then((data) => { 
-            $scope.isIntendedAudienceEnabled = data.intendedAudienceColumn
-        ;})
+        })        
         
         $scope.modalTitle = ({
             'create': `Create ${$scope.contentName}`,
@@ -182,9 +178,8 @@ function StubModalInstanceCtrl($rootScope, $scope, $modalInstance, $window, conf
     $scope.warningMessages = undefined
 
     function updateWarnings() {
-        $scope.warningMessages = generateErrorMessages($scope.stub, $scope.formData.audienceOption, $scope.isIntendedAudienceEnabled)
+        $scope.warningMessages = generateErrorMessages($scope.stub, $scope.formData.audienceOption)
     }
-    $scope.$watch('isIntendedAudienceEnabled', updateWarnings, true)
     $scope.$watch('stub', updateWarnings, true)
     $scope.$watch('formData.audienceOption', updateWarnings, true)
 

--- a/public/lib/column-service.js
+++ b/public/lib/column-service.js
@@ -4,9 +4,6 @@ import moment from 'moment';
 import { columnDefaults } from './column-defaults'
 import startTemplate from "components/content-list-item/content-list-item-start.html";
 import endTemplate from "components/content-list-item/content-list-item-end.html";
-import { getDefaultFeatureSwitchValues } from './feature-switches.ts';
-
-const columnDefaultsWithoutIntendedAudience = columnDefaults.filter(column => column.name !== 'intended-audience')
 
 
 angular.module('wfColumnService', [])
@@ -19,16 +16,15 @@ angular.module('wfColumnService', [])
 
                     var self = this;
 
-                    self.availableColums = columnDefaultsWithoutIntendedAudience;
+                    self.availableColums = columnDefaults;
                     self.contentItemTemplate;
 
                     self.preferencePromise = wfPreferencesService.getAllPreferences().then(function resolve(preferencesData) {
-                        var { columnConfiguration = [], featureSwitches = getDefaultFeatureSwitchValues() } = preferencesData;
+                        var { columnConfiguration = [] } = preferencesData;
                         if (typeof columnConfiguration[0] !== "string") {
                             return reject();
                         } else {
-                            var shouldExcludeIntendedAudience = !featureSwitches.intendedAudienceColumn
-                            self.availableColums = shouldExcludeIntendedAudience ? columnDefaultsWithoutIntendedAudience : columnDefaults
+                            self.availableColums = columnDefaults
                             self.columns = self.availableColums;
 
                             self.columns.forEach((col) => { // set all to inactive

--- a/public/lib/feature-switches.ts
+++ b/public/lib/feature-switches.ts
@@ -6,13 +6,7 @@ type FeatureSwitch = {
   description: string;
 };
 
-const featureSwitchList: FeatureSwitch[] = [
-  {
-    key: "intendedAudienceColumn",
-    defaultValue: true,
-    description: "Show Intended Audience",
-  },
-];
+const featureSwitchList: FeatureSwitch[] = [];
 
 export const featureSwitchKeys = featureSwitchList.map(
   (featureSwitch) => featureSwitch.key,

--- a/public/lib/stub-form-validation.ts
+++ b/public/lib/stub-form-validation.ts
@@ -39,10 +39,9 @@ const stubHasInvalidCommissionedLength = (stub: Stub) =>
 const generateErrorMessages = (
   stub: Stub,
   intendedAudienceOption?: string,
-  requireIntendedAudience?: boolean,
 ): string[] | undefined => {
   const errors: string[] = [];
-  if (requireIntendedAudience && !intendedAudienceOption) {
+  if (!intendedAudienceOption) {
     errors.push(MESSAGING.intendedAudienceRequired);
   }
   if (stubIsMissingRequiredLength(stub)) {


### PR DESCRIPTION
## What does this change?

Removes the feature switch for intended audience (was true by default) any removes any usages of it, as we do not intend to turn the feature off any more.

## How has this change been tested?

Ran locally and verfied:
 - the "no active switches" message is displayed when you press shift-f12
 - the intended audience column can still be toggled on and off in the columns menu (scroll to the right end of the table for the button, then click the 'update' button at the bottom of the menu to reload the screen.
 - the intended audience dropdown is still rendered and populates the tag id in the create content payload
 - the "intended audience is not available" message still shows if workflow cannot connect to tag manager

## How can we measure success?

All user see the new UI

